### PR TITLE
Added docs link at the top

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -10,13 +10,14 @@
 .. image:: https://img.shields.io/pypi/pyversions/nextcord.svg
    :target: https://pypi.python.org/pypi/nextcord
    :alt: PyPI supported Python versions
+.. image:: https://img.shields.io/readthedocs/nextcord
+   :target: https://nextcord.readthedocs.io/en/latest
+   :alt: Nextcord documentation
    
 Nextcord
 --------
    
 A modern, easy to use, feature-rich, and async ready API wrapper for Discord written in Python.
-
-`Documentation <https://nextcord.readthedocs.io/en/latest/>`_
 
 Fork notice
 --------------------------

--- a/README.rst
+++ b/README.rst
@@ -10,8 +10,13 @@
 .. image:: https://img.shields.io/pypi/pyversions/nextcord.svg
    :target: https://pypi.python.org/pypi/nextcord
    :alt: PyPI supported Python versions
+   
+Nextcord
+--------
+   
+A modern, easy to use, feature-rich, and async ready API wrapper for Discord written in Python.
 
-Nextcord is a modern, easy to use, feature-rich, and async ready API wrapper for Discord written in Python.
+`Documentation <https://nextcord.readthedocs.io/en/latest/>`_
 
 Fork notice
 --------------------------


### PR DESCRIPTION
## Summary

I always found the docs link too far down in the discord.py repo that it takes too long to find.

This change adds an additional link to make it easier for newcomers to find the docs.

I also added a header to create extra padding above the first paragraph.

### Before and After

:one: is the current readme

:two: is with the [updated readme](https://github.com/DenverCoderOne/nextcord/blob/enhanced-readme/README.rst)

![image](https://user-images.githubusercontent.com/20955511/131478627-573a9dff-eb28-4ac1-bfeb-0d98fe97495d.png)

## Checklist

- [x] This PR is **not** a code change (e.g. documentation, README, ...)
