### PR TITLE
changed have been to has been

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -16,7 +16,7 @@ A modern, easy to use, feature-rich, and async ready API wrapper for Discord wri
 Fork notice
 --------------------------
 
-This is a fork of the Discord.py library, which unfortunately have been `officially discontinued <https://gist.github.com/Rapptz/4a2f62751b9600a31a0d3c78100287f1/>`_ at 28th August 2021. Nextcord will replace Discord.py, with **continued support and features**, to still offer former Discord.py-users a stable API wrapper for their bots.
+This is a fork of the Discord.py library, which unfortunately has been `officially discontinued <https://gist.github.com/Rapptz/4a2f62751b9600a31a0d3c78100287f1/>`_ at 28th August 2021. Nextcord will replace Discord.py, with **continued support and features**, to still offer former Discord.py-users a stable API wrapper for their bots.
 
 Key Features
 -------------


### PR DESCRIPTION
The discord.py library is a singular noun, so the has verb must be has

## Summary

<!-- What is this pull request for? Does it fix any issues? -->

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
