### PR TITLE
docs: change wording of readme and docstrings

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -16,7 +16,8 @@ A modern, easy to use, feature-rich, and async ready API wrapper for Discord wri
 Fork notice
 --------------------------
 
-This is a fork of the Discord.py library, which unfortunately has been `officially discontinued <https://gist.github.com/Rapptz/4a2f62751b9600a31a0d3c78100287f1/>`_ at 28th August 2021. Nextcord will replace Discord.py, with **continued support and features**, to still offer former Discord.py-users a stable API wrapper for their bots.
+This is a fork of discord.py, which unfortunately has been `officially discontinued <https://gist.github.com/Rapptz/4a2f62751b9600a31a0d3c78100287f1/>`_ at 28th August 2021.
+Nextcord will try to replace discord.py, with **continued support and features**, to still offer former discord.py-users a stable API wrapper for their bots.   
 
 Key Features
 -------------

--- a/discord/__init__.py
+++ b/discord/__init__.py
@@ -17,7 +17,7 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
 FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 
-Fake module to allow for compatibility with old discord.py cogs
+Module to allow for backwards compatibility for existing code and extensions
 """
 
 from nextcord import *

--- a/discord/ext/commands/__init__.py
+++ b/discord/ext/commands/__init__.py
@@ -17,7 +17,7 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
 FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 
-Fake module to allow for compatibility with old discord.py cogs
+Module to allow for backwards compatibility for existing code and extensions
 """
 
 from nextcord.ext.commands import *

--- a/discord/ext/tasks/__init__.py
+++ b/discord/ext/tasks/__init__.py
@@ -17,7 +17,7 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
 FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 
-Fake module to allow for compatibility with old discord.py cogs
+Module to allow for backwards compatibility for existing code and extensions
 """
 
 from nextcord.tasks import *

--- a/discord/opus.py
+++ b/discord/opus.py
@@ -17,7 +17,7 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
 FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 
-Fake module to allow for compatibility with old discord.py cogs
+Module to allow for backwards compatibility for existing code and extensions
 """
 
 from nextcord.opus import *

--- a/discord/types/__init__.py
+++ b/discord/types/__init__.py
@@ -17,7 +17,7 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
 FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 
-Fake module to allow for compatibility with old discord.py cogs
+Module to allow for backwards compatibility for existing code and extensions
 """
 
 from nextcord.types import *

--- a/discord/ui/__init__.py
+++ b/discord/ui/__init__.py
@@ -17,7 +17,7 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
 FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 
-Fake module to allow for compatibility with old discord.py cogs
+Module to allow for backwards compatibility for existing code and extensions
 """
 
 from nextcord.ui import *

--- a/discord/voice_client.py
+++ b/discord/voice_client.py
@@ -17,7 +17,7 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
 FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 
-Fake module to allow for compatibility with old discord.py cogs
+Module to allow for backwards compatibility for existing code and extensions
 """
 
 from nextcord.voice_client import *

--- a/discord/webhook/__init__.py
+++ b/discord/webhook/__init__.py
@@ -17,7 +17,7 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
 FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 
-Fake module to allow for compatibility with old discord.py cogs
+Module to allow for backwards compatibility for existing code and extensions
 """
 
 from nextcord.webhook import *


### PR DESCRIPTION
## Summary
Changes the wording of the README and the `discord/**/__init__.py` docstrings to be more exact.
<!-- What is this pull request for? Does it fix any issues? -->

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
