### PR TITLE
Fixed typos in docs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -17,20 +17,20 @@
 Nextcord
 --------
    
-A modern, easy to use, feature-rich, and async ready API wrapper for Discord written in Python.
+A modern, easy-to-use, feature-rich, and async-ready API wrapper for Discord written in Python.
 
 Fork notice
 --------------------------
 
-This is a fork of discord.py, which unfortunately has been `officially discontinued <https://gist.github.com/Rapptz/4a2f62751b9600a31a0d3c78100287f1/>`_ at 28th August 2021.
-Nextcord will try to replace discord.py, with **continued support and features**, to still offer former discord.py-users a stable API wrapper for their bots.   
+This is a fork of discord.py, which unfortunately has been `officially discontinued <https://gist.github.com/Rapptz/4a2f62751b9600a31a0d3c78100287f1/>`_ on 28th August 2021.
+Nextcord will try to replace discord.py, with **continued support and features**, to still offer former discord.py users a stable API wrapper for their bots.   
 
 Key Features
 -------------
 
-- Modern Pythonic API using ``async`` and ``await``.
-- Proper rate limit handling.
-- Optimised in both speed and memory.
+- Modern Pythonic API using ``async`` and ``await``
+- Proper rate limit handling
+- Optimised in both speed and memory
 
 Installing
 ----------

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -1,34 +1,34 @@
-.. currentmodule:: nextcord
+.. currentmodule nextcord
 
 API Reference
 ===============
 
 The following section outlines the API of nextcord.
 
-.. note::
+.. note
 
     This module uses the Python logging module to log diagnostic and errors
-    in an output independent way.  If the logging module is not configured,
-    these logs will not be output anywhere.  See :ref:`logging_setup` for
+    in an output-independent way.  If the logging module is not configured,
+    these logs will not be output anywhere.  See ref`logging_setup` for
     more information on how to set up and use the logging module with
     nextcord.
 
 Version Related Info
 ---------------------
 
-There are two main ways to query version information about the library. For guarantees, check :ref:`version_guarantees`.
+There are two main ways to query version information about the library. For guarantees, check ref`version_guarantees`.
 
-.. data:: version_info
+.. data version_info
 
-    A named tuple that is similar to :obj:`py:sys.version_info`.
+    A named tuple that is similar to obj`pysys.version_info`.
 
-    Just like :obj:`py:sys.version_info` the valid values for ``releaselevel`` are
+    Just like obj`pysys.version_info` the valid values for ``releaselevel`` are
     'alpha', 'beta', 'candidate' and 'final'.
 
-.. data:: __version__
+.. data __version__
 
     A string representation of the version. e.g. ``'1.0.0rc1'``. This is based
-    off of :pep:`440`.
+    off of pep`440`.
 
 Clients
 --------
@@ -36,25 +36,25 @@ Clients
 Client
 ~~~~~~~
 
-.. attributetable:: Client
+.. attributetable Client
 
-.. autoclass:: Client
-    :members:
-    :exclude-members: fetch_guilds, event
+.. autoclass Client
+    members
+    exclude-members fetch_guilds, event
 
-    .. automethod:: Client.event()
-        :decorator:
+    .. automethod Client.event()
+        decorator
 
-    .. automethod:: Client.fetch_guilds
-        :async-for:
+    .. automethod Client.fetch_guilds
+        async-for
 
 AutoShardedClient
 ~~~~~~~~~~~~~~~~~~
 
-.. attributetable:: AutoShardedClient
+.. attributetable AutoShardedClient
 
-.. autoclass:: AutoShardedClient
-    :members:
+.. autoclass AutoShardedClient
+    members
 
 Application Info
 ------------------
@@ -62,34 +62,34 @@ Application Info
 AppInfo
 ~~~~~~~~
 
-.. attributetable:: AppInfo
+.. attributetable AppInfo
 
-.. autoclass:: AppInfo()
-    :members:
+.. autoclass AppInfo()
+    members
 
 PartialAppInfo
 ~~~~~~~~~~~~~~~
 
-.. attributetable:: PartialAppInfo
+.. attributetable PartialAppInfo
 
-.. autoclass:: PartialAppInfo()
-    :members:
+.. autoclass PartialAppInfo()
+    members
 
 Team
 ~~~~~
 
-.. attributetable:: Team
+.. attributetable Team
 
-.. autoclass:: Team()
-    :members:
+.. autoclass Team()
+    members
 
 TeamMember
 ~~~~~~~~~~~
 
-.. attributetable:: TeamMember
+.. attributetable TeamMember
 
-.. autoclass:: TeamMember()
-    :members:
+.. autoclass TeamMember()
+    members
 
 Voice Related
 ---------------
@@ -97,176 +97,176 @@ Voice Related
 VoiceClient
 ~~~~~~~~~~~~
 
-.. attributetable:: VoiceClient
+.. attributetable VoiceClient
 
-.. autoclass:: VoiceClient()
-    :members:
-    :exclude-members: connect, on_voice_state_update, on_voice_server_update
+.. autoclass VoiceClient()
+    members
+    exclude-members connect, on_voice_state_update, on_voice_server_update
 
 VoiceProtocol
 ~~~~~~~~~~~~~~~
 
-.. attributetable:: VoiceProtocol
+.. attributetable VoiceProtocol
 
-.. autoclass:: VoiceProtocol
-    :members:
+.. autoclass VoiceProtocol
+    members
 
 AudioSource
 ~~~~~~~~~~~~
 
-.. attributetable:: AudioSource
+.. attributetable AudioSource
 
-.. autoclass:: AudioSource
-    :members:
+.. autoclass AudioSource
+    members
 
 PCMAudio
 ~~~~~~~~~
 
-.. attributetable:: PCMAudio
+.. attributetable PCMAudio
 
-.. autoclass:: PCMAudio
-    :members:
+.. autoclass PCMAudio
+    members
 
 FFmpegAudio
 ~~~~~~~~~~~~
 
-.. attributetable:: FFmpegAudio
+.. attributetable FFmpegAudio
 
-.. autoclass:: FFmpegAudio
-    :members:
+.. autoclass FFmpegAudio
+    members
 
 FFmpegPCMAudio
 ~~~~~~~~~~~~~~~
 
-.. attributetable:: FFmpegPCMAudio
+.. attributetable FFmpegPCMAudio
 
-.. autoclass:: FFmpegPCMAudio
-    :members:
+.. autoclass FFmpegPCMAudio
+    members
 
 FFmpegOpusAudio
 ~~~~~~~~~~~~~~~~
 
-.. attributetable:: FFmpegOpusAudio
+.. attributetable FFmpegOpusAudio
 
-.. autoclass:: FFmpegOpusAudio
-    :members:
+.. autoclass FFmpegOpusAudio
+    members
 
 PCMVolumeTransformer
 ~~~~~~~~~~~~~~~~~~~~~
 
-.. attributetable:: PCMVolumeTransformer
+.. attributetable PCMVolumeTransformer
 
-.. autoclass:: PCMVolumeTransformer
-    :members:
+.. autoclass PCMVolumeTransformer
+    members
 
 Opus Library
 ~~~~~~~~~~~~~
 
-.. autofunction:: nextcord.opus.load_opus
+.. autofunction nextcord.opus.load_opus
 
-.. autofunction:: nextcord.opus.is_loaded
+.. autofunction nextcord.opus.is_loaded
 
-.. _discord-api-events:
+.. _discord-api-events
 
 Event Reference
 ---------------
 
-This section outlines the different types of events listened by :class:`Client`.
+This section outlines the different types of events listened by class`Client`.
 
 There are two ways to register an event, the first way is through the use of
-:meth:`Client.event`. The second way is through subclassing :class:`Client` and
-overriding the specific events. For example: ::
+meth`Client.event`. The second way is through subclassing class`Client` and
+overriding the specific events. For example 
 
     import nextcord
 
-    class MyClient(nextcord.Client):
-        async def on_message(self, message):
-            if message.author == self.user:
+    class MyClient(nextcord.Client)
+        async def on_message(self, message)
+            if message.author == self.user
                 return
 
-            if message.content.startswith('$hello'):
+            if message.content.startswith('$hello')
                 await message.channel.send('Hello World!')
 
 
-If an event handler raises an exception, :func:`on_error` will be called
+If an event handler raises an exception, func`on_error` will be called
 to handle it, which defaults to print a traceback and ignoring the exception.
 
-.. warning::
+.. warning
 
     All the events must be a |coroutine_link|_. If they aren't, then you might get unexpected
-    errors. In order to turn a function into a coroutine they must be ``async def``
+    errors. To turn a function into a coroutine, they must be ``async def``
     functions.
 
-.. function:: on_connect()
+.. function on_connect()
 
     Called when the client has successfully connected to Discord. This is not
-    the same as the client being fully prepared, see :func:`on_ready` for that.
+    the same as the client being fully prepared, see func`on_ready` for that.
 
-    The warnings on :func:`on_ready` also apply.
+    The warnings on func`on_ready` also apply.
 
-.. function:: on_shard_connect(shard_id)
+.. function on_shard_connect(shard_id)
 
-    Similar to :func:`on_connect` except used by :class:`AutoShardedClient`
+    Similar to func`on_connect` except used by class`AutoShardedClient`
     to denote when a particular shard ID has connected to Discord.
 
-    .. versionadded:: 1.4
+    .. versionadded 1.4
 
-    :param shard_id: The shard ID that has connected.
-    :type shard_id: :class:`int`
+    param shard_id The shard ID that has connected.
+    type shard_id class`int`
 
-.. function:: on_disconnect()
+.. function on_disconnect()
 
     Called when the client has disconnected from Discord, or a connection attempt to Discord has failed.
     This could happen either through the internet being disconnected, explicit calls to close,
     or Discord terminating the connection one way or the other.
 
-    This function can be called many times without a corresponding :func:`on_connect` call.
+    This function can be called many times without a corresponding func`on_connect` call.
 
-.. function:: on_shard_disconnect(shard_id)
+.. function on_shard_disconnect(shard_id)
 
-    Similar to :func:`on_disconnect` except used by :class:`AutoShardedClient`
+    Similar to func`on_disconnect` except used by class`AutoShardedClient`
     to denote when a particular shard ID has disconnected from Discord.
 
-    .. versionadded:: 1.4
+    .. versionadded 1.4
 
-    :param shard_id: The shard ID that has disconnected.
-    :type shard_id: :class:`int`
+    param shard_id The shard ID that has disconnected.
+    type shard_id class`int`
 
-.. function:: on_ready()
+.. function on_ready()
 
     Called when the client is done preparing the data received from Discord. Usually after login is successful
-    and the :attr:`Client.guilds` and co. are filled up.
+    and the attr`Client.guilds` and co. are filled up.
 
-    .. warning::
+    .. warning
 
         This function is not guaranteed to be the first event called.
         Likewise, this function is **not** guaranteed to only be called
         once. This library implements reconnection logic and thus will
         end up calling this event whenever a RESUME request fails.
 
-.. function:: on_shard_ready(shard_id)
+.. function on_shard_ready(shard_id)
 
-    Similar to :func:`on_ready` except used by :class:`AutoShardedClient`
+    Similar to func`on_ready` except used by class`AutoShardedClient`
     to denote when a particular shard ID has become ready.
 
-    :param shard_id: The shard ID that is ready.
-    :type shard_id: :class:`int`
+    param shard_id The shard ID that is ready.
+    type shard_id class`int`
 
-.. function:: on_resumed()
+.. function on_resumed()
 
     Called when the client has resumed a session.
 
-.. function:: on_shard_resumed(shard_id)
+.. function on_shard_resumed(shard_id)
 
-    Similar to :func:`on_resumed` except used by :class:`AutoShardedClient`
+    Similar to func`on_resumed` except used by class`AutoShardedClient`
     to denote when a particular shard ID has resumed a session.
 
-    .. versionadded:: 1.4
+    .. versionadded 1.4
 
-    :param shard_id: The shard ID that has resumed.
-    :type shard_id: :class:`int`
+    param shard_id The shard ID that has resumed.
+    type shard_id class`int`
 
-.. function:: on_error(event, *args, **kwargs)
+.. function on_error(event, *args, **kwargs)
 
     Usually when an event raises an uncaught exception, a traceback is
     printed to stderr and the exception is ignored. If you want to
@@ -275,42 +275,42 @@ to handle it, which defaults to print a traceback and ignoring the exception.
     suppress the default action of printing the traceback.
 
     The information of the exception raised and the exception itself can
-    be retrieved with a standard call to :func:`sys.exc_info`.
+    be retrieved with a standard call to func`sys.exc_info`.
 
-    If you want exception to propagate out of the :class:`Client` class
+    If you want exception to propagate out of the class`Client` class
     you can define an ``on_error`` handler consisting of a single empty
-    :ref:`raise statement <py:raise>`. Exceptions raised by ``on_error`` will not be
-    handled in any way by :class:`Client`.
+    ref`raise statement <pyraise>`. Exceptions raised by ``on_error`` will not be
+    handled in any way by class`Client`.
 
-    .. note::
+    .. note
 
-        ``on_error`` will only be dispatched to :meth:`Client.event`.
+        ``on_error`` will only be dispatched to meth`Client.event`.
 
-        It will not be received by :meth:`Client.wait_for`, or, if used,
-        :ref:`ext_commands_api_bot` listeners such as
-        :meth:`~ext.commands.Bot.listen` or :meth:`~ext.commands.Cog.listener`.
+        It will not be received by meth`Client.wait_for`, or, if used,
+        ref`ext_commands_api_bot` listeners such as
+        meth`~ext.commands.Bot.listen` or meth`~ext.commands.Cog.listener`.
 
-    :param event: The name of the event that raised the exception.
-    :type event: :class:`str`
+    param event The name of the event that raised the exception.
+    type event class`str`
 
-    :param args: The positional arguments for the event that raised the
+    param args The positional arguments for the event that raised the
         exception.
-    :param kwargs: The keyword arguments for the event that raised the
+    param kwargs The keyword arguments for the event that raised the
         exception.
 
-.. function:: on_socket_event_type(event_type)
+.. function on_socket_event_type(event_type)
 
     Called whenever a websocket event is received from the WebSocket.
 
     This is mainly useful for logging how many events you are receiving
     from the Discord gateway.
 
-    .. versionadded:: 2.0
+    .. versionadded 2.0
 
-    :param event_type: The event type from Discord that is received, e.g. ``'READY'``.
-    :type event_type: :class:`str`
+    param event_type The event type from Discord that is received, e.g. ``'READY'``.
+    type event_type class`str`
 
-.. function:: on_socket_raw_receive(msg)
+.. function on_socket_raw_receive(msg)
 
     Called whenever a message is completely received from the WebSocket, before
     it's processed and parsed. This event is always dispatched when a
@@ -319,17 +319,17 @@ to handle it, which defaults to print a traceback and ignoring the exception.
     This is only really useful for grabbing the WebSocket stream and
     debugging purposes.
 
-    This requires setting the ``enable_debug_events`` setting in the :class:`Client`.
+    This requires setting the ``enable_debug_events`` setting in the class`Client`.
 
-    .. note::
+    .. note
 
         This is only for the messages received from the client
         WebSocket. The voice WebSocket will not trigger this event.
 
-    :param msg: The message passed in from the WebSocket library.
-    :type msg: :class:`str`
+    param msg The message passed in from the WebSocket library.
+    type msg class`str`
 
-.. function:: on_socket_raw_send(payload)
+.. function on_socket_raw_send(payload)
 
     Called whenever a send operation is done on the WebSocket before the
     message is sent. The passed parameter is the message that is being
@@ -338,70 +338,70 @@ to handle it, which defaults to print a traceback and ignoring the exception.
     This is only really useful for grabbing the WebSocket stream and
     debugging purposes.
 
-    This requires setting the ``enable_debug_events`` setting in the :class:`Client`.
+    This requires setting the ``enable_debug_events`` setting in the class`Client`.
 
-    .. note::
+    .. note
 
         This is only for the messages sent from the client
         WebSocket. The voice WebSocket will not trigger this event.
 
-    :param payload: The message that is about to be passed on to the
-                    WebSocket library. It can be :class:`bytes` to denote a binary
-                    message or :class:`str` to denote a regular text message.
+    param payload The message that is about to be passed on to the
+                    WebSocket library. It can be class`bytes` to denote a binary
+                    message or class`str` to denote a regular text message.
 
-.. function:: on_typing(channel, user, when)
+.. function on_typing(channel, user, when)
 
     Called when someone begins typing a message.
 
-    The ``channel`` parameter can be a :class:`abc.Messageable` instance.
-    Which could either be :class:`TextChannel`, :class:`GroupChannel`, or
-    :class:`DMChannel`.
+    The ``channel`` parameter can be a class`abc.Messageable` instance.
+    Which could either be class`TextChannel`, class`GroupChannel`, or
+    class`DMChannel`.
 
-    If the ``channel`` is a :class:`TextChannel` then the ``user`` parameter
-    is a :class:`Member`, otherwise it is a :class:`User`.
+    If the ``channel`` is a class`TextChannel` then the ``user`` parameter
+    is a class`Member`, otherwise it is a class`User`.
 
-    This requires :attr:`Intents.typing` to be enabled.
+    This requires attr`Intents.typing` to be enabled.
 
-    :param channel: The location where the typing originated from.
-    :type channel: :class:`abc.Messageable`
-    :param user: The user that started typing.
-    :type user: Union[:class:`User`, :class:`Member`]
-    :param when: When the typing started as an aware datetime in UTC.
-    :type when: :class:`datetime.datetime`
+    param channel The location where the typing originated from.
+    type channel class`abc.Messageable`
+    param user The user that started typing.
+    type user Union[class`User`, class`Member`]
+    param when When the typing started as an aware datetime in UTC.
+    type when class`datetime.datetime`
 
-.. function:: on_message(message)
+.. function on_message(message)
 
-    Called when a :class:`Message` is created and sent.
+    Called when a class`Message` is created and sent.
 
-    This requires :attr:`Intents.messages` to be enabled.
+    This requires attr`Intents.messages` to be enabled.
 
-    .. warning::
+    .. warning
 
         Your bot's own messages and private messages are sent through this
         event. This can lead cases of 'recursion' depending on how your bot was
         programmed. If you want the bot to not reply to itself, consider
-        checking the user IDs. Note that :class:`~ext.commands.Bot` does not
+        checking the user IDs. Note that class`~ext.commands.Bot` does not
         have this problem.
 
-    :param message: The current message.
-    :type message: :class:`Message`
+    param message The current message.
+    type message class`Message`
 
-.. function:: on_message_delete(message)
+.. function on_message_delete(message)
 
     Called when a message is deleted. If the message is not found in the
     internal message cache, then this event will not be called.
     Messages might not be in cache if the message is too old
     or the client is participating in high traffic guilds.
 
-    If this occurs increase the :class:`max_messages <Client>` parameter
-    or use the :func:`on_raw_message_delete` event instead.
+    If this occurs increase the class`max_messages <Client>` parameter
+    or use the func`on_raw_message_delete` event instead.
 
-    This requires :attr:`Intents.messages` to be enabled.
+    This requires attr`Intents.messages` to be enabled.
 
-    :param message: The deleted message.
-    :type message: :class:`Message`
+    param message The deleted message.
+    type message class`Message`
 
-.. function:: on_bulk_message_delete(messages)
+.. function on_bulk_message_delete(messages)
 
     Called when messages are bulk deleted. If none of the messages deleted
     are found in the internal message cache, then this event will not be called.
@@ -410,51 +410,51 @@ to handle it, which defaults to print a traceback and ignoring the exception.
     the messages list. Messages might not be in cache if the message is too old
     or the client is participating in high traffic guilds.
 
-    If this occurs increase the :class:`max_messages <Client>` parameter
-    or use the :func:`on_raw_bulk_message_delete` event instead.
+    If this occurs increase the class`max_messages <Client>` parameter
+    or use the func`on_raw_bulk_message_delete` event instead.
 
-    This requires :attr:`Intents.messages` to be enabled.
+    This requires attr`Intents.messages` to be enabled.
 
-    :param messages: The messages that have been deleted.
-    :type messages: List[:class:`Message`]
+    param messages The messages that have been deleted.
+    type messages List[class`Message`]
 
-.. function:: on_raw_message_delete(payload)
+.. function on_raw_message_delete(payload)
 
-    Called when a message is deleted. Unlike :func:`on_message_delete`, this is
+    Called when a message is deleted. Unlike func`on_message_delete`, this is
     called regardless of the message being in the internal message cache or not.
 
     If the message is found in the message cache,
-    it can be accessed via :attr:`RawMessageDeleteEvent.cached_message`
+    it can be accessed via attr`RawMessageDeleteEvent.cached_message`
 
-    This requires :attr:`Intents.messages` to be enabled.
+    This requires attr`Intents.messages` to be enabled.
 
-    :param payload: The raw event payload data.
-    :type payload: :class:`RawMessageDeleteEvent`
+    param payload The raw event payload data.
+    type payload class`RawMessageDeleteEvent`
 
-.. function:: on_raw_bulk_message_delete(payload)
+.. function on_raw_bulk_message_delete(payload)
 
-    Called when a bulk delete is triggered. Unlike :func:`on_bulk_message_delete`, this is
+    Called when a bulk delete is triggered. Unlike func`on_bulk_message_delete`, this is
     called regardless of the messages being in the internal message cache or not.
 
     If the messages are found in the message cache,
-    they can be accessed via :attr:`RawBulkMessageDeleteEvent.cached_messages`
+    they can be accessed via attr`RawBulkMessageDeleteEvent.cached_messages`
 
-    This requires :attr:`Intents.messages` to be enabled.
+    This requires attr`Intents.messages` to be enabled.
 
-    :param payload: The raw event payload data.
-    :type payload: :class:`RawBulkMessageDeleteEvent`
+    param payload The raw event payload data.
+    type payload class`RawBulkMessageDeleteEvent`
 
-.. function:: on_message_edit(before, after)
+.. function on_message_edit(before, after)
 
-    Called when a :class:`Message` receives an update event. If the message is not found
+    Called when a class`Message` receives an update event. If the message is not found
     in the internal message cache, then these events will not be called.
     Messages might not be in cache if the message is too old
     or the client is participating in high traffic guilds.
 
-    If this occurs increase the :class:`max_messages <Client>` parameter
-    or use the :func:`on_raw_message_edit` event instead.
+    If this occurs increase the class`max_messages <Client>` parameter
+    or use the func`on_raw_message_edit` event instead.
 
-    The following non-exhaustive cases trigger this event:
+    The following non-exhaustive cases trigger this event
 
     - A message has been pinned or unpinned.
     - The message content has been changed.
@@ -465,667 +465,667 @@ to handle it, which defaults to print a traceback and ignoring the exception.
     - The message's embeds were suppressed or unsuppressed.
     - A call message has received an update to its participants or ending time.
 
-    This requires :attr:`Intents.messages` to be enabled.
+    This requires attr`Intents.messages` to be enabled.
 
-    :param before: The previous version of the message.
-    :type before: :class:`Message`
-    :param after: The current version of the message.
-    :type after: :class:`Message`
+    param before The previous version of the message.
+    type before class`Message`
+    param after The current version of the message.
+    type after class`Message`
 
-.. function:: on_raw_message_edit(payload)
+.. function on_raw_message_edit(payload)
 
-    Called when a message is edited. Unlike :func:`on_message_edit`, this is called
+    Called when a message is edited. Unlike func`on_message_edit`, this is called
     regardless of the state of the internal message cache.
 
     If the message is found in the message cache,
-    it can be accessed via :attr:`RawMessageUpdateEvent.cached_message`. The cached message represents
+    it can be accessed via attr`RawMessageUpdateEvent.cached_message`. The cached message represents
     the message before it has been edited. For example, if the content of a message is modified and
-    triggers the :func:`on_raw_message_edit` coroutine, the :attr:`RawMessageUpdateEvent.cached_message`
-    will return a :class:`Message` object that represents the message before the content was modified.
+    triggers the func`on_raw_message_edit` coroutine, the attr`RawMessageUpdateEvent.cached_message`
+    will return a class`Message` object that represents the message before the content was modified.
 
     Due to the inherently raw nature of this event, the data parameter coincides with
-    the raw data given by the `gateway <https://discord.com/developers/docs/topics/gateway#message-update>`_.
+    the raw data given by the `gateway <https//discord.com/developers/docs/topics/gateway#message-update>`_.
 
     Since the data payload can be partial, care must be taken when accessing stuff in the dictionary.
     One example of a common case of partial data is when the ``'content'`` key is inaccessible. This
     denotes an "embed" only edit, which is an edit in which only the embeds are updated by the Discord
     embed server.
 
-    This requires :attr:`Intents.messages` to be enabled.
+    This requires attr`Intents.messages` to be enabled.
 
-    :param payload: The raw event payload data.
-    :type payload: :class:`RawMessageUpdateEvent`
+    param payload The raw event payload data.
+    type payload class`RawMessageUpdateEvent`
 
-.. function:: on_reaction_add(reaction, user)
+.. function on_reaction_add(reaction, user)
 
-    Called when a message has a reaction added to it. Similar to :func:`on_message_edit`,
+    Called when a message has a reaction added to it. Similar to func`on_message_edit`,
     if the message is not found in the internal message cache, then this
-    event will not be called. Consider using :func:`on_raw_reaction_add` instead.
+    event will not be called. Consider using func`on_raw_reaction_add` instead.
 
-    .. note::
+    .. note
 
-        To get the :class:`Message` being reacted, access it via :attr:`Reaction.message`.
+        To get the class`Message` being reacted, access it via attr`Reaction.message`.
 
-    This requires :attr:`Intents.reactions` to be enabled.
+    This requires attr`Intents.reactions` to be enabled.
 
-    .. note::
+    .. note
 
-        This doesn't require :attr:`Intents.members` within a guild context,
+        This doesn't require attr`Intents.members` within a guild context,
         but due to Discord not providing updated user information in a direct message
         it's required for direct messages to receive this event.
-        Consider using :func:`on_raw_reaction_add` if you need this and do not otherwise want
+        Consider using func`on_raw_reaction_add` if you need this and do not otherwise want
         to enable the members intent.
 
-    :param reaction: The current state of the reaction.
-    :type reaction: :class:`Reaction`
-    :param user: The user who added the reaction.
-    :type user: Union[:class:`Member`, :class:`User`]
+    param reaction The current state of the reaction.
+    type reaction class`Reaction`
+    param user The user who added the reaction.
+    type user Union[class`Member`, class`User`]
 
-.. function:: on_raw_reaction_add(payload)
+.. function on_raw_reaction_add(payload)
 
-    Called when a message has a reaction added. Unlike :func:`on_reaction_add`, this is
+    Called when a message has a reaction added. Unlike func`on_reaction_add`, this is
     called regardless of the state of the internal message cache.
 
-    This requires :attr:`Intents.reactions` to be enabled.
+    This requires attr`Intents.reactions` to be enabled.
 
-    :param payload: The raw event payload data.
-    :type payload: :class:`RawReactionActionEvent`
+    param payload The raw event payload data.
+    type payload class`RawReactionActionEvent`
 
-.. function:: on_reaction_remove(reaction, user)
+.. function on_reaction_remove(reaction, user)
 
     Called when a message has a reaction removed from it. Similar to on_message_edit,
     if the message is not found in the internal message cache, then this event
     will not be called.
 
-    .. note::
+    .. note
 
-        To get the message being reacted, access it via :attr:`Reaction.message`.
+        To get the message being reacted, access it via attr`Reaction.message`.
 
-    This requires both :attr:`Intents.reactions` and :attr:`Intents.members` to be enabled.
+    This requires both attr`Intents.reactions` and attr`Intents.members` to be enabled.
 
-    .. note::
+    .. note
 
-        Consider using :func:`on_raw_reaction_remove` if you need this and do not want
+        Consider using func`on_raw_reaction_remove` if you need this and do not want
         to enable the members intent.
 
-    :param reaction: The current state of the reaction.
-    :type reaction: :class:`Reaction`
-    :param user: The user who added the reaction.
-    :type user: Union[:class:`Member`, :class:`User`]
+    param reaction The current state of the reaction.
+    type reaction class`Reaction`
+    param user The user who added the reaction.
+    type user Union[class`Member`, class`User`]
 
-.. function:: on_raw_reaction_remove(payload)
+.. function on_raw_reaction_remove(payload)
 
-    Called when a message has a reaction removed. Unlike :func:`on_reaction_remove`, this is
+    Called when a message has a reaction removed. Unlike func`on_reaction_remove`, this is
     called regardless of the state of the internal message cache.
 
-    This requires :attr:`Intents.reactions` to be enabled.
+    This requires attr`Intents.reactions` to be enabled.
 
-    :param payload: The raw event payload data.
-    :type payload: :class:`RawReactionActionEvent`
+    param payload The raw event payload data.
+    type payload class`RawReactionActionEvent`
 
-.. function:: on_reaction_clear(message, reactions)
+.. function on_reaction_clear(message, reactions)
 
-    Called when a message has all its reactions removed from it. Similar to :func:`on_message_edit`,
+    Called when a message has all its reactions removed from it. Similar to func`on_message_edit`,
     if the message is not found in the internal message cache, then this event
-    will not be called. Consider using :func:`on_raw_reaction_clear` instead.
+    will not be called. Consider using func`on_raw_reaction_clear` instead.
 
-    This requires :attr:`Intents.reactions` to be enabled.
+    This requires attr`Intents.reactions` to be enabled.
 
-    :param message: The message that had its reactions cleared.
-    :type message: :class:`Message`
-    :param reactions: The reactions that were removed.
-    :type reactions: List[:class:`Reaction`]
+    param message The message that had its reactions cleared.
+    type message class`Message`
+    param reactions The reactions that were removed.
+    type reactions List[class`Reaction`]
 
-.. function:: on_raw_reaction_clear(payload)
+.. function on_raw_reaction_clear(payload)
 
-    Called when a message has all its reactions removed. Unlike :func:`on_reaction_clear`,
+    Called when a message has all its reactions removed. Unlike func`on_reaction_clear`,
     this is called regardless of the state of the internal message cache.
 
-    This requires :attr:`Intents.reactions` to be enabled.
+    This requires attr`Intents.reactions` to be enabled.
 
-    :param payload: The raw event payload data.
-    :type payload: :class:`RawReactionClearEvent`
+    param payload The raw event payload data.
+    type payload class`RawReactionClearEvent`
 
-.. function:: on_reaction_clear_emoji(reaction)
+.. function on_reaction_clear_emoji(reaction)
 
-    Called when a message has a specific reaction removed from it. Similar to :func:`on_message_edit`,
+    Called when a message has a specific reaction removed from it. Similar to func`on_message_edit`,
     if the message is not found in the internal message cache, then this event
-    will not be called. Consider using :func:`on_raw_reaction_clear_emoji` instead.
+    will not be called. Consider using func`on_raw_reaction_clear_emoji` instead.
 
-    This requires :attr:`Intents.reactions` to be enabled.
+    This requires attr`Intents.reactions` to be enabled.
 
-    .. versionadded:: 1.3
+    .. versionadded 1.3
 
-    :param reaction: The reaction that got cleared.
-    :type reaction: :class:`Reaction`
+    param reaction The reaction that got cleared.
+    type reaction class`Reaction`
 
-.. function:: on_raw_reaction_clear_emoji(payload)
+.. function on_raw_reaction_clear_emoji(payload)
 
-    Called when a message has a specific reaction removed from it. Unlike :func:`on_reaction_clear_emoji` this is called
+    Called when a message has a specific reaction removed from it. Unlike func`on_reaction_clear_emoji` this is called
     regardless of the state of the internal message cache.
 
-    This requires :attr:`Intents.reactions` to be enabled.
+    This requires attr`Intents.reactions` to be enabled.
 
-    .. versionadded:: 1.3
+    .. versionadded 1.3
 
-    :param payload: The raw event payload data.
-    :type payload: :class:`RawReactionClearEmojiEvent`
+    param payload The raw event payload data.
+    type payload class`RawReactionClearEmojiEvent`
 
-.. function:: on_interaction(interaction)
+.. function on_interaction(interaction)
 
     Called when an interaction happened.
 
     This currently happens due to slash command invocations or components being used.
 
-    .. warning::
+    .. warning
 
         This is a low level function that is not generally meant to be used.
         If you are working with components, consider using the callbacks associated
-        with the :class:`~nextcord.ui.View` instead as it provides a nicer user experience.
+        with the class`~nextcord.ui.View` instead as it provides a nicer user experience.
 
-    .. versionadded:: 2.0
+    .. versionadded 2.0
 
-    :param interaction: The interaction data.
-    :type interaction: :class:`Interaction`
+    param interaction The interaction data.
+    type interaction class`Interaction`
 
-.. function:: on_private_channel_update(before, after)
+.. function on_private_channel_update(before, after)
 
     Called whenever a private group DM is updated. e.g. changed name or topic.
 
-    This requires :attr:`Intents.messages` to be enabled.
+    This requires attr`Intents.messages` to be enabled.
 
-    :param before: The updated group channel's old info.
-    :type before: :class:`GroupChannel`
-    :param after: The updated group channel's new info.
-    :type after: :class:`GroupChannel`
+    param before The updated group channel's old info.
+    type before class`GroupChannel`
+    param after The updated group channel's new info.
+    type after class`GroupChannel`
 
-.. function:: on_private_channel_pins_update(channel, last_pin)
+.. function on_private_channel_pins_update(channel, last_pin)
 
     Called whenever a message is pinned or unpinned from a private channel.
 
-    :param channel: The private channel that had its pins updated.
-    :type channel: :class:`abc.PrivateChannel`
-    :param last_pin: The latest message that was pinned as an aware datetime in UTC. Could be ``None``.
-    :type last_pin: Optional[:class:`datetime.datetime`]
+    param channel The private channel that had its pins updated.
+    type channel class`abc.PrivateChannel`
+    param last_pin The latest message that was pinned as an aware datetime in UTC. Could be ``None``.
+    type last_pin Optional[class`datetime.datetime`]
 
-.. function:: on_guild_channel_delete(channel)
+.. function on_guild_channel_delete(channel)
               on_guild_channel_create(channel)
 
     Called whenever a guild channel is deleted or created.
 
-    Note that you can get the guild from :attr:`~abc.GuildChannel.guild`.
+    Note that you can get the guild from attr`~abc.GuildChannel.guild`.
 
-    This requires :attr:`Intents.guilds` to be enabled.
+    This requires attr`Intents.guilds` to be enabled.
 
-    :param channel: The guild channel that got created or deleted.
-    :type channel: :class:`abc.GuildChannel`
+    param channel The guild channel that got created or deleted.
+    type channel class`abc.GuildChannel`
 
-.. function:: on_guild_channel_update(before, after)
+.. function on_guild_channel_update(before, after)
 
     Called whenever a guild channel is updated. e.g. changed name, topic, permissions.
 
-    This requires :attr:`Intents.guilds` to be enabled.
+    This requires attr`Intents.guilds` to be enabled.
 
-    :param before: The updated guild channel's old info.
-    :type before: :class:`abc.GuildChannel`
-    :param after: The updated guild channel's new info.
-    :type after: :class:`abc.GuildChannel`
+    param before The updated guild channel's old info.
+    type before class`abc.GuildChannel`
+    param after The updated guild channel's new info.
+    type after class`abc.GuildChannel`
 
-.. function:: on_guild_channel_pins_update(channel, last_pin)
+.. function on_guild_channel_pins_update(channel, last_pin)
 
     Called whenever a message is pinned or unpinned from a guild channel.
 
-    This requires :attr:`Intents.guilds` to be enabled.
+    This requires attr`Intents.guilds` to be enabled.
 
-    :param channel: The guild channel that had its pins updated.
-    :type channel: Union[:class:`abc.GuildChannel`, :class:`Thread`]
-    :param last_pin: The latest message that was pinned as an aware datetime in UTC. Could be ``None``.
-    :type last_pin: Optional[:class:`datetime.datetime`]
+    param channel The guild channel that had its pins updated.
+    type channel Union[class`abc.GuildChannel`, class`Thread`]
+    param last_pin The latest message that was pinned as an aware datetime in UTC. Could be ``None``.
+    type last_pin Optional[class`datetime.datetime`]
 
-.. function:: on_thread_join(thread)
+.. function on_thread_join(thread)
 
     Called whenever a thread is joined or created. Note that from the API's perspective there is no way to
     differentiate between a thread being created or the bot joining a thread.
 
-    Note that you can get the guild from :attr:`Thread.guild`.
+    Note that you can get the guild from attr`Thread.guild`.
 
-    This requires :attr:`Intents.guilds` to be enabled.
+    This requires attr`Intents.guilds` to be enabled.
 
-    .. versionadded:: 2.0
+    .. versionadded 2.0
 
-    :param thread: The thread that got joined.
-    :type thread: :class:`Thread`
+    param thread The thread that got joined.
+    type thread class`Thread`
 
-.. function:: on_thread_remove(thread)
+.. function on_thread_remove(thread)
 
     Called whenever a thread is removed. This is different from a thread being deleted.
 
-    Note that you can get the guild from :attr:`Thread.guild`.
+    Note that you can get the guild from attr`Thread.guild`.
 
-    This requires :attr:`Intents.guilds` to be enabled.
+    This requires attr`Intents.guilds` to be enabled.
 
-    .. warning::
+    .. warning
 
         Due to technical limitations, this event might not be called
         as soon as one expects. Since the library tracks thread membership
         locally, the API only sends updated thread membership status upon being
         synced by joining a thread.
 
-    .. versionadded:: 2.0
+    .. versionadded 2.0
 
-    :param thread: The thread that got removed.
-    :type thread: :class:`Thread`
+    param thread The thread that got removed.
+    type thread class`Thread`
 
-.. function:: on_thread_delete(thread)
+.. function on_thread_delete(thread)
 
     Called whenever a thread is deleted.
 
-    Note that you can get the guild from :attr:`Thread.guild`.
+    Note that you can get the guild from attr`Thread.guild`.
 
-    This requires :attr:`Intents.guilds` to be enabled.
+    This requires attr`Intents.guilds` to be enabled.
 
-    .. versionadded:: 2.0
+    .. versionadded 2.0
 
-    :param thread: The thread that got deleted.
-    :type thread: :class:`Thread`
+    param thread The thread that got deleted.
+    type thread class`Thread`
 
-.. function:: on_thread_member_join(member)
+.. function on_thread_member_join(member)
               on_thread_member_remove(member)
 
-    Called when a :class:`ThreadMember` leaves or joins a :class:`Thread`.
+    Called when a class`ThreadMember` leaves or joins a class`Thread`.
 
-    You can get the thread a member belongs in by accessing :attr:`ThreadMember.thread`.
+    You can get the thread a member belongs in by accessing attr`ThreadMember.thread`.
 
-    This requires :attr:`Intents.members` to be enabled.
+    This requires attr`Intents.members` to be enabled.
 
-    .. versionadded:: 2.0
+    .. versionadded 2.0
 
-    :param member: The member who joined or left.
-    :type member: :class:`ThreadMember`
+    param member The member who joined or left.
+    type member class`ThreadMember`
 
-.. function:: on_thread_update(before, after)
+.. function on_thread_update(before, after)
 
     Called whenever a thread is updated.
 
-    This requires :attr:`Intents.guilds` to be enabled.
+    This requires attr`Intents.guilds` to be enabled.
 
-    .. versionadded:: 2.0
+    .. versionadded 2.0
 
-    :param before: The updated thread's old info.
-    :type before: :class:`Thread`
-    :param after: The updated thread's new info.
-    :type after: :class:`Thread`
+    param before The updated thread's old info.
+    type before class`Thread`
+    param after The updated thread's new info.
+    type after class`Thread`
 
-.. function:: on_guild_integrations_update(guild)
+.. function on_guild_integrations_update(guild)
 
     Called whenever an integration is created, modified, or removed from a guild.
 
-    This requires :attr:`Intents.integrations` to be enabled.
+    This requires attr`Intents.integrations` to be enabled.
 
-    .. versionadded:: 1.4
+    .. versionadded 1.4
 
-    :param guild: The guild that had its integrations updated.
-    :type guild: :class:`Guild`
+    param guild The guild that had its integrations updated.
+    type guild class`Guild`
 
-.. function:: on_integration_create(integration)
+.. function on_integration_create(integration)
 
     Called when an integration is created.
 
-    This requires :attr:`Intents.integrations` to be enabled.
+    This requires attr`Intents.integrations` to be enabled.
 
-    .. versionadded:: 2.0
+    .. versionadded 2.0
 
-    :param integration: The integration that was created.
-    :type integration: :class:`Integration`
+    param integration The integration that was created.
+    type integration class`Integration`
 
-.. function:: on_integration_update(integration)
+.. function on_integration_update(integration)
 
     Called when an integration is updated.
 
-    This requires :attr:`Intents.integrations` to be enabled.
+    This requires attr`Intents.integrations` to be enabled.
 
-    .. versionadded:: 2.0
+    .. versionadded 2.0
 
-    :param integration: The integration that was created.
-    :type integration: :class:`Integration`
+    param integration The integration that was created.
+    type integration class`Integration`
 
-.. function:: on_raw_integration_delete(payload)
+.. function on_raw_integration_delete(payload)
 
     Called when an integration is deleted.
 
-    This requires :attr:`Intents.integrations` to be enabled.
+    This requires attr`Intents.integrations` to be enabled.
 
-    .. versionadded:: 2.0
+    .. versionadded 2.0
 
-    :param payload: The raw event payload data.
-    :type payload: :class:`RawIntegrationDeleteEvent`
+    param payload The raw event payload data.
+    type payload class`RawIntegrationDeleteEvent`
 
-.. function:: on_webhooks_update(channel)
+.. function on_webhooks_update(channel)
 
     Called whenever a webhook is created, modified, or removed from a guild channel.
 
-    This requires :attr:`Intents.webhooks` to be enabled.
+    This requires attr`Intents.webhooks` to be enabled.
 
-    :param channel: The channel that had its webhooks updated.
-    :type channel: :class:`abc.GuildChannel`
+    param channel The channel that had its webhooks updated.
+    type channel class`abc.GuildChannel`
 
-.. function:: on_member_join(member)
+.. function on_member_join(member)
               on_member_remove(member)
 
-    Called when a :class:`Member` leaves or joins a :class:`Guild`.
+    Called when a class`Member` leaves or joins a class`Guild`.
 
-    This requires :attr:`Intents.members` to be enabled.
+    This requires attr`Intents.members` to be enabled.
 
-    :param member: The member who joined or left.
-    :type member: :class:`Member`
+    param member The member who joined or left.
+    type member class`Member`
 
-.. function:: on_member_update(before, after)
+.. function on_member_update(before, after)
 
-    Called when a :class:`Member` updates their profile.
+    Called when a class`Member` updates their profile.
 
-    This is called when one or more of the following things change:
+    This is called when one or more of the following things change
 
     - nickname
     - roles
     - pending
 
-    This requires :attr:`Intents.members` to be enabled.
+    This requires attr`Intents.members` to be enabled.
 
-    :param before: The updated member's old info.
-    :type before: :class:`Member`
-    :param after: The updated member's updated info.
-    :type after: :class:`Member`
+    param before The updated member's old info.
+    type before class`Member`
+    param after The updated member's updated info.
+    type after class`Member`
 
-.. function:: on_presence_update(before, after)
+.. function on_presence_update(before, after)
 
-    Called when a :class:`Member` updates their presence.
+    Called when a class`Member` updates their presence.
 
-    This is called when one or more of the following things change:
+    This is called when one or more of the following things change
 
     - status
     - activity
 
-    This requires :attr:`Intents.presences` and :attr:`Intents.members` to be enabled.
+    This requires attr`Intents.presences` and attr`Intents.members` to be enabled.
 
-    .. versionadded:: 2.0
+    .. versionadded 2.0
 
-    :param before: The updated member's old info.
-    :type before: :class:`Member`
-    :param after: The updated member's updated info.
-    :type after: :class:`Member`
+    param before The updated member's old info.
+    type before class`Member`
+    param after The updated member's updated info.
+    type after class`Member`
 
-.. function:: on_user_update(before, after)
+.. function on_user_update(before, after)
 
-    Called when a :class:`User` updates their profile.
+    Called when a class`User` updates their profile.
 
-    This is called when one or more of the following things change:
+    This is called when one or more of the following things change
 
     - avatar
     - username
     - discriminator
 
-    This requires :attr:`Intents.members` to be enabled.
+    This requires attr`Intents.members` to be enabled.
 
-    :param before: The updated user's old info.
-    :type before: :class:`User`
-    :param after: The updated user's updated info.
-    :type after: :class:`User`
+    param before The updated user's old info.
+    type before class`User`
+    param after The updated user's updated info.
+    type after class`User`
 
-.. function:: on_guild_join(guild)
+.. function on_guild_join(guild)
 
-    Called when a :class:`Guild` is either created by the :class:`Client` or when the
-    :class:`Client` joins a guild.
+    Called when a class`Guild` is either created by the class`Client` or when the
+    class`Client` joins a guild.
 
-    This requires :attr:`Intents.guilds` to be enabled.
+    This requires attr`Intents.guilds` to be enabled.
 
-    :param guild: The guild that was joined.
-    :type guild: :class:`Guild`
+    param guild The guild that was joined.
+    type guild class`Guild`
 
-.. function:: on_guild_remove(guild)
+.. function on_guild_remove(guild)
 
-    Called when a :class:`Guild` is removed from the :class:`Client`.
+    Called when a class`Guild` is removed from the class`Client`.
 
-    This happens through, but not limited to, these circumstances:
+    This happens through, but not limited to, these circumstances
 
     - The client got banned.
     - The client got kicked.
     - The client left the guild.
     - The client or the guild owner deleted the guild.
 
-    In order for this event to be invoked then the :class:`Client` must have
-    been part of the guild to begin with. (i.e. it is part of :attr:`Client.guilds`)
+    For this event to be invoked, the class`Client` must have
+    been part of the guild to begin with. (i.e. it is part of attr`Client.guilds`)
 
-    This requires :attr:`Intents.guilds` to be enabled.
+    This requires attr`Intents.guilds` to be enabled.
 
-    :param guild: The guild that got removed.
-    :type guild: :class:`Guild`
+    param guild The guild that got removed.
+    type guild class`Guild`
 
-.. function:: on_guild_update(before, after)
+.. function on_guild_update(before, after)
 
-    Called when a :class:`Guild` updates, for example:
+    Called when a class`Guild` updates, for example
 
     - Changed name
     - Changed AFK channel
     - Changed AFK timeout
     - etc
 
-    This requires :attr:`Intents.guilds` to be enabled.
+    This requires attr`Intents.guilds` to be enabled.
 
-    :param before: The guild prior to being updated.
-    :type before: :class:`Guild`
-    :param after: The guild after being updated.
-    :type after: :class:`Guild`
+    param before The guild prior to being updated.
+    type before class`Guild`
+    param after The guild after being updated.
+    type after class`Guild`
 
-.. function:: on_guild_role_create(role)
+.. function on_guild_role_create(role)
               on_guild_role_delete(role)
 
-    Called when a :class:`Guild` creates or deletes a new :class:`Role`.
+    Called when a class`Guild` creates or deletes a new class`Role`.
 
-    To get the guild it belongs to, use :attr:`Role.guild`.
+    To get the guild it belongs to, use attr`Role.guild`.
 
-    This requires :attr:`Intents.guilds` to be enabled.
+    This requires attr`Intents.guilds` to be enabled.
 
-    :param role: The role that was created or deleted.
-    :type role: :class:`Role`
+    param role The role that was created or deleted.
+    type role class`Role`
 
-.. function:: on_guild_role_update(before, after)
+.. function on_guild_role_update(before, after)
 
-    Called when a :class:`Role` is changed guild-wide.
+    Called when a class`Role` is changed guild-wide.
 
-    This requires :attr:`Intents.guilds` to be enabled.
+    This requires attr`Intents.guilds` to be enabled.
 
-    :param before: The updated role's old info.
-    :type before: :class:`Role`
-    :param after: The updated role's updated info.
-    :type after: :class:`Role`
+    param before The updated role's old info.
+    type before class`Role`
+    param after The updated role's updated info.
+    type after class`Role`
 
-.. function:: on_guild_emojis_update(guild, before, after)
+.. function on_guild_emojis_update(guild, before, after)
 
-    Called when a :class:`Guild` adds or removes :class:`Emoji`.
+    Called when a class`Guild` adds or removes class`Emoji`.
 
-    This requires :attr:`Intents.emojis_and_stickers` to be enabled.
+    This requires attr`Intents.emojis_and_stickers` to be enabled.
 
-    :param guild: The guild who got their emojis updated.
-    :type guild: :class:`Guild`
-    :param before: A list of emojis before the update.
-    :type before: Sequence[:class:`Emoji`]
-    :param after: A list of emojis after the update.
-    :type after: Sequence[:class:`Emoji`]
+    param guild The guild who got their emojis updated.
+    type guild class`Guild`
+    param before A list of emojis before the update.
+    type before Sequence[class`Emoji`]
+    param after A list of emojis after the update.
+    type after Sequence[class`Emoji`]
 
-.. function:: on_guild_stickers_update(guild, before, after)
+.. function on_guild_stickers_update(guild, before, after)
 
-    Called when a :class:`Guild` updates its stickers.
+    Called when a class`Guild` updates its stickers.
 
-    This requires :attr:`Intents.emojis_and_stickers` to be enabled.
+    This requires attr`Intents.emojis_and_stickers` to be enabled.
 
-    .. versionadded:: 2.0
+    .. versionadded 2.0
 
-    :param guild: The guild who got their stickers updated.
-    :type guild: :class:`Guild`
-    :param before: A list of stickers before the update.
-    :type before: Sequence[:class:`GuildSticker`]
-    :param after: A list of stickers after the update.
-    :type after: Sequence[:class:`GuildSticker`]
+    param guild The guild who got their stickers updated.
+    type guild class`Guild`
+    param before A list of stickers before the update.
+    type before Sequence[class`GuildSticker`]
+    param after A list of stickers after the update.
+    type after Sequence[class`GuildSticker`]
 
-.. function:: on_guild_available(guild)
+.. function on_guild_available(guild)
               on_guild_unavailable(guild)
 
     Called when a guild becomes available or unavailable. The guild must have
-    existed in the :attr:`Client.guilds` cache.
+    existed in the attr`Client.guilds` cache.
 
-    This requires :attr:`Intents.guilds` to be enabled.
+    This requires attr`Intents.guilds` to be enabled.
 
-    :param guild: The :class:`Guild` that has changed availability.
+    param guild The class`Guild` that has changed availability.
 
-.. function:: on_voice_state_update(member, before, after)
+.. function on_voice_state_update(member, before, after)
 
-    Called when a :class:`Member` changes their :class:`VoiceState`.
+    Called when a class`Member` changes their class`VoiceState`.
 
-    The following, but not limited to, examples illustrate when this event is called:
+    The following, but not limited to, examples illustrate when this event is called
 
     - A member joins a voice or stage channel.
     - A member leaves a voice or stage channel.
     - A member is muted or deafened by their own accord.
     - A member is muted or deafened by a guild administrator.
 
-    This requires :attr:`Intents.voice_states` to be enabled.
+    This requires attr`Intents.voice_states` to be enabled.
 
-    :param member: The member whose voice states changed.
-    :type member: :class:`Member`
-    :param before: The voice state prior to the changes.
-    :type before: :class:`VoiceState`
-    :param after: The voice state after the changes.
-    :type after: :class:`VoiceState`
+    param member The member whose voice states changed.
+    type member class`Member`
+    param before The voice state prior to the changes.
+    type before class`VoiceState`
+    param after The voice state after the changes.
+    type after class`VoiceState`
 
-.. function:: on_stage_instance_create(stage_instance)
+.. function on_stage_instance_create(stage_instance)
               on_stage_instance_delete(stage_instance)
 
-    Called when a :class:`StageInstance` is created or deleted for a :class:`StageChannel`.
+    Called when a class`StageInstance` is created or deleted for a class`StageChannel`.
 
-    .. versionadded:: 2.0
+    .. versionadded 2.0
 
-    :param stage_instance: The stage instance that was created or deleted.
-    :type stage_instance: :class:`StageInstance`
+    param stage_instance The stage instance that was created or deleted.
+    type stage_instance class`StageInstance`
 
-.. function:: on_stage_instance_update(before, after)
+.. function on_stage_instance_update(before, after)
 
-    Called when a :class:`StageInstance` is updated.
+    Called when a class`StageInstance` is updated.
 
-    The following, but not limited to, examples illustrate when this event is called:
+    The following, but not limited to, examples illustrate when this event is called
 
     - The topic is changed.
     - The privacy level is changed.
 
-    .. versionadded:: 2.0
+    .. versionadded 2.0
 
-    :param before: The stage instance before the update.
-    :type before: :class:`StageInstance`
-    :param after: The stage instance after the update.
-    :type after: :class:`StageInstance`
+    param before The stage instance before the update.
+    type before class`StageInstance`
+    param after The stage instance after the update.
+    type after class`StageInstance`
 
-.. function:: on_member_ban(guild, user)
+.. function on_member_ban(guild, user)
 
-    Called when user gets banned from a :class:`Guild`.
+    Called when user gets banned from a class`Guild`.
 
-    This requires :attr:`Intents.bans` to be enabled.
+    This requires attr`Intents.bans` to be enabled.
 
-    :param guild: The guild the user got banned from.
-    :type guild: :class:`Guild`
-    :param user: The user that got banned.
-                 Can be either :class:`User` or :class:`Member` depending if
+    param guild The guild the user got banned from.
+    type guild class`Guild`
+    param user The user that got banned.
+                 Can be either class`User` or class`Member` depending if
                  the user was in the guild or not at the time of removal.
-    :type user: Union[:class:`User`, :class:`Member`]
+    type user Union[class`User`, class`Member`]
 
-.. function:: on_member_unban(guild, user)
+.. function on_member_unban(guild, user)
 
-    Called when a :class:`User` gets unbanned from a :class:`Guild`.
+    Called when a class`User` gets unbanned from a class`Guild`.
 
-    This requires :attr:`Intents.bans` to be enabled.
+    This requires attr`Intents.bans` to be enabled.
 
-    :param guild: The guild the user got unbanned from.
-    :type guild: :class:`Guild`
-    :param user: The user that got unbanned.
-    :type user: :class:`User`
+    param guild The guild the user got unbanned from.
+    type guild class`Guild`
+    param user The user that got unbanned.
+    type user class`User`
 
-.. function:: on_invite_create(invite)
+.. function on_invite_create(invite)
 
-    Called when an :class:`Invite` is created.
-    You must have the :attr:`~Permissions.manage_channels` permission to receive this.
+    Called when an class`Invite` is created.
+    You must have the attr`~Permissions.manage_channels` permission to receive this.
 
-    .. versionadded:: 1.3
+    .. versionadded 1.3
 
-    .. note::
+    .. note
 
-        There is a rare possibility that the :attr:`Invite.guild` and :attr:`Invite.channel`
-        attributes will be of :class:`Object` rather than the respective models.
+        There is a rare possibility that the attr`Invite.guild` and attr`Invite.channel`
+        attributes will be of class`Object` rather than the respective models.
 
-    This requires :attr:`Intents.invites` to be enabled.
+    This requires attr`Intents.invites` to be enabled.
 
-    :param invite: The invite that was created.
-    :type invite: :class:`Invite`
+    param invite The invite that was created.
+    type invite class`Invite`
 
-.. function:: on_invite_delete(invite)
+.. function on_invite_delete(invite)
 
-    Called when an :class:`Invite` is deleted.
-    You must have the :attr:`~Permissions.manage_channels` permission to receive this.
+    Called when an class`Invite` is deleted.
+    You must have the attr`~Permissions.manage_channels` permission to receive this.
 
-    .. versionadded:: 1.3
+    .. versionadded 1.3
 
-    .. note::
+    .. note
 
-        There is a rare possibility that the :attr:`Invite.guild` and :attr:`Invite.channel`
-        attributes will be of :class:`Object` rather than the respective models.
+        There is a rare possibility that the attr`Invite.guild` and attr`Invite.channel`
+        attributes will be of class`Object` rather than the respective models.
 
         Outside of those two attributes, the only other attribute guaranteed to be
-        filled by the Discord gateway for this event is :attr:`Invite.code`.
+        filled by the Discord gateway for this event is attr`Invite.code`.
 
-    This requires :attr:`Intents.invites` to be enabled.
+    This requires attr`Intents.invites` to be enabled.
 
-    :param invite: The invite that was deleted.
-    :type invite: :class:`Invite`
+    param invite The invite that was deleted.
+    type invite class`Invite`
 
-.. function:: on_group_join(channel, user)
+.. function on_group_join(channel, user)
               on_group_remove(channel, user)
 
-    Called when someone joins or leaves a :class:`GroupChannel`.
+    Called when someone joins or leaves a class`GroupChannel`.
 
-    :param channel: The group that the user joined or left.
-    :type channel: :class:`GroupChannel`
-    :param user: The user that joined or left.
-    :type user: :class:`User`
+    param channel The group that the user joined or left.
+    type channel class`GroupChannel`
+    param user The user that joined or left.
+    type user class`User`
 
-.. _discord-api-utils:
+.. _discord-api-utils
 
 Utility Functions
 -----------------
 
-.. autofunction:: nextcord.utils.find
+.. autofunction nextcord.utils.find
 
-.. autofunction:: nextcord.utils.get
+.. autofunction nextcord.utils.get
 
-.. autofunction:: nextcord.utils.snowflake_time
+.. autofunction nextcord.utils.snowflake_time
 
-.. autofunction:: nextcord.utils.oauth_url
+.. autofunction nextcord.utils.oauth_url
 
-.. autofunction:: nextcord.utils.remove_markdown
+.. autofunction nextcord.utils.remove_markdown
 
-.. autofunction:: nextcord.utils.escape_markdown
+.. autofunction nextcord.utils.escape_markdown
 
-.. autofunction:: nextcord.utils.escape_mentions
+.. autofunction nextcord.utils.escape_mentions
 
-.. autofunction:: nextcord.utils.resolve_invite
+.. autofunction nextcord.utils.resolve_invite
 
-.. autofunction:: nextcord.utils.resolve_template
+.. autofunction nextcord.utils.resolve_template
 
-.. autofunction:: nextcord.utils.sleep_until
+.. autofunction nextcord.utils.sleep_until
 
-.. autofunction:: nextcord.utils.utcnow
+.. autofunction nextcord.utils.utcnow
 
-.. autofunction:: nextcord.utils.format_dt
+.. autofunction nextcord.utils.format_dt
 
-.. autofunction:: nextcord.utils.as_chunks
+.. autofunction nextcord.utils.as_chunks
 
-.. _discord-api-enums:
+.. _discord-api-enums
 
 Enumerations
 -------------
@@ -1134,609 +1134,609 @@ The API provides some enumerations for certain types of strings to avoid the API
 from being stringly typed in case the strings change in the future.
 
 All enumerations are subclasses of an internal class which mimics the behaviour
-of :class:`enum.Enum`.
+of class`enum.Enum`.
 
-.. class:: ChannelType
+.. class ChannelType
 
     Specifies the type of channel.
 
-    .. attribute:: text
+    .. attribute text
 
         A text channel.
-    .. attribute:: voice
+    .. attribute voice
 
         A voice channel.
-    .. attribute:: private
+    .. attribute private
 
         A private text channel. Also called a direct message.
-    .. attribute:: group
+    .. attribute group
 
         A private group text channel.
-    .. attribute:: category
+    .. attribute category
 
         A category channel.
-    .. attribute:: news
+    .. attribute news
 
         A guild news channel.
 
-    .. attribute:: store
+    .. attribute store
 
         A guild store channel.
 
-    .. attribute:: stage_voice
+    .. attribute stage_voice
 
         A guild stage voice channel.
 
-        .. versionadded:: 1.7
+        .. versionadded 1.7
 
-    .. attribute:: news_thread
+    .. attribute news_thread
 
         A news thread
 
-        .. versionadded:: 2.0
+        .. versionadded 2.0
 
-    .. attribute:: public_thread
+    .. attribute public_thread
 
         A public thread
 
-        .. versionadded:: 2.0
+        .. versionadded 2.0
 
-    .. attribute:: private_thread
+    .. attribute private_thread
 
         A private thread
 
-        .. versionadded:: 2.0
+        .. versionadded 2.0
 
-.. class:: MessageType
+.. class MessageType
 
-    Specifies the type of :class:`Message`. This is used to denote if a message
+    Specifies the type of class`Message`. This is used to denote if a message
     is to be interpreted as a system message or a regular message.
 
-    .. container:: operations
+    .. container operations
 
-      .. describe:: x == y
+      .. describe x == y
 
           Checks if two messages are equal.
-      .. describe:: x != y
+      .. describe x != y
 
           Checks if two messages are not equal.
 
-    .. attribute:: default
+    .. attribute default
 
         The default message type. This is the same as regular messages.
-    .. attribute:: recipient_add
+    .. attribute recipient_add
 
         The system message when a user is added to a group private
         message or a thread.
-    .. attribute:: recipient_remove
+    .. attribute recipient_remove
 
         The system message when a user is removed from a group private
         message or a thread.
-    .. attribute:: call
+    .. attribute call
 
         The system message denoting call state, e.g. missed call, started call,
         etc.
-    .. attribute:: channel_name_change
+    .. attribute channel_name_change
 
         The system message denoting that a channel's name has been changed.
-    .. attribute:: channel_icon_change
+    .. attribute channel_icon_change
 
         The system message denoting that a channel's icon has been changed.
-    .. attribute:: pins_add
+    .. attribute pins_add
 
         The system message denoting that a pinned message has been added to a channel.
-    .. attribute:: new_member
+    .. attribute new_member
 
         The system message denoting that a new member has joined a Guild.
 
-    .. attribute:: premium_guild_subscription
+    .. attribute premium_guild_subscription
 
         The system message denoting that a member has "nitro boosted" a guild.
-    .. attribute:: premium_guild_tier_1
+    .. attribute premium_guild_tier_1
 
         The system message denoting that a member has "nitro boosted" a guild
         and it achieved level 1.
-    .. attribute:: premium_guild_tier_2
+    .. attribute premium_guild_tier_2
 
         The system message denoting that a member has "nitro boosted" a guild
         and it achieved level 2.
-    .. attribute:: premium_guild_tier_3
+    .. attribute premium_guild_tier_3
 
         The system message denoting that a member has "nitro boosted" a guild
         and it achieved level 3.
-    .. attribute:: channel_follow_add
+    .. attribute channel_follow_add
 
         The system message denoting that an announcement channel has been followed.
 
-        .. versionadded:: 1.3
-    .. attribute:: guild_stream
+        .. versionadded 1.3
+    .. attribute guild_stream
 
         The system message denoting that a member is streaming in the guild.
 
-        .. versionadded:: 1.7
-    .. attribute:: guild_discovery_disqualified
+        .. versionadded 1.7
+    .. attribute guild_discovery_disqualified
 
         The system message denoting that the guild is no longer eligible for Server
         Discovery.
 
-        .. versionadded:: 1.7
-    .. attribute:: guild_discovery_requalified
+        .. versionadded 1.7
+    .. attribute guild_discovery_requalified
 
         The system message denoting that the guild has become eligible again for Server
         Discovery.
 
-        .. versionadded:: 1.7
-    .. attribute:: guild_discovery_grace_period_initial_warning
+        .. versionadded 1.7
+    .. attribute guild_discovery_grace_period_initial_warning
 
         The system message denoting that the guild has failed to meet the Server
         Discovery requirements for one week.
 
-        .. versionadded:: 1.7
-    .. attribute:: guild_discovery_grace_period_final_warning
+        .. versionadded 1.7
+    .. attribute guild_discovery_grace_period_final_warning
 
         The system message denoting that the guild has failed to meet the Server
         Discovery requirements for 3 weeks in a row.
 
-        .. versionadded:: 1.7
-    .. attribute:: thread_created
+        .. versionadded 1.7
+    .. attribute thread_created
 
         The system message denoting that a thread has been created. This is only
         sent if the thread has been created from an older message. The period of time
         required for a message to be considered old cannot be relied upon and is up to
         Discord.
 
-        .. versionadded:: 2.0
-    .. attribute:: reply
+        .. versionadded 2.0
+    .. attribute reply
 
         The system message denoting that the author is replying to a message.
 
-        .. versionadded:: 2.0
-    .. attribute:: application_command
+        .. versionadded 2.0
+    .. attribute application_command
 
         The system message denoting that an application (or "slash") command was executed.
 
-        .. versionadded:: 2.0
-    .. attribute:: guild_invite_reminder
+        .. versionadded 2.0
+    .. attribute guild_invite_reminder
 
         The system message sent as a reminder to invite people to the guild.
 
-        .. versionadded:: 2.0
-    .. attribute:: thread_starter_message
+        .. versionadded 2.0
+    .. attribute thread_starter_message
 
         The system message denoting the message in the thread that is the one that started the
         thread's conversation topic.
 
-        .. versionadded:: 2.0
+        .. versionadded 2.0
 
-.. class:: UserFlags
+.. class UserFlags
 
     Represents Discord User flags.
 
-    .. attribute:: staff
+    .. attribute staff
 
         The user is a Discord Employee.
-    .. attribute:: partner
+    .. attribute partner
 
         The user is a Discord Partner.
-    .. attribute:: hypesquad
+    .. attribute hypesquad
 
         The user is a HypeSquad Events member.
-    .. attribute:: bug_hunter
+    .. attribute bug_hunter
 
         The user is a Bug Hunter.
-    .. attribute:: mfa_sms
+    .. attribute mfa_sms
 
         The user has SMS recovery for Multi Factor Authentication enabled.
-    .. attribute:: premium_promo_dismissed
+    .. attribute premium_promo_dismissed
 
         The user has dismissed the Discord Nitro promotion.
-    .. attribute:: hypesquad_bravery
+    .. attribute hypesquad_bravery
 
         The user is a HypeSquad Bravery member.
-    .. attribute:: hypesquad_brilliance
+    .. attribute hypesquad_brilliance
 
         The user is a HypeSquad Brilliance member.
-    .. attribute:: hypesquad_balance
+    .. attribute hypesquad_balance
 
         The user is a HypeSquad Balance member.
-    .. attribute:: early_supporter
+    .. attribute early_supporter
 
         The user is an Early Supporter.
-    .. attribute:: team_user
+    .. attribute team_user
 
         The user is a Team User.
-    .. attribute:: system
+    .. attribute system
 
         The user is a system user (i.e. represents Discord officially).
-    .. attribute:: has_unread_urgent_messages
+    .. attribute has_unread_urgent_messages
 
         The user has an unread system message.
-    .. attribute:: bug_hunter_level_2
+    .. attribute bug_hunter_level_2
 
         The user is a Bug Hunter Level 2.
-    .. attribute:: verified_bot
+    .. attribute verified_bot
 
         The user is a Verified Bot.
-    .. attribute:: verified_bot_developer
+    .. attribute verified_bot_developer
 
         The user is an Early Verified Bot Developer.
-    .. attribute:: discord_certified_moderator
+    .. attribute discord_certified_moderator
 
         The user is a Discord Certified Moderator.
 
-.. class:: ActivityType
+.. class ActivityType
 
-    Specifies the type of :class:`Activity`. This is used to check how to
+    Specifies the type of class`Activity`. This is used to check how to
     interpret the activity itself.
 
-    .. attribute:: unknown
+    .. attribute unknown
 
         An unknown activity type. This should generally not happen.
-    .. attribute:: playing
+    .. attribute playing
 
         A "Playing" activity type.
-    .. attribute:: streaming
+    .. attribute streaming
 
         A "Streaming" activity type.
-    .. attribute:: listening
+    .. attribute listening
 
         A "Listening" activity type.
-    .. attribute:: watching
+    .. attribute watching
 
         A "Watching" activity type.
-    .. attribute:: custom
+    .. attribute custom
 
         A custom activity type.
-    .. attribute:: competing
+    .. attribute competing
 
         A competing activity type.
 
-        .. versionadded:: 1.5
+        .. versionadded 1.5
 
-.. class:: InteractionType
+.. class InteractionType
 
-    Specifies the type of :class:`Interaction`.
+    Specifies the type of class`Interaction`.
 
-    .. versionadded:: 2.0
+    .. versionadded 2.0
 
-    .. attribute:: ping
+    .. attribute ping
 
         Represents Discord pinging to see if the interaction response server is alive.
-    .. attribute:: application_command
+    .. attribute application_command
 
         Represents a slash command interaction.
-    .. attribute:: component
+    .. attribute component
 
         Represents a component based interaction, i.e. using the Discord Bot UI Kit.
 
-.. class:: InteractionResponseType
+.. class InteractionResponseType
 
     Specifies the response type for the interaction.
 
-    .. versionadded:: 2.0
+    .. versionadded 2.0
 
-    .. attribute:: pong
+    .. attribute pong
 
         Pongs the interaction when given a ping.
 
-        See also :meth:`InteractionResponse.pong`
-    .. attribute:: channel_message
+        See also meth`InteractionResponse.pong`
+    .. attribute channel_message
 
         Respond to the interaction with a message.
 
-        See also :meth:`InteractionResponse.send_message`
-    .. attribute:: deferred_channel_message
+        See also meth`InteractionResponse.send_message`
+    .. attribute deferred_channel_message
 
         Responds to the interaction with a message at a later time.
 
-        See also :meth:`InteractionResponse.defer`
-    .. attribute:: deferred_message_update
+        See also meth`InteractionResponse.defer`
+    .. attribute deferred_message_update
 
         Acknowledges the component interaction with a promise that
         the message will update later (though there is no need to actually update the message).
 
-        See also :meth:`InteractionResponse.defer`
-    .. attribute:: message_update
+        See also meth`InteractionResponse.defer`
+    .. attribute message_update
 
         Responds to the interaction by editing the message.
 
-        See also :meth:`InteractionResponse.edit_message`
+        See also meth`InteractionResponse.edit_message`
 
-.. class:: ComponentType
+.. class ComponentType
 
     Represents the component type of a component.
 
-    .. versionadded:: 2.0
+    .. versionadded 2.0
 
-    .. attribute:: action_row
+    .. attribute action_row
 
         Represents the group component which holds different components in a row.
-    .. attribute:: button
+    .. attribute button
 
         Represents a button component.
-    .. attribute:: select
+    .. attribute select
 
         Represents a select component.
 
 
-.. class:: ButtonStyle
+.. class ButtonStyle
 
     Represents the style of the button component.
 
-    .. versionadded:: 2.0
+    .. versionadded 2.0
 
-    .. attribute:: primary
+    .. attribute primary
 
         Represents a blurple button for the primary action.
-    .. attribute:: secondary
+    .. attribute secondary
 
         Represents a grey button for the secondary action.
-    .. attribute:: success
+    .. attribute success
 
         Represents a green button for a successful action.
-    .. attribute:: danger
+    .. attribute danger
 
         Represents a red button for a dangerous action.
-    .. attribute:: link
+    .. attribute link
 
         Represents a link button.
 
-    .. attribute:: blurple
+    .. attribute blurple
 
-        An alias for :attr:`primary`.
-    .. attribute:: grey
+        An alias for attr`primary`.
+    .. attribute grey
 
-        An alias for :attr:`secondary`.
-    .. attribute:: gray
+        An alias for attr`secondary`.
+    .. attribute gray
 
-        An alias for :attr:`secondary`.
-    .. attribute:: green
+        An alias for attr`secondary`.
+    .. attribute green
 
-        An alias for :attr:`success`.
-    .. attribute:: red
+        An alias for attr`success`.
+    .. attribute red
 
-        An alias for :attr:`danger`.
-    .. attribute:: url
+        An alias for attr`danger`.
+    .. attribute url
 
-        An alias for :attr:`link`.
+        An alias for attr`link`.
 
-.. class:: VoiceRegion
+.. class VoiceRegion
 
     Specifies the region a voice server belongs to.
 
-    .. attribute:: amsterdam
+    .. attribute amsterdam
 
         The Amsterdam region.
-    .. attribute:: brazil
+    .. attribute brazil
 
         The Brazil region.
-    .. attribute:: dubai
+    .. attribute dubai
 
         The Dubai region.
 
-        .. versionadded:: 1.3
+        .. versionadded 1.3
 
-    .. attribute:: eu_central
+    .. attribute eu_central
 
         The EU Central region.
-    .. attribute:: eu_west
+    .. attribute eu_west
 
         The EU West region.
-    .. attribute:: europe
+    .. attribute europe
 
         The Europe region.
 
-        .. versionadded:: 1.3
+        .. versionadded 1.3
 
-    .. attribute:: frankfurt
+    .. attribute frankfurt
 
         The Frankfurt region.
-    .. attribute:: hongkong
+    .. attribute hongkong
 
         The Hong Kong region.
-    .. attribute:: india
+    .. attribute india
 
         The India region.
 
-        .. versionadded:: 1.2
+        .. versionadded 1.2
 
-    .. attribute:: japan
+    .. attribute japan
 
         The Japan region.
-    .. attribute:: london
+    .. attribute london
 
         The London region.
-    .. attribute:: russia
+    .. attribute russia
 
         The Russia region.
-    .. attribute:: singapore
+    .. attribute singapore
 
         The Singapore region.
-    .. attribute:: southafrica
+    .. attribute southafrica
 
         The South Africa region.
-    .. attribute:: south_korea
+    .. attribute south_korea
 
         The South Korea region.
-    .. attribute:: sydney
+    .. attribute sydney
 
         The Sydney region.
-    .. attribute:: us_central
+    .. attribute us_central
 
         The US Central region.
-    .. attribute:: us_east
+    .. attribute us_east
 
         The US East region.
-    .. attribute:: us_south
+    .. attribute us_south
 
         The US South region.
-    .. attribute:: us_west
+    .. attribute us_west
 
         The US West region.
-    .. attribute:: vip_amsterdam
+    .. attribute vip_amsterdam
 
         The Amsterdam region for VIP guilds.
-    .. attribute:: vip_us_east
+    .. attribute vip_us_east
 
         The US East region for VIP guilds.
-    .. attribute:: vip_us_west
+    .. attribute vip_us_west
 
         The US West region for VIP guilds.
 
-.. class:: VerificationLevel
+.. class VerificationLevel
 
-    Specifies a :class:`Guild`\'s verification level, which is the criteria in
+    Specifies a class`Guild`\'s verification level, which is the criteria in
     which a member must meet before being able to send messages to the guild.
 
-    .. container:: operations
+    .. container operations
 
-        .. versionadded:: 2.0
+        .. versionadded 2.0
 
-        .. describe:: x == y
+        .. describe x == y
 
             Checks if two verification levels are equal.
-        .. describe:: x != y
+        .. describe x != y
 
             Checks if two verification levels are not equal.
-        .. describe:: x > y
+        .. describe x > y
 
             Checks if a verification level is higher than another.
-        .. describe:: x < y
+        .. describe x < y
 
             Checks if a verification level is lower than another.
-        .. describe:: x >= y
+        .. describe x >= y
 
             Checks if a verification level is higher or equal to another.
-        .. describe:: x <= y
+        .. describe x <= y
 
             Checks if a verification level is lower or equal to another.
 
-    .. attribute:: none
+    .. attribute none
 
         No criteria set.
-    .. attribute:: low
+    .. attribute low
 
         Member must have a verified email on their Discord account.
-    .. attribute:: medium
+    .. attribute medium
 
         Member must have a verified email and be registered on Discord for more
         than five minutes.
-    .. attribute:: high
+    .. attribute high
 
         Member must have a verified email, be registered on Discord for more
         than five minutes, and be a member of the guild itself for more than
         ten minutes.
-    .. attribute:: highest
+    .. attribute highest
 
         Member must have a verified phone on their Discord account.
 
-.. class:: NotificationLevel
+.. class NotificationLevel
 
-    Specifies whether a :class:`Guild` has notifications on for all messages or mentions only by default.
+    Specifies whether a class`Guild` has notifications on for all messages or mentions only by default.
 
-    .. container:: operations
+    .. container operations
 
-        .. versionadded:: 2.0
+        .. versionadded 2.0
 
-        .. describe:: x == y
+        .. describe x == y
 
             Checks if two notification levels are equal.
-        .. describe:: x != y
+        .. describe x != y
 
             Checks if two notification levels are not equal.
-        .. describe:: x > y
+        .. describe x > y
 
             Checks if a notification level is higher than another.
-        .. describe:: x < y
+        .. describe x < y
 
             Checks if a notification level is lower than another.
-        .. describe:: x >= y
+        .. describe x >= y
 
             Checks if a notification level is higher or equal to another.
-        .. describe:: x <= y
+        .. describe x <= y
 
             Checks if a notification level is lower or equal to another.
 
-    .. attribute:: all_messages
+    .. attribute all_messages
 
         Members receive notifications for every message regardless of them being mentioned.
-    .. attribute:: only_mentions
+    .. attribute only_mentions
 
         Members receive notifications for messages they are mentioned in.
 
-.. class:: ContentFilter
+.. class ContentFilter
 
-    Specifies a :class:`Guild`\'s explicit content filter, which is the machine
+    Specifies a class`Guild`\'s explicit content filter, which is the machine
     learning algorithms that Discord uses to detect if an image contains
     pornography or otherwise explicit content.
 
-    .. container:: operations
+    .. container operations
 
-        .. versionadded:: 2.0
+        .. versionadded 2.0
 
-        .. describe:: x == y
+        .. describe x == y
 
             Checks if two content filter levels are equal.
-        .. describe:: x != y
+        .. describe x != y
 
             Checks if two content filter levels are not equal.
-        .. describe:: x > y
+        .. describe x > y
 
             Checks if a content filter level is higher than another.
-        .. describe:: x < y
+        .. describe x < y
 
             Checks if a content filter level is lower than another.
-        .. describe:: x >= y
+        .. describe x >= y
 
             Checks if a content filter level is higher or equal to another.
-        .. describe:: x <= y
+        .. describe x <= y
 
             Checks if a content filter level is lower or equal to another.
 
-    .. attribute:: disabled
+    .. attribute disabled
 
         The guild does not have the content filter enabled.
-    .. attribute:: no_role
+    .. attribute no_role
 
         The guild has the content filter enabled for members without a role.
-    .. attribute:: all_members
+    .. attribute all_members
 
         The guild has the content filter enabled for every member.
 
-.. class:: Status
+.. class Status
 
-    Specifies a :class:`Member` 's status.
+    Specifies a class`Member` 's status.
 
-    .. attribute:: online
+    .. attribute online
 
         The member is online.
-    .. attribute:: offline
+    .. attribute offline
 
         The member is offline.
-    .. attribute:: idle
+    .. attribute idle
 
         The member is idle.
-    .. attribute:: dnd
+    .. attribute dnd
 
         The member is "Do Not Disturb".
-    .. attribute:: do_not_disturb
+    .. attribute do_not_disturb
 
-        An alias for :attr:`dnd`.
-    .. attribute:: invisible
+        An alias for attr`dnd`.
+    .. attribute invisible
 
         The member is "invisible". In reality, this is only used in sending
-        a presence a la :meth:`Client.change_presence`. When you receive a
-        user's presence this will be :attr:`offline` instead.
+        a presence a la meth`Client.change_presence`. When you receive a
+        user's presence this will be attr`offline` instead.
 
 
-.. class:: AuditLogAction
+.. class AuditLogAction
 
-    Represents the type of action being done for a :class:`AuditLogEntry`\,
-    which is retrievable via :meth:`Guild.audit_logs`.
+    Represents the type of action being done for a class`AuditLogEntry`\,
+    which is retrievable via meth`Guild.audit_logs`.
 
-    .. attribute:: guild_update
+    .. attribute guild_update
 
-        The guild has updated. Things that trigger this include:
+        The guild has updated. Things that trigger this include
 
         - Changing the guild vanity URL
         - Changing the guild invite splash
@@ -1746,852 +1746,852 @@ of :class:`enum.Enum`.
         - Changing the guild moderation settings
         - Changing things related to the guild widget
 
-        When this is the action, the type of :attr:`~AuditLogEntry.target` is
-        the :class:`Guild`.
+        When this is the action, the type of attr`~AuditLogEntry.target` is
+        the class`Guild`.
 
-        Possible attributes for :class:`AuditLogDiff`:
+        Possible attributes for class`AuditLogDiff`
 
-        - :attr:`~AuditLogDiff.afk_channel`
-        - :attr:`~AuditLogDiff.system_channel`
-        - :attr:`~AuditLogDiff.afk_timeout`
-        - :attr:`~AuditLogDiff.default_message_notifications`
-        - :attr:`~AuditLogDiff.explicit_content_filter`
-        - :attr:`~AuditLogDiff.mfa_level`
-        - :attr:`~AuditLogDiff.name`
-        - :attr:`~AuditLogDiff.owner`
-        - :attr:`~AuditLogDiff.splash`
-        - :attr:`~AuditLogDiff.discovery_splash`
-        - :attr:`~AuditLogDiff.icon`
-        - :attr:`~AuditLogDiff.banner`
-        - :attr:`~AuditLogDiff.vanity_url_code`
+        - attr`~AuditLogDiff.afk_channel`
+        - attr`~AuditLogDiff.system_channel`
+        - attr`~AuditLogDiff.afk_timeout`
+        - attr`~AuditLogDiff.default_message_notifications`
+        - attr`~AuditLogDiff.explicit_content_filter`
+        - attr`~AuditLogDiff.mfa_level`
+        - attr`~AuditLogDiff.name`
+        - attr`~AuditLogDiff.owner`
+        - attr`~AuditLogDiff.splash`
+        - attr`~AuditLogDiff.discovery_splash`
+        - attr`~AuditLogDiff.icon`
+        - attr`~AuditLogDiff.banner`
+        - attr`~AuditLogDiff.vanity_url_code`
 
-    .. attribute:: channel_create
+    .. attribute channel_create
 
         A new channel was created.
 
-        When this is the action, the type of :attr:`~AuditLogEntry.target` is
-        either a :class:`abc.GuildChannel` or :class:`Object` with an ID.
+        When this is the action, the type of attr`~AuditLogEntry.target` is
+        either a class`abc.GuildChannel` or class`Object` with an ID.
 
-        A more filled out object in the :class:`Object` case can be found
-        by using :attr:`~AuditLogEntry.after`.
+        A more filled out object in the class`Object` case can be found
+        by using attr`~AuditLogEntry.after`.
 
-        Possible attributes for :class:`AuditLogDiff`:
+        Possible attributes for class`AuditLogDiff`
 
-        - :attr:`~AuditLogDiff.name`
-        - :attr:`~AuditLogDiff.type`
-        - :attr:`~AuditLogDiff.overwrites`
+        - attr`~AuditLogDiff.name`
+        - attr`~AuditLogDiff.type`
+        - attr`~AuditLogDiff.overwrites`
 
-    .. attribute:: channel_update
+    .. attribute channel_update
 
-        A channel was updated. Things that trigger this include:
+        A channel was updated. Things that trigger this include
 
         - The channel name or topic was changed
         - The channel bitrate was changed
 
-        When this is the action, the type of :attr:`~AuditLogEntry.target` is
-        the :class:`abc.GuildChannel` or :class:`Object` with an ID.
+        When this is the action, the type of attr`~AuditLogEntry.target` is
+        the class`abc.GuildChannel` or class`Object` with an ID.
 
-        A more filled out object in the :class:`Object` case can be found
-        by using :attr:`~AuditLogEntry.after` or :attr:`~AuditLogEntry.before`.
+        A more filled out object in the class`Object` case can be found
+        by using attr`~AuditLogEntry.after` or attr`~AuditLogEntry.before`.
 
-        Possible attributes for :class:`AuditLogDiff`:
+        Possible attributes for class`AuditLogDiff`
 
-        - :attr:`~AuditLogDiff.name`
-        - :attr:`~AuditLogDiff.type`
-        - :attr:`~AuditLogDiff.position`
-        - :attr:`~AuditLogDiff.overwrites`
-        - :attr:`~AuditLogDiff.topic`
-        - :attr:`~AuditLogDiff.bitrate`
-        - :attr:`~AuditLogDiff.rtc_region`
-        - :attr:`~AuditLogDiff.video_quality_mode`
-        - :attr:`~AuditLogDiff.default_auto_archive_duration`
+        - attr`~AuditLogDiff.name`
+        - attr`~AuditLogDiff.type`
+        - attr`~AuditLogDiff.position`
+        - attr`~AuditLogDiff.overwrites`
+        - attr`~AuditLogDiff.topic`
+        - attr`~AuditLogDiff.bitrate`
+        - attr`~AuditLogDiff.rtc_region`
+        - attr`~AuditLogDiff.video_quality_mode`
+        - attr`~AuditLogDiff.default_auto_archive_duration`
 
-    .. attribute:: channel_delete
+    .. attribute channel_delete
 
         A channel was deleted.
 
-        When this is the action, the type of :attr:`~AuditLogEntry.target` is
-        an :class:`Object` with an ID.
+        When this is the action, the type of attr`~AuditLogEntry.target` is
+        an class`Object` with an ID.
 
         A more filled out object can be found by using the
-        :attr:`~AuditLogEntry.before` object.
+        attr`~AuditLogEntry.before` object.
 
-        Possible attributes for :class:`AuditLogDiff`:
+        Possible attributes for class`AuditLogDiff`
 
-        - :attr:`~AuditLogDiff.name`
-        - :attr:`~AuditLogDiff.type`
-        - :attr:`~AuditLogDiff.overwrites`
+        - attr`~AuditLogDiff.name`
+        - attr`~AuditLogDiff.type`
+        - attr`~AuditLogDiff.overwrites`
 
-    .. attribute:: overwrite_create
+    .. attribute overwrite_create
 
         A channel permission overwrite was created.
 
-        When this is the action, the type of :attr:`~AuditLogEntry.target` is
-        the :class:`abc.GuildChannel` or :class:`Object` with an ID.
+        When this is the action, the type of attr`~AuditLogEntry.target` is
+        the class`abc.GuildChannel` or class`Object` with an ID.
 
-        When this is the action, the type of :attr:`~AuditLogEntry.extra` is
-        either a :class:`Role` or :class:`Member`. If the object is not found
-        then it is a :class:`Object` with an ID being filled, a name, and a
+        When this is the action, the type of attr`~AuditLogEntry.extra` is
+        either a class`Role` or class`Member`. If the object is not found
+        then it is a class`Object` with an ID being filled, a name, and a
         ``type`` attribute set to either ``'role'`` or ``'member'`` to help
         dictate what type of ID it is.
 
-        Possible attributes for :class:`AuditLogDiff`:
+        Possible attributes for class`AuditLogDiff`
 
-        - :attr:`~AuditLogDiff.deny`
-        - :attr:`~AuditLogDiff.allow`
-        - :attr:`~AuditLogDiff.id`
-        - :attr:`~AuditLogDiff.type`
+        - attr`~AuditLogDiff.deny`
+        - attr`~AuditLogDiff.allow`
+        - attr`~AuditLogDiff.id`
+        - attr`~AuditLogDiff.type`
 
-    .. attribute:: overwrite_update
+    .. attribute overwrite_update
 
         A channel permission overwrite was changed, this is typically
         when the permission values change.
 
-        See :attr:`overwrite_create` for more information on how the
-        :attr:`~AuditLogEntry.target` and :attr:`~AuditLogEntry.extra` fields
+        See attr`overwrite_create` for more information on how the
+        attr`~AuditLogEntry.target` and attr`~AuditLogEntry.extra` fields
         are set.
 
-        Possible attributes for :class:`AuditLogDiff`:
+        Possible attributes for class`AuditLogDiff`
 
-        - :attr:`~AuditLogDiff.deny`
-        - :attr:`~AuditLogDiff.allow`
-        - :attr:`~AuditLogDiff.id`
-        - :attr:`~AuditLogDiff.type`
+        - attr`~AuditLogDiff.deny`
+        - attr`~AuditLogDiff.allow`
+        - attr`~AuditLogDiff.id`
+        - attr`~AuditLogDiff.type`
 
-    .. attribute:: overwrite_delete
+    .. attribute overwrite_delete
 
         A channel permission overwrite was deleted.
 
-        See :attr:`overwrite_create` for more information on how the
-        :attr:`~AuditLogEntry.target` and :attr:`~AuditLogEntry.extra` fields
+        See attr`overwrite_create` for more information on how the
+        attr`~AuditLogEntry.target` and attr`~AuditLogEntry.extra` fields
         are set.
 
-        Possible attributes for :class:`AuditLogDiff`:
+        Possible attributes for class`AuditLogDiff`
 
-        - :attr:`~AuditLogDiff.deny`
-        - :attr:`~AuditLogDiff.allow`
-        - :attr:`~AuditLogDiff.id`
-        - :attr:`~AuditLogDiff.type`
+        - attr`~AuditLogDiff.deny`
+        - attr`~AuditLogDiff.allow`
+        - attr`~AuditLogDiff.id`
+        - attr`~AuditLogDiff.type`
 
-    .. attribute:: kick
+    .. attribute kick
 
         A member was kicked.
 
-        When this is the action, the type of :attr:`~AuditLogEntry.target` is
-        the :class:`User` who got kicked.
+        When this is the action, the type of attr`~AuditLogEntry.target` is
+        the class`User` who got kicked.
 
-        When this is the action, :attr:`~AuditLogEntry.changes` is empty.
+        When this is the action, attr`~AuditLogEntry.changes` is empty.
 
-    .. attribute:: member_prune
+    .. attribute member_prune
 
         A member prune was triggered.
 
-        When this is the action, the type of :attr:`~AuditLogEntry.target` is
+        When this is the action, the type of attr`~AuditLogEntry.target` is
         set to ``None``.
 
-        When this is the action, the type of :attr:`~AuditLogEntry.extra` is
-        set to an unspecified proxy object with two attributes:
+        When this is the action, the type of attr`~AuditLogEntry.extra` is
+        set to an unspecified proxy object with two attributes
 
-        - ``delete_members_days``: An integer specifying how far the prune was.
-        - ``members_removed``: An integer specifying how many members were removed.
+        - ``delete_members_days`` An integer specifying how far the prune was.
+        - ``members_removed`` An integer specifying how many members were removed.
 
-        When this is the action, :attr:`~AuditLogEntry.changes` is empty.
+        When this is the action, attr`~AuditLogEntry.changes` is empty.
 
-    .. attribute:: ban
+    .. attribute ban
 
         A member was banned.
 
-        When this is the action, the type of :attr:`~AuditLogEntry.target` is
-        the :class:`User` who got banned.
+        When this is the action, the type of attr`~AuditLogEntry.target` is
+        the class`User` who got banned.
 
-        When this is the action, :attr:`~AuditLogEntry.changes` is empty.
+        When this is the action, attr`~AuditLogEntry.changes` is empty.
 
-    .. attribute:: unban
+    .. attribute unban
 
         A member was unbanned.
 
-        When this is the action, the type of :attr:`~AuditLogEntry.target` is
-        the :class:`User` who got unbanned.
+        When this is the action, the type of attr`~AuditLogEntry.target` is
+        the class`User` who got unbanned.
 
-        When this is the action, :attr:`~AuditLogEntry.changes` is empty.
+        When this is the action, attr`~AuditLogEntry.changes` is empty.
 
-    .. attribute:: member_update
+    .. attribute member_update
 
-        A member has updated. This triggers in the following situations:
+        A member has updated. This triggers in the following situations
 
         - A nickname was changed
         - They were server muted or deafened (or it was undo'd)
 
-        When this is the action, the type of :attr:`~AuditLogEntry.target` is
-        the :class:`Member` or :class:`User` who got updated.
+        When this is the action, the type of attr`~AuditLogEntry.target` is
+        the class`Member` or class`User` who got updated.
 
-        Possible attributes for :class:`AuditLogDiff`:
+        Possible attributes for class`AuditLogDiff`
 
-        - :attr:`~AuditLogDiff.nick`
-        - :attr:`~AuditLogDiff.mute`
-        - :attr:`~AuditLogDiff.deaf`
+        - attr`~AuditLogDiff.nick`
+        - attr`~AuditLogDiff.mute`
+        - attr`~AuditLogDiff.deaf`
 
-    .. attribute:: member_role_update
+    .. attribute member_role_update
 
         A member's role has been updated. This triggers when a member
         either gains a role or loses a role.
 
-        When this is the action, the type of :attr:`~AuditLogEntry.target` is
-        the :class:`Member` or :class:`User` who got the role.
+        When this is the action, the type of attr`~AuditLogEntry.target` is
+        the class`Member` or class`User` who got the role.
 
-        Possible attributes for :class:`AuditLogDiff`:
+        Possible attributes for class`AuditLogDiff`
 
-        - :attr:`~AuditLogDiff.roles`
+        - attr`~AuditLogDiff.roles`
 
-    .. attribute:: member_move
+    .. attribute member_move
 
         A member's voice channel has been updated. This triggers when a
         member is moved to a different voice channel.
 
-        When this is the action, the type of :attr:`~AuditLogEntry.extra` is
-        set to an unspecified proxy object with two attributes:
+        When this is the action, the type of attr`~AuditLogEntry.extra` is
+        set to an unspecified proxy object with two attributes
 
-        - ``channel``: A :class:`TextChannel` or :class:`Object` with the channel ID where the members were moved.
-        - ``count``: An integer specifying how many members were moved.
+        - ``channel`` A class`TextChannel` or class`Object` with the channel ID where the members were moved.
+        - ``count`` An integer specifying how many members were moved.
 
-        .. versionadded:: 1.3
+        .. versionadded 1.3
 
-    .. attribute:: member_disconnect
+    .. attribute member_disconnect
 
         A member's voice state has changed. This triggers when a
         member is force disconnected from voice.
 
-        When this is the action, the type of :attr:`~AuditLogEntry.extra` is
-        set to an unspecified proxy object with one attribute:
+        When this is the action, the type of attr`~AuditLogEntry.extra` is
+        set to an unspecified proxy object with one attribute
 
-        - ``count``: An integer specifying how many members were disconnected.
+        - ``count`` An integer specifying how many members were disconnected.
 
-        .. versionadded:: 1.3
+        .. versionadded 1.3
 
-    .. attribute:: bot_add
+    .. attribute bot_add
 
         A bot was added to the guild.
 
-        When this is the action, the type of :attr:`~AuditLogEntry.target` is
-        the :class:`Member` or :class:`User` which was added to the guild.
+        When this is the action, the type of attr`~AuditLogEntry.target` is
+        the class`Member` or class`User` which was added to the guild.
 
-        .. versionadded:: 1.3
+        .. versionadded 1.3
 
-    .. attribute:: role_create
+    .. attribute role_create
 
         A new role was created.
 
-        When this is the action, the type of :attr:`~AuditLogEntry.target` is
-        the :class:`Role` or a :class:`Object` with the ID.
+        When this is the action, the type of attr`~AuditLogEntry.target` is
+        the class`Role` or a class`Object` with the ID.
 
-        Possible attributes for :class:`AuditLogDiff`:
+        Possible attributes for class`AuditLogDiff`
 
-        - :attr:`~AuditLogDiff.colour`
-        - :attr:`~AuditLogDiff.mentionable`
-        - :attr:`~AuditLogDiff.hoist`
-        - :attr:`~AuditLogDiff.name`
-        - :attr:`~AuditLogDiff.permissions`
+        - attr`~AuditLogDiff.colour`
+        - attr`~AuditLogDiff.mentionable`
+        - attr`~AuditLogDiff.hoist`
+        - attr`~AuditLogDiff.name`
+        - attr`~AuditLogDiff.permissions`
 
-    .. attribute:: role_update
+    .. attribute role_update
 
-        A role was updated. This triggers in the following situations:
+        A role was updated. This triggers in the following situations
 
         - The name has changed
         - The permissions have changed
         - The colour has changed
         - Its hoist/mentionable state has changed
 
-        When this is the action, the type of :attr:`~AuditLogEntry.target` is
-        the :class:`Role` or a :class:`Object` with the ID.
+        When this is the action, the type of attr`~AuditLogEntry.target` is
+        the class`Role` or a class`Object` with the ID.
 
-        Possible attributes for :class:`AuditLogDiff`:
+        Possible attributes for class`AuditLogDiff`
 
-        - :attr:`~AuditLogDiff.colour`
-        - :attr:`~AuditLogDiff.mentionable`
-        - :attr:`~AuditLogDiff.hoist`
-        - :attr:`~AuditLogDiff.name`
-        - :attr:`~AuditLogDiff.permissions`
+        - attr`~AuditLogDiff.colour`
+        - attr`~AuditLogDiff.mentionable`
+        - attr`~AuditLogDiff.hoist`
+        - attr`~AuditLogDiff.name`
+        - attr`~AuditLogDiff.permissions`
 
-    .. attribute:: role_delete
+    .. attribute role_delete
 
         A role was deleted.
 
-        When this is the action, the type of :attr:`~AuditLogEntry.target` is
-        the :class:`Role` or a :class:`Object` with the ID.
+        When this is the action, the type of attr`~AuditLogEntry.target` is
+        the class`Role` or a class`Object` with the ID.
 
-        Possible attributes for :class:`AuditLogDiff`:
+        Possible attributes for class`AuditLogDiff`
 
-        - :attr:`~AuditLogDiff.colour`
-        - :attr:`~AuditLogDiff.mentionable`
-        - :attr:`~AuditLogDiff.hoist`
-        - :attr:`~AuditLogDiff.name`
-        - :attr:`~AuditLogDiff.permissions`
+        - attr`~AuditLogDiff.colour`
+        - attr`~AuditLogDiff.mentionable`
+        - attr`~AuditLogDiff.hoist`
+        - attr`~AuditLogDiff.name`
+        - attr`~AuditLogDiff.permissions`
 
-    .. attribute:: invite_create
+    .. attribute invite_create
 
         An invite was created.
 
-        When this is the action, the type of :attr:`~AuditLogEntry.target` is
-        the :class:`Invite` that was created.
+        When this is the action, the type of attr`~AuditLogEntry.target` is
+        the class`Invite` that was created.
 
-        Possible attributes for :class:`AuditLogDiff`:
+        Possible attributes for class`AuditLogDiff`
 
-        - :attr:`~AuditLogDiff.max_age`
-        - :attr:`~AuditLogDiff.code`
-        - :attr:`~AuditLogDiff.temporary`
-        - :attr:`~AuditLogDiff.inviter`
-        - :attr:`~AuditLogDiff.channel`
-        - :attr:`~AuditLogDiff.uses`
-        - :attr:`~AuditLogDiff.max_uses`
+        - attr`~AuditLogDiff.max_age`
+        - attr`~AuditLogDiff.code`
+        - attr`~AuditLogDiff.temporary`
+        - attr`~AuditLogDiff.inviter`
+        - attr`~AuditLogDiff.channel`
+        - attr`~AuditLogDiff.uses`
+        - attr`~AuditLogDiff.max_uses`
 
-    .. attribute:: invite_update
+    .. attribute invite_update
 
         An invite was updated.
 
-        When this is the action, the type of :attr:`~AuditLogEntry.target` is
-        the :class:`Invite` that was updated.
+        When this is the action, the type of attr`~AuditLogEntry.target` is
+        the class`Invite` that was updated.
 
-    .. attribute:: invite_delete
+    .. attribute invite_delete
 
         An invite was deleted.
 
-        When this is the action, the type of :attr:`~AuditLogEntry.target` is
-        the :class:`Invite` that was deleted.
+        When this is the action, the type of attr`~AuditLogEntry.target` is
+        the class`Invite` that was deleted.
 
-        Possible attributes for :class:`AuditLogDiff`:
+        Possible attributes for class`AuditLogDiff`
 
-        - :attr:`~AuditLogDiff.max_age`
-        - :attr:`~AuditLogDiff.code`
-        - :attr:`~AuditLogDiff.temporary`
-        - :attr:`~AuditLogDiff.inviter`
-        - :attr:`~AuditLogDiff.channel`
-        - :attr:`~AuditLogDiff.uses`
-        - :attr:`~AuditLogDiff.max_uses`
+        - attr`~AuditLogDiff.max_age`
+        - attr`~AuditLogDiff.code`
+        - attr`~AuditLogDiff.temporary`
+        - attr`~AuditLogDiff.inviter`
+        - attr`~AuditLogDiff.channel`
+        - attr`~AuditLogDiff.uses`
+        - attr`~AuditLogDiff.max_uses`
 
-    .. attribute:: webhook_create
+    .. attribute webhook_create
 
         A webhook was created.
 
-        When this is the action, the type of :attr:`~AuditLogEntry.target` is
-        the :class:`Object` with the webhook ID.
+        When this is the action, the type of attr`~AuditLogEntry.target` is
+        the class`Object` with the webhook ID.
 
-        Possible attributes for :class:`AuditLogDiff`:
+        Possible attributes for class`AuditLogDiff`
 
-        - :attr:`~AuditLogDiff.channel`
-        - :attr:`~AuditLogDiff.name`
-        - :attr:`~AuditLogDiff.type` (always set to ``1`` if so)
+        - attr`~AuditLogDiff.channel`
+        - attr`~AuditLogDiff.name`
+        - attr`~AuditLogDiff.type` (always set to ``1`` if so)
 
-    .. attribute:: webhook_update
+    .. attribute webhook_update
 
-        A webhook was updated. This trigger in the following situations:
+        A webhook was updated. This trigger in the following situations
 
         - The webhook name changed
         - The webhook channel changed
 
-        When this is the action, the type of :attr:`~AuditLogEntry.target` is
-        the :class:`Object` with the webhook ID.
+        When this is the action, the type of attr`~AuditLogEntry.target` is
+        the class`Object` with the webhook ID.
 
-        Possible attributes for :class:`AuditLogDiff`:
+        Possible attributes for class`AuditLogDiff`
 
-        - :attr:`~AuditLogDiff.channel`
-        - :attr:`~AuditLogDiff.name`
-        - :attr:`~AuditLogDiff.avatar`
+        - attr`~AuditLogDiff.channel`
+        - attr`~AuditLogDiff.name`
+        - attr`~AuditLogDiff.avatar`
 
-    .. attribute:: webhook_delete
+    .. attribute webhook_delete
 
         A webhook was deleted.
 
-        When this is the action, the type of :attr:`~AuditLogEntry.target` is
-        the :class:`Object` with the webhook ID.
+        When this is the action, the type of attr`~AuditLogEntry.target` is
+        the class`Object` with the webhook ID.
 
-        Possible attributes for :class:`AuditLogDiff`:
+        Possible attributes for class`AuditLogDiff`
 
-        - :attr:`~AuditLogDiff.channel`
-        - :attr:`~AuditLogDiff.name`
-        - :attr:`~AuditLogDiff.type` (always set to ``1`` if so)
+        - attr`~AuditLogDiff.channel`
+        - attr`~AuditLogDiff.name`
+        - attr`~AuditLogDiff.type` (always set to ``1`` if so)
 
-    .. attribute:: emoji_create
+    .. attribute emoji_create
 
         An emoji was created.
 
-        When this is the action, the type of :attr:`~AuditLogEntry.target` is
-        the :class:`Emoji` or :class:`Object` with the emoji ID.
+        When this is the action, the type of attr`~AuditLogEntry.target` is
+        the class`Emoji` or class`Object` with the emoji ID.
 
-        Possible attributes for :class:`AuditLogDiff`:
+        Possible attributes for class`AuditLogDiff`
 
-        - :attr:`~AuditLogDiff.name`
+        - attr`~AuditLogDiff.name`
 
-    .. attribute:: emoji_update
+    .. attribute emoji_update
 
         An emoji was updated. This triggers when the name has changed.
 
-        When this is the action, the type of :attr:`~AuditLogEntry.target` is
-        the :class:`Emoji` or :class:`Object` with the emoji ID.
+        When this is the action, the type of attr`~AuditLogEntry.target` is
+        the class`Emoji` or class`Object` with the emoji ID.
 
-        Possible attributes for :class:`AuditLogDiff`:
+        Possible attributes for class`AuditLogDiff`
 
-        - :attr:`~AuditLogDiff.name`
+        - attr`~AuditLogDiff.name`
 
-    .. attribute:: emoji_delete
+    .. attribute emoji_delete
 
         An emoji was deleted.
 
-        When this is the action, the type of :attr:`~AuditLogEntry.target` is
-        the :class:`Object` with the emoji ID.
+        When this is the action, the type of attr`~AuditLogEntry.target` is
+        the class`Object` with the emoji ID.
 
-        Possible attributes for :class:`AuditLogDiff`:
+        Possible attributes for class`AuditLogDiff`
 
-        - :attr:`~AuditLogDiff.name`
+        - attr`~AuditLogDiff.name`
 
-    .. attribute:: message_delete
+    .. attribute message_delete
 
         A message was deleted by a moderator. Note that this
         only triggers if the message was deleted by someone other than the author.
 
-        When this is the action, the type of :attr:`~AuditLogEntry.target` is
-        the :class:`Member` or :class:`User` who had their message deleted.
+        When this is the action, the type of attr`~AuditLogEntry.target` is
+        the class`Member` or class`User` who had their message deleted.
 
-        When this is the action, the type of :attr:`~AuditLogEntry.extra` is
-        set to an unspecified proxy object with two attributes:
+        When this is the action, the type of attr`~AuditLogEntry.extra` is
+        set to an unspecified proxy object with two attributes
 
-        - ``count``: An integer specifying how many messages were deleted.
-        - ``channel``: A :class:`TextChannel` or :class:`Object` with the channel ID where the message got deleted.
+        - ``count`` An integer specifying how many messages were deleted.
+        - ``channel`` A class`TextChannel` or class`Object` with the channel ID where the message got deleted.
 
-    .. attribute:: message_bulk_delete
+    .. attribute message_bulk_delete
 
         Messages were bulk deleted by a moderator.
 
-        When this is the action, the type of :attr:`~AuditLogEntry.target` is
-        the :class:`TextChannel` or :class:`Object` with the ID of the channel that was purged.
+        When this is the action, the type of attr`~AuditLogEntry.target` is
+        the class`TextChannel` or class`Object` with the ID of the channel that was purged.
 
-        When this is the action, the type of :attr:`~AuditLogEntry.extra` is
-        set to an unspecified proxy object with one attribute:
+        When this is the action, the type of attr`~AuditLogEntry.extra` is
+        set to an unspecified proxy object with one attribute
 
-        - ``count``: An integer specifying how many messages were deleted.
+        - ``count`` An integer specifying how many messages were deleted.
 
-        .. versionadded:: 1.3
+        .. versionadded 1.3
 
-    .. attribute:: message_pin
+    .. attribute message_pin
 
         A message was pinned in a channel.
 
-        When this is the action, the type of :attr:`~AuditLogEntry.target` is
-        the :class:`Member` or :class:`User` who had their message pinned.
+        When this is the action, the type of attr`~AuditLogEntry.target` is
+        the class`Member` or class`User` who had their message pinned.
 
-        When this is the action, the type of :attr:`~AuditLogEntry.extra` is
-        set to an unspecified proxy object with two attributes:
+        When this is the action, the type of attr`~AuditLogEntry.extra` is
+        set to an unspecified proxy object with two attributes
 
-        - ``channel``: A :class:`TextChannel` or :class:`Object` with the channel ID where the message was pinned.
-        - ``message_id``: the ID of the message which was pinned.
+        - ``channel`` A class`TextChannel` or class`Object` with the channel ID where the message was pinned.
+        - ``message_id`` the ID of the message which was pinned.
 
-        .. versionadded:: 1.3
+        .. versionadded 1.3
 
-    .. attribute:: message_unpin
+    .. attribute message_unpin
 
         A message was unpinned in a channel.
 
-        When this is the action, the type of :attr:`~AuditLogEntry.target` is
-        the :class:`Member` or :class:`User` who had their message unpinned.
+        When this is the action, the type of attr`~AuditLogEntry.target` is
+        the class`Member` or class`User` who had their message unpinned.
 
-        When this is the action, the type of :attr:`~AuditLogEntry.extra` is
-        set to an unspecified proxy object with two attributes:
+        When this is the action, the type of attr`~AuditLogEntry.extra` is
+        set to an unspecified proxy object with two attributes
 
-        - ``channel``: A :class:`TextChannel` or :class:`Object` with the channel ID where the message was unpinned.
-        - ``message_id``: the ID of the message which was unpinned.
+        - ``channel`` A class`TextChannel` or class`Object` with the channel ID where the message was unpinned.
+        - ``message_id`` the ID of the message which was unpinned.
 
-        .. versionadded:: 1.3
+        .. versionadded 1.3
 
-    .. attribute:: integration_create
+    .. attribute integration_create
 
         A guild integration was created.
 
-        When this is the action, the type of :attr:`~AuditLogEntry.target` is
-        the :class:`Object` with the integration ID of the integration which was created.
+        When this is the action, the type of attr`~AuditLogEntry.target` is
+        the class`Object` with the integration ID of the integration which was created.
 
-        .. versionadded:: 1.3
+        .. versionadded 1.3
 
-    .. attribute:: integration_update
+    .. attribute integration_update
 
         A guild integration was updated.
 
-        When this is the action, the type of :attr:`~AuditLogEntry.target` is
-        the :class:`Object` with the integration ID of the integration which was updated.
+        When this is the action, the type of attr`~AuditLogEntry.target` is
+        the class`Object` with the integration ID of the integration which was updated.
 
-        .. versionadded:: 1.3
+        .. versionadded 1.3
 
-    .. attribute:: integration_delete
+    .. attribute integration_delete
 
         A guild integration was deleted.
 
-        When this is the action, the type of :attr:`~AuditLogEntry.target` is
-        the :class:`Object` with the integration ID of the integration which was deleted.
+        When this is the action, the type of attr`~AuditLogEntry.target` is
+        the class`Object` with the integration ID of the integration which was deleted.
 
-        .. versionadded:: 1.3
+        .. versionadded 1.3
 
-    .. attribute:: stage_instance_create
+    .. attribute stage_instance_create
 
         A stage instance was started.
 
-        When this is the action, the type of :attr:`~AuditLogEntry.target` is
-        the :class:`StageInstance` or :class:`Object` with the ID of the stage
+        When this is the action, the type of attr`~AuditLogEntry.target` is
+        the class`StageInstance` or class`Object` with the ID of the stage
         instance which was created.
 
-        Possible attributes for :class:`AuditLogDiff`:
+        Possible attributes for class`AuditLogDiff`
 
-        - :attr:`~AuditLogDiff.topic`
-        - :attr:`~AuditLogDiff.privacy_level`
+        - attr`~AuditLogDiff.topic`
+        - attr`~AuditLogDiff.privacy_level`
 
-        .. versionadded:: 2.0
+        .. versionadded 2.0
 
-    .. attribute:: stage_instance_update
+    .. attribute stage_instance_update
 
         A stage instance was updated.
 
-        When this is the action, the type of :attr:`~AuditLogEntry.target` is
-        the :class:`StageInstance` or :class:`Object` with the ID of the stage
+        When this is the action, the type of attr`~AuditLogEntry.target` is
+        the class`StageInstance` or class`Object` with the ID of the stage
         instance which was updated.
 
-        Possible attributes for :class:`AuditLogDiff`:
+        Possible attributes for class`AuditLogDiff`
 
-        - :attr:`~AuditLogDiff.topic`
-        - :attr:`~AuditLogDiff.privacy_level`
+        - attr`~AuditLogDiff.topic`
+        - attr`~AuditLogDiff.privacy_level`
 
-        .. versionadded:: 2.0
+        .. versionadded 2.0
 
-    .. attribute:: stage_instance_delete
+    .. attribute stage_instance_delete
 
         A stage instance was ended.
 
-        .. versionadded:: 2.0
+        .. versionadded 2.0
 
-    .. attribute:: sticker_create
+    .. attribute sticker_create
 
         A sticker was created.
 
-        When this is the action, the type of :attr:`~AuditLogEntry.target` is
-        the :class:`GuildSticker` or :class:`Object` with the ID of the sticker
+        When this is the action, the type of attr`~AuditLogEntry.target` is
+        the class`GuildSticker` or class`Object` with the ID of the sticker
         which was updated.
 
-        Possible attributes for :class:`AuditLogDiff`:
+        Possible attributes for class`AuditLogDiff`
 
-        - :attr:`~AuditLogDiff.name`
-        - :attr:`~AuditLogDiff.emoji`
-        - :attr:`~AuditLogDiff.type`
-        - :attr:`~AuditLogDiff.format_type`
-        - :attr:`~AuditLogDiff.description`
-        - :attr:`~AuditLogDiff.available`
+        - attr`~AuditLogDiff.name`
+        - attr`~AuditLogDiff.emoji`
+        - attr`~AuditLogDiff.type`
+        - attr`~AuditLogDiff.format_type`
+        - attr`~AuditLogDiff.description`
+        - attr`~AuditLogDiff.available`
 
-        .. versionadded:: 2.0
+        .. versionadded 2.0
 
-    .. attribute:: sticker_update
+    .. attribute sticker_update
 
         A sticker was updated.
 
-        When this is the action, the type of :attr:`~AuditLogEntry.target` is
-        the :class:`GuildSticker` or :class:`Object` with the ID of the sticker
+        When this is the action, the type of attr`~AuditLogEntry.target` is
+        the class`GuildSticker` or class`Object` with the ID of the sticker
         which was updated.
 
-        Possible attributes for :class:`AuditLogDiff`:
+        Possible attributes for class`AuditLogDiff`
 
-        - :attr:`~AuditLogDiff.name`
-        - :attr:`~AuditLogDiff.emoji`
-        - :attr:`~AuditLogDiff.type`
-        - :attr:`~AuditLogDiff.format_type`
-        - :attr:`~AuditLogDiff.description`
-        - :attr:`~AuditLogDiff.available`
+        - attr`~AuditLogDiff.name`
+        - attr`~AuditLogDiff.emoji`
+        - attr`~AuditLogDiff.type`
+        - attr`~AuditLogDiff.format_type`
+        - attr`~AuditLogDiff.description`
+        - attr`~AuditLogDiff.available`
 
-        .. versionadded:: 2.0
+        .. versionadded 2.0
 
-    .. attribute:: sticker_delete
+    .. attribute sticker_delete
 
         A sticker was deleted.
 
-        When this is the action, the type of :attr:`~AuditLogEntry.target` is
-        the :class:`GuildSticker` or :class:`Object` with the ID of the sticker
+        When this is the action, the type of attr`~AuditLogEntry.target` is
+        the class`GuildSticker` or class`Object` with the ID of the sticker
         which was updated.
 
-        Possible attributes for :class:`AuditLogDiff`:
+        Possible attributes for class`AuditLogDiff`
 
-        - :attr:`~AuditLogDiff.name`
-        - :attr:`~AuditLogDiff.emoji`
-        - :attr:`~AuditLogDiff.type`
-        - :attr:`~AuditLogDiff.format_type`
-        - :attr:`~AuditLogDiff.description`
-        - :attr:`~AuditLogDiff.available`
+        - attr`~AuditLogDiff.name`
+        - attr`~AuditLogDiff.emoji`
+        - attr`~AuditLogDiff.type`
+        - attr`~AuditLogDiff.format_type`
+        - attr`~AuditLogDiff.description`
+        - attr`~AuditLogDiff.available`
 
-        .. versionadded:: 2.0
+        .. versionadded 2.0
 
-    .. attribute:: thread_create
+    .. attribute thread_create
 
         A thread was created.
 
-        When this is the action, the type of :attr:`~AuditLogEntry.target` is
-        the :class:`Thread` or :class:`Object` with the ID of the thread which
+        When this is the action, the type of attr`~AuditLogEntry.target` is
+        the class`Thread` or class`Object` with the ID of the thread which
         was created.
 
-        Possible attributes for :class:`AuditLogDiff`:
+        Possible attributes for class`AuditLogDiff`
 
-        - :attr:`~AuditLogDiff.name`
-        - :attr:`~AuditLogDiff.archived`
-        - :attr:`~AuditLogDiff.locked`
-        - :attr:`~AuditLogDiff.auto_archive_duration`
+        - attr`~AuditLogDiff.name`
+        - attr`~AuditLogDiff.archived`
+        - attr`~AuditLogDiff.locked`
+        - attr`~AuditLogDiff.auto_archive_duration`
 
-        .. versionadded:: 2.0
+        .. versionadded 2.0
 
-    .. attribute:: thread_update
+    .. attribute thread_update
 
         A thread was updated.
 
-        When this is the action, the type of :attr:`~AuditLogEntry.target` is
-        the :class:`Thread` or :class:`Object` with the ID of the thread which
+        When this is the action, the type of attr`~AuditLogEntry.target` is
+        the class`Thread` or class`Object` with the ID of the thread which
         was updated.
 
-        Possible attributes for :class:`AuditLogDiff`:
+        Possible attributes for class`AuditLogDiff`
 
-        - :attr:`~AuditLogDiff.name`
-        - :attr:`~AuditLogDiff.archived`
-        - :attr:`~AuditLogDiff.locked`
-        - :attr:`~AuditLogDiff.auto_archive_duration`
+        - attr`~AuditLogDiff.name`
+        - attr`~AuditLogDiff.archived`
+        - attr`~AuditLogDiff.locked`
+        - attr`~AuditLogDiff.auto_archive_duration`
 
-        .. versionadded:: 2.0
+        .. versionadded 2.0
 
-    .. attribute:: thread_delete
+    .. attribute thread_delete
 
         A thread was deleted.
 
-        When this is the action, the type of :attr:`~AuditLogEntry.target` is
-        the :class:`Thread` or :class:`Object` with the ID of the thread which
+        When this is the action, the type of attr`~AuditLogEntry.target` is
+        the class`Thread` or class`Object` with the ID of the thread which
         was deleted.
 
-        Possible attributes for :class:`AuditLogDiff`:
+        Possible attributes for class`AuditLogDiff`
 
-        - :attr:`~AuditLogDiff.name`
-        - :attr:`~AuditLogDiff.archived`
-        - :attr:`~AuditLogDiff.locked`
-        - :attr:`~AuditLogDiff.auto_archive_duration`
+        - attr`~AuditLogDiff.name`
+        - attr`~AuditLogDiff.archived`
+        - attr`~AuditLogDiff.locked`
+        - attr`~AuditLogDiff.auto_archive_duration`
 
-        .. versionadded:: 2.0
+        .. versionadded 2.0
 
-.. class:: AuditLogActionCategory
+.. class AuditLogActionCategory
 
-    Represents the category that the :class:`AuditLogAction` belongs to.
+    Represents the category that the class`AuditLogAction` belongs to.
 
-    This can be retrieved via :attr:`AuditLogEntry.category`.
+    This can be retrieved via attr`AuditLogEntry.category`.
 
-    .. attribute:: create
+    .. attribute create
 
         The action is the creation of something.
 
-    .. attribute:: delete
+    .. attribute delete
 
         The action is the deletion of something.
 
-    .. attribute:: update
+    .. attribute update
 
         The action is the update of something.
 
-.. class:: TeamMembershipState
+.. class TeamMembershipState
 
-    Represents the membership state of a team member retrieved through :func:`Client.application_info`.
+    Represents the membership state of a team member retrieved through func`Client.application_info`.
 
-    .. versionadded:: 1.3
+    .. versionadded 1.3
 
-    .. attribute:: invited
+    .. attribute invited
 
         Represents an invited member.
 
-    .. attribute:: accepted
+    .. attribute accepted
 
         Represents a member currently in the team.
 
-.. class:: WebhookType
+.. class WebhookType
 
     Represents the type of webhook that can be received.
 
-    .. versionadded:: 1.3
+    .. versionadded 1.3
 
-    .. attribute:: incoming
+    .. attribute incoming
 
         Represents a webhook that can post messages to channels with a token.
 
-    .. attribute:: channel_follower
+    .. attribute channel_follower
 
         Represents a webhook that is internally managed by Discord, used for following channels.
 
-    .. attribute:: application
+    .. attribute application
 
         Represents a webhook that is used for interactions or applications.
 
-        .. versionadded:: 2.0
+        .. versionadded 2.0
 
-.. class:: ExpireBehaviour
+.. class ExpireBehaviour
 
-    Represents the behaviour the :class:`Integration` should perform
+    Represents the behaviour the class`Integration` should perform
     when a user's subscription has finished.
 
     There is an alias for this called ``ExpireBehavior``.
 
-    .. versionadded:: 1.4
+    .. versionadded 1.4
 
-    .. attribute:: remove_role
+    .. attribute remove_role
 
-        This will remove the :attr:`StreamIntegration.role` from the user
+        This will remove the attr`StreamIntegration.role` from the user
         when their subscription is finished.
 
-    .. attribute:: kick
+    .. attribute kick
 
         This will kick the user when their subscription is finished.
 
-.. class:: DefaultAvatar
+.. class DefaultAvatar
 
-    Represents the default avatar of a Discord :class:`User`
+    Represents the default avatar of a Discord class`User`
 
-    .. attribute:: blurple
+    .. attribute blurple
 
         Represents the default avatar with the color blurple.
-        See also :attr:`Colour.blurple`
-    .. attribute:: grey
+        See also attr`Colour.blurple`
+    .. attribute grey
 
         Represents the default avatar with the color grey.
-        See also :attr:`Colour.greyple`
-    .. attribute:: gray
+        See also attr`Colour.greyple`
+    .. attribute gray
 
-        An alias for :attr:`grey`.
-    .. attribute:: green
+        An alias for attr`grey`.
+    .. attribute green
 
         Represents the default avatar with the color green.
-        See also :attr:`Colour.green`
-    .. attribute:: orange
+        See also attr`Colour.green`
+    .. attribute orange
 
         Represents the default avatar with the color orange.
-        See also :attr:`Colour.orange`
-    .. attribute:: red
+        See also attr`Colour.orange`
+    .. attribute red
 
         Represents the default avatar with the color red.
-        See also :attr:`Colour.red`
+        See also attr`Colour.red`
 
-.. class:: StickerType
+.. class StickerType
 
     Represents the type of sticker.
 
-    .. versionadded:: 2.0
+    .. versionadded 2.0
 
-    .. attribute:: standard
+    .. attribute standard
 
         Represents a standard sticker that all Nitro users can use.
 
-    .. attribute:: guild
+    .. attribute guild
 
         Represents a custom sticker created in a guild.
 
-.. class:: StickerFormatType
+.. class StickerFormatType
 
     Represents the type of sticker images.
 
-    .. versionadded:: 1.6
+    .. versionadded 1.6
 
-    .. attribute:: png
+    .. attribute png
 
         Represents a sticker with a png image.
 
-    .. attribute:: apng
+    .. attribute apng
 
         Represents a sticker with an apng image.
 
-    .. attribute:: lottie
+    .. attribute lottie
 
         Represents a sticker with a lottie image.
 
-.. class:: InviteTarget
+.. class InviteTarget
 
     Represents the invite type for voice channel invites.
 
-    .. versionadded:: 2.0
+    .. versionadded 2.0
 
-    .. attribute:: unknown
+    .. attribute unknown
 
         The invite doesn't target anyone or anything.
 
-    .. attribute:: stream
+    .. attribute stream
 
         A stream invite that targets a user.
 
-    .. attribute:: embedded_application
+    .. attribute embedded_application
 
         A stream invite that targets an embedded application.
 
-.. class:: VideoQualityMode
+.. class VideoQualityMode
 
     Represents the camera video quality mode for voice channel participants.
 
-    .. versionadded:: 2.0
+    .. versionadded 2.0
 
-    .. attribute:: auto
+    .. attribute auto
 
         Represents auto camera video quality.
 
-    .. attribute:: full
+    .. attribute full
 
         Represents full camera video quality.
 
-.. class:: StagePrivacyLevel
+.. class StagePrivacyLevel
 
     Represents a stage instance's privacy level.
 
-    .. versionadded:: 2.0
+    .. versionadded 2.0
 
-    .. attribute:: public
+    .. attribute public
 
         The stage instance can be joined by external users.
 
-    .. attribute:: closed
+    .. attribute closed
 
         The stage instance can only be joined by members of the guild.
 
-    .. attribute:: guild_only
+    .. attribute guild_only
 
-        Alias for :attr:`.closed`
+        Alias for attr`.closed`
 
-.. class:: NSFWLevel
+.. class NSFWLevel
 
     Represents the NSFW level of a guild.
 
-    .. versionadded:: 2.0
+    .. versionadded 2.0
 
-    .. container:: operations
+    .. container operations
 
-        .. describe:: x == y
+        .. describe x == y
 
             Checks if two NSFW levels are equal.
-        .. describe:: x != y
+        .. describe x != y
 
             Checks if two NSFW levels are not equal.
-        .. describe:: x > y
+        .. describe x > y
 
             Checks if a NSFW level is higher than another.
-        .. describe:: x < y
+        .. describe x < y
 
             Checks if a NSFW level is lower than another.
-        .. describe:: x >= y
+        .. describe x >= y
 
             Checks if a NSFW level is higher or equal to another.
-        .. describe:: x <= y
+        .. describe x <= y
 
             Checks if a NSFW level is lower or equal to another.
 
-    .. attribute:: default
+    .. attribute default
 
         The guild has not been categorised yet.
 
-    .. attribute:: explicit
+    .. attribute explicit
 
         The guild contains NSFW content.
 
-    .. attribute:: safe
+    .. attribute safe
 
         The guild does not contain any NSFW content.
 
-    .. attribute:: age_restricted
+    .. attribute age_restricted
 
         The guild may contain NSFW content.
 
@@ -2599,193 +2599,193 @@ Async Iterator
 ----------------
 
 Some API functions return an "async iterator". An async iterator is something that is
-capable of being used in an :ref:`async for statement <py:async for>`.
+capable of being used in an ref`async for statement <pyasync for>`.
 
-These async iterators can be used as follows: ::
+These async iterators can be used as follows 
 
-    async for elem in channel.history():
+    async for elem in channel.history()
         # do stuff with elem here
 
 Certain utilities make working with async iterators easier, detailed below.
 
-.. class:: AsyncIterator
+.. class AsyncIterator
 
     Represents the "AsyncIterator" concept. Note that no such class exists,
     it is purely abstract.
 
-    .. container:: operations
+    .. container operations
 
-        .. describe:: async for x in y
+        .. describe async for x in y
 
             Iterates over the contents of the async iterator.
 
 
-    .. method:: next()
-        :async:
+    .. method next()
+        async
 
         |coro|
 
         Advances the iterator by one, if possible. If no more items are found
-        then this raises :exc:`NoMoreItems`.
+        then this raises exc`NoMoreItems`.
 
-    .. method:: get(**attrs)
-        :async:
+    .. method get(**attrs)
+        async
 
         |coro|
 
-        Similar to :func:`utils.get` except run over the async iterator.
+        Similar to func`utils.get` except run over the async iterator.
 
-        Getting the last message by a user named 'Dave' or ``None``: ::
+        Getting the last message by a user named 'Dave' or ``None`` 
 
             msg = await channel.history().get(author__name='Dave')
 
-    .. method:: find(predicate)
-        :async:
+    .. method find(predicate)
+        async
 
         |coro|
 
-        Similar to :func:`utils.find` except run over the async iterator.
+        Similar to func`utils.find` except run over the async iterator.
 
-        Unlike :func:`utils.find`\, the predicate provided can be a
+        Unlike func`utils.find`\, the predicate provided can be a
         |coroutine_link|_.
 
-        Getting the last audit log with a reason or ``None``: ::
+        Getting the last audit log with a reason or ``None`` 
 
-            def predicate(event):
+            def predicate(event)
                 return event.reason is not None
 
             event = await guild.audit_logs().find(predicate)
 
-        :param predicate: The predicate to use. Could be a |coroutine_link|_.
-        :return: The first element that returns ``True`` for the predicate or ``None``.
+        param predicate The predicate to use. Could be a |coroutine_link|_.
+        return The first element that returns ``True`` for the predicate or ``None``.
 
-    .. method:: flatten()
-        :async:
+    .. method flatten()
+        async
 
         |coro|
 
-        Flattens the async iterator into a :class:`list` with all the elements.
+        Flattens the async iterator into a class`list` with all the elements.
 
-        :return: A list of every element in the async iterator.
-        :rtype: list
+        return A list of every element in the async iterator.
+        rtype list
 
-    .. method:: chunk(max_size)
+    .. method chunk(max_size)
 
         Collects items into chunks of up to a given maximum size.
-        Another :class:`AsyncIterator` is returned which collects items into
-        :class:`list`\s of a given size. The maximum chunk size must be a positive integer.
+        Another class`AsyncIterator` is returned which collects items into
+        class`list`\s of a given size. The maximum chunk size must be a positive integer.
 
-        .. versionadded:: 1.6
+        .. versionadded 1.6
 
-        Collecting groups of users: ::
+        Collecting groups of users 
 
-            async for leader, *users in reaction.users().chunk(3):
+            async for leader, *users in reaction.users().chunk(3)
                 ...
 
-        .. warning::
+        .. warning
 
             The last chunk collected may not be as large as ``max_size``.
 
-        :param max_size: The size of individual chunks.
-        :rtype: :class:`AsyncIterator`
+        param max_size The size of individual chunks.
+        rtype class`AsyncIterator`
 
-    .. method:: map(func)
+    .. method map(func)
 
-        This is similar to the built-in :func:`map <py:map>` function. Another
-        :class:`AsyncIterator` is returned that executes the function on
+        This is similar to the built-in func`map <pymap>` function. Another
+        class`AsyncIterator` is returned that executes the function on
         every element it is iterating over. This function can either be a
         regular function or a |coroutine_link|_.
 
-        Creating a content iterator: ::
+        Creating a content iterator 
 
-            def transform(message):
+            def transform(message)
                 return message.content
 
-            async for content in channel.history().map(transform):
+            async for content in channel.history().map(transform)
                 message_length = len(content)
 
-        :param func: The function to call on every element. Could be a |coroutine_link|_.
-        :rtype: :class:`AsyncIterator`
+        param func The function to call on every element. Could be a |coroutine_link|_.
+        rtype class`AsyncIterator`
 
-    .. method:: filter(predicate)
+    .. method filter(predicate)
 
-        This is similar to the built-in :func:`filter <py:filter>` function. Another
-        :class:`AsyncIterator` is returned that filters over the original
+        This is similar to the built-in func`filter <pyfilter>` function. Another
+        class`AsyncIterator` is returned that filters over the original
         async iterator. This predicate can be a regular function or a |coroutine_link|_.
 
-        Getting messages by non-bot accounts: ::
+        Getting messages by non-bot accounts 
 
-            def predicate(message):
+            def predicate(message)
                 return not message.author.bot
 
-            async for elem in channel.history().filter(predicate):
+            async for elem in channel.history().filter(predicate)
                 ...
 
-        :param predicate: The predicate to call on every element. Could be a |coroutine_link|_.
-        :rtype: :class:`AsyncIterator`
+        param predicate The predicate to call on every element. Could be a |coroutine_link|_.
+        rtype class`AsyncIterator`
 
-.. _discord-api-audit-logs:
+.. _discord-api-audit-logs
 
 Audit Log Data
 ----------------
 
-Working with :meth:`Guild.audit_logs` is a complicated process with a lot of machinery
-involved. The library attempts to make it easy to use and friendly. In order to accomplish
+Working with meth`Guild.audit_logs` is a complicated process with a lot of machinery
+involved. The library attempts to make it easy to use and friendly. To accomplish
 this goal, it must make use of a couple of data classes that aid in this goal.
 
 AuditLogEntry
 ~~~~~~~~~~~~~~~
 
-.. attributetable:: AuditLogEntry
+.. attributetable AuditLogEntry
 
-.. autoclass:: AuditLogEntry
-    :members:
+.. autoclass AuditLogEntry
+    members
 
 AuditLogChanges
 ~~~~~~~~~~~~~~~~~
 
-.. attributetable:: AuditLogChanges
+.. attributetable AuditLogChanges
 
-.. class:: AuditLogChanges
+.. class AuditLogChanges
 
     An audit log change set.
 
-    .. attribute:: before
+    .. attribute before
 
-        The old value. The attribute has the type of :class:`AuditLogDiff`.
+        The old value. The attribute has the type of class`AuditLogDiff`.
 
-        Depending on the :class:`AuditLogActionCategory` retrieved by
-        :attr:`~AuditLogEntry.category`\, the data retrieved by this
-        attribute differs:
+        Depending on the class`AuditLogActionCategory` retrieved by
+        attr`~AuditLogEntry.category`\, the data retrieved by this
+        attribute differs
 
         +----------------------------------------+---------------------------------------------------+
         |                Category                |                    Description                    |
         +----------------------------------------+---------------------------------------------------+
-        | :attr:`~AuditLogActionCategory.create` | All attributes are set to ``None``.               |
+        | attr`~AuditLogActionCategory.create` | All attributes are set to ``None``.               |
         +----------------------------------------+---------------------------------------------------+
-        | :attr:`~AuditLogActionCategory.delete` | All attributes are set the value before deletion. |
+        | attr`~AuditLogActionCategory.delete` | All attributes are set the value before deletion. |
         +----------------------------------------+---------------------------------------------------+
-        | :attr:`~AuditLogActionCategory.update` | All attributes are set the value before updating. |
+        | attr`~AuditLogActionCategory.update` | All attributes are set the value before updating. |
         +----------------------------------------+---------------------------------------------------+
         | ``None``                               | No attributes are set.                            |
         +----------------------------------------+---------------------------------------------------+
 
-    .. attribute:: after
+    .. attribute after
 
-        The new value. The attribute has the type of :class:`AuditLogDiff`.
+        The new value. The attribute has the type of class`AuditLogDiff`.
 
-        Depending on the :class:`AuditLogActionCategory` retrieved by
-        :attr:`~AuditLogEntry.category`\, the data retrieved by this
-        attribute differs:
+        Depending on the class`AuditLogActionCategory` retrieved by
+        attr`~AuditLogEntry.category`\, the data retrieved by this
+        attribute differs
 
         +----------------------------------------+--------------------------------------------------+
         |                Category                |                   Description                    |
         +----------------------------------------+--------------------------------------------------+
-        | :attr:`~AuditLogActionCategory.create` | All attributes are set to the created value      |
+        | attr`~AuditLogActionCategory.create` | All attributes are set to the created value      |
         +----------------------------------------+--------------------------------------------------+
-        | :attr:`~AuditLogActionCategory.delete` | All attributes are set to ``None``               |
+        | attr`~AuditLogActionCategory.delete` | All attributes are set to ``None``               |
         +----------------------------------------+--------------------------------------------------+
-        | :attr:`~AuditLogActionCategory.update` | All attributes are set the value after updating. |
+        | attr`~AuditLogActionCategory.update` | All attributes are set the value after updating. |
         +----------------------------------------+--------------------------------------------------+
         | ``None``                               | No attributes are set.                           |
         +----------------------------------------+--------------------------------------------------+
@@ -2793,9 +2793,9 @@ AuditLogChanges
 AuditLogDiff
 ~~~~~~~~~~~~~
 
-.. attributetable:: AuditLogDiff
+.. attributetable AuditLogDiff
 
-.. class:: AuditLogDiff
+.. class AuditLogDiff
 
     Represents an audit log "change" object. A change object has dynamic
     attributes that depend on the type of action being done. Certain actions
@@ -2806,552 +2806,552 @@ AuditLogDiff
 
     To get a list of attributes that have been set, you can iterate over
     them. To see a list of all possible attributes that could be set based
-    on the action being done, check the documentation for :class:`AuditLogAction`,
+    on the action being done, check the documentation for class`AuditLogAction`,
     otherwise check the documentation below for all attributes that are possible.
 
-    .. container:: operations
+    .. container operations
 
-        .. describe:: iter(diff)
+        .. describe iter(diff)
 
             Returns an iterator over (attribute, value) tuple of this diff.
 
-    .. attribute:: name
+    .. attribute name
 
         A name of something.
 
-        :type: :class:`str`
+        type class`str`
 
-    .. attribute:: icon
+    .. attribute icon
 
-        A guild's icon. See also :attr:`Guild.icon`.
+        A guild's icon. See also attr`Guild.icon`.
 
-        :type: :class:`Asset`
+        type class`Asset`
 
-    .. attribute:: splash
+    .. attribute splash
 
-        The guild's invite splash. See also :attr:`Guild.splash`.
+        The guild's invite splash. See also attr`Guild.splash`.
 
-        :type: :class:`Asset`
+        type class`Asset`
 
-    .. attribute:: discovery_splash
+    .. attribute discovery_splash
 
-        The guild's discovery splash. See also :attr:`Guild.discovery_splash`.
+        The guild's discovery splash. See also attr`Guild.discovery_splash`.
 
-        :type: :class:`Asset`
+        type class`Asset`
 
-    .. attribute:: banner
+    .. attribute banner
 
-        The guild's banner. See also :attr:`Guild.banner`.
+        The guild's banner. See also attr`Guild.banner`.
 
-        :type: :class:`Asset`
+        type class`Asset`
 
-    .. attribute:: owner
+    .. attribute owner
 
-        The guild's owner. See also :attr:`Guild.owner`
+        The guild's owner. See also attr`Guild.owner`
 
-        :type: Union[:class:`Member`, :class:`User`]
+        type Union[class`Member`, class`User`]
 
-    .. attribute:: region
+    .. attribute region
 
-        The guild's voice region. See also :attr:`Guild.region`.
+        The guild's voice region. See also attr`Guild.region`.
 
-        :type: :class:`VoiceRegion`
+        type class`VoiceRegion`
 
-    .. attribute:: afk_channel
+    .. attribute afk_channel
 
         The guild's AFK channel.
 
-        If this could not be found, then it falls back to a :class:`Object`
+        If this could not be found, then it falls back to a class`Object`
         with the ID being set.
 
-        See :attr:`Guild.afk_channel`.
+        See attr`Guild.afk_channel`.
 
-        :type: Union[:class:`VoiceChannel`, :class:`Object`]
+        type Union[class`VoiceChannel`, class`Object`]
 
-    .. attribute:: system_channel
+    .. attribute system_channel
 
         The guild's system channel.
 
-        If this could not be found, then it falls back to a :class:`Object`
+        If this could not be found, then it falls back to a class`Object`
         with the ID being set.
 
-        See :attr:`Guild.system_channel`.
+        See attr`Guild.system_channel`.
 
-        :type: Union[:class:`TextChannel`, :class:`Object`]
+        type Union[class`TextChannel`, class`Object`]
 
 
-    .. attribute:: rules_channel
+    .. attribute rules_channel
 
         The guild's rules channel.
 
-        If this could not be found then it falls back to a :class:`Object`
+        If this could not be found then it falls back to a class`Object`
         with the ID being set.
 
-        See :attr:`Guild.rules_channel`.
+        See attr`Guild.rules_channel`.
 
-        :type: Union[:class:`TextChannel`, :class:`Object`]
+        type Union[class`TextChannel`, class`Object`]
 
 
-    .. attribute:: public_updates_channel
+    .. attribute public_updates_channel
 
         The guild's public updates channel.
 
-        If this could not be found then it falls back to a :class:`Object`
+        If this could not be found then it falls back to a class`Object`
         with the ID being set.
 
-        See :attr:`Guild.public_updates_channel`.
+        See attr`Guild.public_updates_channel`.
 
-        :type: Union[:class:`TextChannel`, :class:`Object`]
+        type Union[class`TextChannel`, class`Object`]
 
-    .. attribute:: afk_timeout
+    .. attribute afk_timeout
 
-        The guild's AFK timeout. See :attr:`Guild.afk_timeout`.
+        The guild's AFK timeout. See attr`Guild.afk_timeout`.
 
-        :type: :class:`int`
+        type class`int`
 
-    .. attribute:: mfa_level
+    .. attribute mfa_level
 
-        The guild's MFA level. See :attr:`Guild.mfa_level`.
+        The guild's MFA level. See attr`Guild.mfa_level`.
 
-        :type: :class:`int`
+        type class`int`
 
-    .. attribute:: widget_enabled
+    .. attribute widget_enabled
 
         The guild's widget has been enabled or disabled.
 
-        :type: :class:`bool`
+        type class`bool`
 
-    .. attribute:: widget_channel
+    .. attribute widget_channel
 
         The widget's channel.
 
-        If this could not be found then it falls back to a :class:`Object`
+        If this could not be found then it falls back to a class`Object`
         with the ID being set.
 
-        :type: Union[:class:`TextChannel`, :class:`Object`]
+        type Union[class`TextChannel`, class`Object`]
 
-    .. attribute:: verification_level
+    .. attribute verification_level
 
         The guild's verification level.
 
-        See also :attr:`Guild.verification_level`.
+        See also attr`Guild.verification_level`.
 
-        :type: :class:`VerificationLevel`
+        type class`VerificationLevel`
 
-    .. attribute:: default_notifications
+    .. attribute default_notifications
 
         The guild's default notification level.
 
-        See also :attr:`Guild.default_notifications`.
+        See also attr`Guild.default_notifications`.
 
-        :type: :class:`NotificationLevel`
+        type class`NotificationLevel`
 
-    .. attribute:: explicit_content_filter
+    .. attribute explicit_content_filter
 
         The guild's content filter.
 
-        See also :attr:`Guild.explicit_content_filter`.
+        See also attr`Guild.explicit_content_filter`.
 
-        :type: :class:`ContentFilter`
+        type class`ContentFilter`
 
-    .. attribute:: default_message_notifications
+    .. attribute default_message_notifications
 
         The guild's default message notification setting.
 
-        :type: :class:`int`
+        type class`int`
 
-    .. attribute:: vanity_url_code
+    .. attribute vanity_url_code
 
         The guild's vanity URL.
 
-        See also :meth:`Guild.vanity_invite` and :meth:`Guild.edit`.
+        See also meth`Guild.vanity_invite` and meth`Guild.edit`.
 
-        :type: :class:`str`
+        type class`str`
 
-    .. attribute:: position
+    .. attribute position
 
-        The position of a :class:`Role` or :class:`abc.GuildChannel`.
+        The position of a class`Role` or class`abc.GuildChannel`.
 
-        :type: :class:`int`
+        type class`int`
 
-    .. attribute:: type
+    .. attribute type
 
         The type of channel or sticker.
 
-        :type: Union[:class:`ChannelType`, :class:`StickerType`]
+        type Union[class`ChannelType`, class`StickerType`]
 
-    .. attribute:: topic
+    .. attribute topic
 
-        The topic of a :class:`TextChannel` or :class:`StageChannel`.
+        The topic of a class`TextChannel` or class`StageChannel`.
 
-        See also :attr:`TextChannel.topic` or :attr:`StageChannel.topic`.
+        See also attr`TextChannel.topic` or attr`StageChannel.topic`.
 
-        :type: :class:`str`
+        type class`str`
 
-    .. attribute:: bitrate
+    .. attribute bitrate
 
-        The bitrate of a :class:`VoiceChannel`.
+        The bitrate of a class`VoiceChannel`.
 
-        See also :attr:`VoiceChannel.bitrate`.
+        See also attr`VoiceChannel.bitrate`.
 
-        :type: :class:`int`
+        type class`int`
 
-    .. attribute:: overwrites
+    .. attribute overwrites
 
         A list of permission overwrite tuples that represents a target and a
-        :class:`PermissionOverwrite` for said target.
+        class`PermissionOverwrite` for said target.
 
         The first element is the object being targeted, which can either
-        be a :class:`Member` or :class:`User` or :class:`Role`. If this object
-        is not found then it is a :class:`Object` with an ID being filled and
+        be a class`Member` or class`User` or class`Role`. If this object
+        is not found then it is a class`Object` with an ID being filled and
         a ``type`` attribute set to either ``'role'`` or ``'member'`` to help
         decide what type of ID it is.
 
-        :type: List[Tuple[target, :class:`PermissionOverwrite`]]
+        type List[Tuple[target, class`PermissionOverwrite`]]
 
-    .. attribute:: privacy_level
+    .. attribute privacy_level
 
         The privacy level of the stage instance.
 
-        :type: :class:`StagePrivacyLevel`
+        type class`StagePrivacyLevel`
 
-    .. attribute:: roles
+    .. attribute roles
 
         A list of roles being added or removed from a member.
 
-        If a role is not found then it is a :class:`Object` with the ID and name being
+        If a role is not found then it is a class`Object` with the ID and name being
         filled in.
 
-        :type: List[Union[:class:`Role`, :class:`Object`]]
+        type List[Union[class`Role`, class`Object`]]
 
-    .. attribute:: nick
+    .. attribute nick
 
         The nickname of a member.
 
-        See also :attr:`Member.nick`
+        See also attr`Member.nick`
 
-        :type: Optional[:class:`str`]
+        type Optional[class`str`]
 
-    .. attribute:: deaf
+    .. attribute deaf
 
         Whether the member is being server deafened.
 
-        See also :attr:`VoiceState.deaf`.
+        See also attr`VoiceState.deaf`.
 
-        :type: :class:`bool`
+        type class`bool`
 
-    .. attribute:: mute
+    .. attribute mute
 
         Whether the member is being server muted.
 
-        See also :attr:`VoiceState.mute`.
+        See also attr`VoiceState.mute`.
 
-        :type: :class:`bool`
+        type class`bool`
 
-    .. attribute:: permissions
+    .. attribute permissions
 
         The permissions of a role.
 
-        See also :attr:`Role.permissions`.
+        See also attr`Role.permissions`.
 
-        :type: :class:`Permissions`
+        type class`Permissions`
 
-    .. attribute:: colour
+    .. attribute colour
                    color
 
         The colour of a role.
 
-        See also :attr:`Role.colour`
+        See also attr`Role.colour`
 
-        :type: :class:`Colour`
+        type class`Colour`
 
-    .. attribute:: hoist
+    .. attribute hoist
 
         Whether the role is being hoisted or not.
 
-        See also :attr:`Role.hoist`
+        See also attr`Role.hoist`
 
-        :type: :class:`bool`
+        type class`bool`
 
-    .. attribute:: mentionable
+    .. attribute mentionable
 
         Whether the role is mentionable or not.
 
-        See also :attr:`Role.mentionable`
+        See also attr`Role.mentionable`
 
-        :type: :class:`bool`
+        type class`bool`
 
-    .. attribute:: code
+    .. attribute code
 
         The invite's code.
 
-        See also :attr:`Invite.code`
+        See also attr`Invite.code`
 
-        :type: :class:`str`
+        type class`str`
 
-    .. attribute:: channel
+    .. attribute channel
 
         A guild channel.
 
-        If the channel is not found then it is a :class:`Object` with the ID
+        If the channel is not found then it is a class`Object` with the ID
         being set. In some cases the channel name is also set.
 
-        :type: Union[:class:`abc.GuildChannel`, :class:`Object`]
+        type Union[class`abc.GuildChannel`, class`Object`]
 
-    .. attribute:: inviter
+    .. attribute inviter
 
         The user who created the invite.
 
-        See also :attr:`Invite.inviter`.
+        See also attr`Invite.inviter`.
 
-        :type: Optional[:class:`User`]
+        type Optional[class`User`]
 
-    .. attribute:: max_uses
+    .. attribute max_uses
 
         The invite's max uses.
 
-        See also :attr:`Invite.max_uses`.
+        See also attr`Invite.max_uses`.
 
-        :type: :class:`int`
+        type class`int`
 
-    .. attribute:: uses
+    .. attribute uses
 
         The invite's current uses.
 
-        See also :attr:`Invite.uses`.
+        See also attr`Invite.uses`.
 
-        :type: :class:`int`
+        type class`int`
 
-    .. attribute:: max_age
+    .. attribute max_age
 
         The invite's max age in seconds.
 
-        See also :attr:`Invite.max_age`.
+        See also attr`Invite.max_age`.
 
-        :type: :class:`int`
+        type class`int`
 
-    .. attribute:: temporary
+    .. attribute temporary
 
         If the invite is a temporary invite.
 
-        See also :attr:`Invite.temporary`.
+        See also attr`Invite.temporary`.
 
-        :type: :class:`bool`
+        type class`bool`
 
-    .. attribute:: allow
+    .. attribute allow
                    deny
 
         The permissions being allowed or denied.
 
-        :type: :class:`Permissions`
+        type class`Permissions`
 
-    .. attribute:: id
+    .. attribute id
 
         The ID of the object being changed.
 
-        :type: :class:`int`
+        type class`int`
 
-    .. attribute:: avatar
+    .. attribute avatar
 
         The avatar of a member.
 
-        See also :attr:`User.avatar`.
+        See also attr`User.avatar`.
 
-        :type: :class:`Asset`
+        type class`Asset`
 
-    .. attribute:: slowmode_delay
+    .. attribute slowmode_delay
 
         The number of seconds members have to wait before
         sending another message in the channel.
 
-        See also :attr:`TextChannel.slowmode_delay`.
+        See also attr`TextChannel.slowmode_delay`.
 
-        :type: :class:`int`
+        type class`int`
 
-    .. attribute:: rtc_region
+    .. attribute rtc_region
 
         The region for the voice channel’s voice communication.
         A value of ``None`` indicates automatic voice region detection.
 
-        See also :attr:`VoiceChannel.rtc_region`.
+        See also attr`VoiceChannel.rtc_region`.
 
-        :type: :class:`VoiceRegion`
+        type class`VoiceRegion`
 
-    .. attribute:: video_quality_mode
+    .. attribute video_quality_mode
 
         The camera video quality for the voice channel's participants.
 
-        See also :attr:`VoiceChannel.video_quality_mode`.
+        See also attr`VoiceChannel.video_quality_mode`.
 
-        :type: :class:`VideoQualityMode`
+        type class`VideoQualityMode`
 
-    .. attribute:: format_type
+    .. attribute format_type
 
         The format type of a sticker being changed.
 
-        See also :attr:`GuildSticker.format`
+        See also attr`GuildSticker.format`
 
-        :type: :class:`StickerFormatType`
+        type class`StickerFormatType`
 
-    .. attribute:: emoji
+    .. attribute emoji
 
         The name of the emoji that represents a sticker being changed.
 
-        See also :attr:`GuildSticker.emoji`
+        See also attr`GuildSticker.emoji`
 
-        :type: :class:`str`
+        type class`str`
 
-    .. attribute:: description
+    .. attribute description
 
         The description of a sticker being changed.
 
-        See also :attr:`GuildSticker.description`
+        See also attr`GuildSticker.description`
 
-        :type: :class:`str`
+        type class`str`
 
-    .. attribute:: available
+    .. attribute available
 
         The availability of a sticker being changed.
 
-        See also :attr:`GuildSticker.available`
+        See also attr`GuildSticker.available`
 
-        :type: :class:`bool`
+        type class`bool`
 
-    .. attribute:: archived
+    .. attribute archived
 
         The thread is now archived.
 
-        :type: :class:`bool`
+        type class`bool`
 
-    .. attribute:: locked
+    .. attribute locked
 
         The thread is being locked or unlocked.
 
-        :type: :class:`bool`
+        type class`bool`
 
-    .. attribute:: auto_archive_duration
+    .. attribute auto_archive_duration
 
         The thread's auto archive duration being changed.
 
-        See also :attr:`Thread.auto_archive_duration`
+        See also attr`Thread.auto_archive_duration`
 
-        :type: :class:`int`
+        type class`int`
 
-    .. attribute:: default_auto_archive_duration
+    .. attribute default_auto_archive_duration
 
         The default auto archive duration for newly created threads being changed.
 
-        :type: :class:`int`
+        type class`int`
 
-.. this is currently missing the following keys: reason and application_id
+.. this is currently missing the following keys reason and application_id
    I'm not sure how to about porting these
 
 Webhook Support
 ------------------
 
-nextcord offers support for creating, editing, and executing webhooks through the :class:`Webhook` class.
+nextcord offers support for creating, editing, and executing webhooks through the class`Webhook` class.
 
 Webhook
 ~~~~~~~~~
 
-.. attributetable:: Webhook
+.. attributetable Webhook
 
-.. autoclass:: Webhook()
-    :members:
-    :inherited-members:
+.. autoclass Webhook()
+    members
+    inherited-members
 
 WebhookMessage
 ~~~~~~~~~~~~~~~~
 
-.. attributetable:: WebhookMessage
+.. attributetable WebhookMessage
 
-.. autoclass:: WebhookMessage()
-    :members:
+.. autoclass WebhookMessage()
+    members
 
 SyncWebhook
 ~~~~~~~~~~~~
 
-.. attributetable:: SyncWebhook
+.. attributetable SyncWebhook
 
-.. autoclass:: SyncWebhook()
-    :members:
-    :inherited-members:
+.. autoclass SyncWebhook()
+    members
+    inherited-members
 
 SyncWebhookMessage
 ~~~~~~~~~~~~~~~~~~~
 
-.. attributetable:: SyncWebhookMessage
+.. attributetable SyncWebhookMessage
 
-.. autoclass:: SyncWebhookMessage()
-    :members:
+.. autoclass SyncWebhookMessage()
+    members
 
-.. _discord_api_abcs:
+.. _discord_api_abcs
 
 Abstract Base Classes
 -----------------------
 
-An :term:`abstract base class` (also known as an ``abc``) is a class that models can inherit
+An term`abstract base class` (also known as an ``abc``) is a class that models can inherit
 to get their behaviour. **Abstract base classes should not be instantiated**.
-They are mainly there for usage with :func:`isinstance` and :func:`issubclass`\.
+They are mainly there for usage with func`isinstance` and func`issubclass`\.
 
 This library has a module related to abstract base classes, in which all the ABCs are subclasses of
-:class:`typing.Protocol`.
+class`typing.Protocol`.
 
 Snowflake
 ~~~~~~~~~~
 
-.. attributetable:: nextcord.abc.Snowflake
+.. attributetable nextcord.abc.Snowflake
 
-.. autoclass:: nextcord.abc.Snowflake()
-    :members:
+.. autoclass nextcord.abc.Snowflake()
+    members
 
 User
 ~~~~~
 
-.. attributetable:: nextcord.abc.User
+.. attributetable nextcord.abc.User
 
-.. autoclass:: nextcord.abc.User()
-    :members:
+.. autoclass nextcord.abc.User()
+    members
 
 PrivateChannel
 ~~~~~~~~~~~~~~~
 
-.. attributetable:: nextcord.abc.PrivateChannel
+.. attributetable nextcord.abc.PrivateChannel
 
-.. autoclass:: nextcord.abc.PrivateChannel()
-    :members:
+.. autoclass nextcord.abc.PrivateChannel()
+    members
 
 GuildChannel
 ~~~~~~~~~~~~~
 
-.. attributetable:: nextcord.abc.GuildChannel
+.. attributetable nextcord.abc.GuildChannel
 
-.. autoclass:: nextcord.abc.GuildChannel()
-    :members:
+.. autoclass nextcord.abc.GuildChannel()
+    members
 
 Messageable
 ~~~~~~~~~~~~
 
-.. attributetable:: nextcord.abc.Messageable
+.. attributetable nextcord.abc.Messageable
 
-.. autoclass:: nextcord.abc.Messageable()
-    :members:
-    :exclude-members: history, typing
+.. autoclass nextcord.abc.Messageable()
+    members
+    exclude-members history, typing
 
-    .. automethod:: nextcord.abc.Messageable.history
-        :async-for:
+    .. automethod nextcord.abc.Messageable.history
+        async-for
 
-    .. automethod:: nextcord.abc.Messageable.typing
-        :async-with:
+    .. automethod nextcord.abc.Messageable.typing
+        async-with
 
 Connectable
 ~~~~~~~~~~~~
 
-.. attributetable:: nextcord.abc.Connectable
+.. attributetable nextcord.abc.Connectable
 
-.. autoclass:: nextcord.abc.Connectable()
+.. autoclass nextcord.abc.Connectable()
 
-.. _discord_api_models:
+.. _discord_api_models
 
 Discord Models
 ---------------
@@ -3359,775 +3359,775 @@ Discord Models
 Models are classes that are received from Discord and are not meant to be created by
 the user of the library.
 
-.. danger::
+.. danger
 
     The classes listed below are **not intended to be created by users** and are also
     **read-only**.
 
-    For example, this means that you should not make your own :class:`User` instances
-    nor should you modify the :class:`User` instance yourself.
+    For example, this means that you should not make your own class`User` instances
+    nor should you modify the class`User` instance yourself.
 
     If you want to get one of these model classes instances they'd have to be through
-    the cache, and a common way of doing so is through the :func:`utils.find` function
+    the cache, and a common way of doing so is through the func`utils.find` function
     or attributes of model classes that you receive from the events specified in the
-    :ref:`discord-api-events`.
+    ref`discord-api-events`.
 
-.. note::
+.. note
 
-    Nearly all classes here have :ref:`py:slots` defined which means that it is
+    Nearly all classes here have ref`pyslots` defined which means that it is
     impossible to have dynamic attributes to the data classes.
 
 
 ClientUser
 ~~~~~~~~~~~~
 
-.. attributetable:: ClientUser
+.. attributetable ClientUser
 
-.. autoclass:: ClientUser()
-    :members:
-    :inherited-members:
+.. autoclass ClientUser()
+    members
+    inherited-members
 
 User
 ~~~~~
 
-.. attributetable:: User
+.. attributetable User
 
-.. autoclass:: User()
-    :members:
-    :inherited-members:
-    :exclude-members: history, typing
+.. autoclass User()
+    members
+    inherited-members
+    exclude-members history, typing
 
-    .. automethod:: history
-        :async-for:
+    .. automethod history
+        async-for
 
-    .. automethod:: typing
-        :async-with:
+    .. automethod typing
+        async-with
 
 Attachment
 ~~~~~~~~~~~
 
-.. attributetable:: Attachment
+.. attributetable Attachment
 
-.. autoclass:: Attachment()
-    :members:
+.. autoclass Attachment()
+    members
 
 Asset
 ~~~~~
 
-.. attributetable:: Asset
+.. attributetable Asset
 
-.. autoclass:: Asset()
-    :members:
-    :inherited-members:
+.. autoclass Asset()
+    members
+    inherited-members
 
 Message
 ~~~~~~~
 
-.. attributetable:: Message
+.. attributetable Message
 
-.. autoclass:: Message()
-    :members:
+.. autoclass Message()
+    members
 
 Component
 ~~~~~~~~~~
 
-.. attributetable:: Component
+.. attributetable Component
 
-.. autoclass:: Component()
-    :members:
+.. autoclass Component()
+    members
 
 ActionRow
 ~~~~~~~~~~
 
-.. attributetable:: ActionRow
+.. attributetable ActionRow
 
-.. autoclass:: ActionRow()
-    :members:
+.. autoclass ActionRow()
+    members
 
 Button
 ~~~~~~~
 
-.. attributetable:: Button
+.. attributetable Button
 
-.. autoclass:: Button()
-    :members:
-    :inherited-members:
+.. autoclass Button()
+    members
+    inherited-members
 
 SelectMenu
 ~~~~~~~~~~~
 
-.. attributetable:: SelectMenu
+.. attributetable SelectMenu
 
-.. autoclass:: SelectMenu()
-    :members:
-    :inherited-members:
+.. autoclass SelectMenu()
+    members
+    inherited-members
 
 
 DeletedReferencedMessage
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. attributetable:: DeletedReferencedMessage
+.. attributetable DeletedReferencedMessage
 
-.. autoclass:: DeletedReferencedMessage()
-    :members:
+.. autoclass DeletedReferencedMessage()
+    members
 
 
 Reaction
 ~~~~~~~~~
 
-.. attributetable:: Reaction
+.. attributetable Reaction
 
-.. autoclass:: Reaction()
-    :members:
-    :exclude-members: users
+.. autoclass Reaction()
+    members
+    exclude-members users
 
-    .. automethod:: users
-        :async-for:
+    .. automethod users
+        async-for
 
 Guild
 ~~~~~~
 
-.. attributetable:: Guild
+.. attributetable Guild
 
-.. autoclass:: Guild()
-    :members:
-    :exclude-members: fetch_members, audit_logs
+.. autoclass Guild()
+    members
+    exclude-members fetch_members, audit_logs
 
-    .. automethod:: fetch_members
-        :async-for:
+    .. automethod fetch_members
+        async-for
 
-    .. automethod:: audit_logs
-        :async-for:
+    .. automethod audit_logs
+        async-for
 
-.. class:: BanEntry
+.. class BanEntry
 
-    A namedtuple which represents a ban returned from :meth:`~Guild.bans`.
+    A namedtuple which represents a ban returned from meth`~Guild.bans`.
 
-    .. attribute:: reason
+    .. attribute reason
 
         The reason this user was banned.
 
-        :type: Optional[:class:`str`]
-    .. attribute:: user
+        type Optional[class`str`]
+    .. attribute user
 
-        The :class:`User` that was banned.
+        The class`User` that was banned.
 
-        :type: :class:`User`
+        type class`User`
 
 
 Integration
 ~~~~~~~~~~~~
 
-.. autoclass:: Integration()
-    :members:
+.. autoclass Integration()
+    members
 
-.. autoclass:: IntegrationAccount()
-    :members:
+.. autoclass IntegrationAccount()
+    members
 
-.. autoclass:: BotIntegration()
-    :members:
+.. autoclass BotIntegration()
+    members
 
-.. autoclass:: IntegrationApplication()
-    :members:
+.. autoclass IntegrationApplication()
+    members
 
-.. autoclass:: StreamIntegration()
-    :members:
+.. autoclass StreamIntegration()
+    members
 
 Interaction
 ~~~~~~~~~~~~
 
-.. attributetable:: Interaction
+.. attributetable Interaction
 
-.. autoclass:: Interaction()
-    :members:
+.. autoclass Interaction()
+    members
 
 InteractionResponse
 ~~~~~~~~~~~~~~~~~~~~
 
-.. attributetable:: InteractionResponse
+.. attributetable InteractionResponse
 
-.. autoclass:: InteractionResponse()
-    :members:
+.. autoclass InteractionResponse()
+    members
 
 InteractionMessage
 ~~~~~~~~~~~~~~~~~~~
 
-.. attributetable:: InteractionMessage
+.. attributetable InteractionMessage
 
-.. autoclass:: InteractionMessage()
-    :members:
+.. autoclass InteractionMessage()
+    members
 
 Member
 ~~~~~~
 
-.. attributetable:: Member
+.. attributetable Member
 
-.. autoclass:: Member()
-    :members:
-    :inherited-members:
-    :exclude-members: history, typing
+.. autoclass Member()
+    members
+    inherited-members
+    exclude-members history, typing
 
-    .. automethod:: history
-        :async-for:
+    .. automethod history
+        async-for
 
-    .. automethod:: typing
-        :async-with:
+    .. automethod typing
+        async-with
 
 Spotify
 ~~~~~~~~
 
-.. attributetable:: Spotify
+.. attributetable Spotify
 
-.. autoclass:: Spotify()
-    :members:
+.. autoclass Spotify()
+    members
 
 VoiceState
 ~~~~~~~~~~~
 
-.. attributetable:: VoiceState
+.. attributetable VoiceState
 
-.. autoclass:: VoiceState()
-    :members:
+.. autoclass VoiceState()
+    members
 
 Emoji
 ~~~~~
 
-.. attributetable:: Emoji
+.. attributetable Emoji
 
-.. autoclass:: Emoji()
-    :members:
-    :inherited-members:
+.. autoclass Emoji()
+    members
+    inherited-members
 
 PartialEmoji
 ~~~~~~~~~~~~~~~~~~~~~~
 
-.. attributetable:: PartialEmoji
+.. attributetable PartialEmoji
 
-.. autoclass:: PartialEmoji()
-    :members:
-    :inherited-members:
+.. autoclass PartialEmoji()
+    members
+    inherited-members
 
 Role
 ~~~~~
 
-.. attributetable:: Role
+.. attributetable Role
 
-.. autoclass:: Role()
-    :members:
+.. autoclass Role()
+    members
 
 RoleTags
 ~~~~~~~~~~
 
-.. attributetable:: RoleTags
+.. attributetable RoleTags
 
-.. autoclass:: RoleTags()
-    :members:
+.. autoclass RoleTags()
+    members
 
 PartialMessageable
 ~~~~~~~~~~~~~~~~~~~~
 
-.. attributetable:: PartialMessageable
+.. attributetable PartialMessageable
 
-.. autoclass:: PartialMessageable()
-    :members:
-    :inherited-members:
+.. autoclass PartialMessageable()
+    members
+    inherited-members
 
 TextChannel
 ~~~~~~~~~~~~
 
-.. attributetable:: TextChannel
+.. attributetable TextChannel
 
-.. autoclass:: TextChannel()
-    :members:
-    :inherited-members:
-    :exclude-members: history, typing
+.. autoclass TextChannel()
+    members
+    inherited-members
+    exclude-members history, typing
 
-    .. automethod:: history
-        :async-for:
+    .. automethod history
+        async-for
 
-    .. automethod:: typing
-        :async-with:
+    .. automethod typing
+        async-with
 
 Thread
 ~~~~~~~~
 
-.. attributetable:: Thread
+.. attributetable Thread
 
-.. autoclass:: Thread()
-    :members:
-    :inherited-members:
-    :exclude-members: history, typing
+.. autoclass Thread()
+    members
+    inherited-members
+    exclude-members history, typing
 
-    .. automethod:: history
-        :async-for:
+    .. automethod history
+        async-for
 
-    .. automethod:: typing
-        :async-with:
+    .. automethod typing
+        async-with
 
 ThreadMember
 ~~~~~~~~~~~~~
 
-.. attributetable:: ThreadMember
+.. attributetable ThreadMember
 
-.. autoclass:: ThreadMember()
-    :members:
+.. autoclass ThreadMember()
+    members
 
 StoreChannel
 ~~~~~~~~~~~~~
 
-.. attributetable:: StoreChannel
+.. attributetable StoreChannel
 
-.. autoclass:: StoreChannel()
-    :members:
-    :inherited-members:
+.. autoclass StoreChannel()
+    members
+    inherited-members
 
 VoiceChannel
 ~~~~~~~~~~~~~
 
-.. attributetable:: VoiceChannel
+.. attributetable VoiceChannel
 
-.. autoclass:: VoiceChannel()
-    :members:
-    :inherited-members:
+.. autoclass VoiceChannel()
+    members
+    inherited-members
 
 StageChannel
 ~~~~~~~~~~~~~
 
-.. attributetable:: StageChannel
+.. attributetable StageChannel
 
-.. autoclass:: StageChannel()
-    :members:
-    :inherited-members:
+.. autoclass StageChannel()
+    members
+    inherited-members
 
 
 StageInstance
 ~~~~~~~~~~~~~~
 
-.. attributetable:: StageInstance
+.. attributetable StageInstance
 
-.. autoclass:: StageInstance()
-    :members:
+.. autoclass StageInstance()
+    members
 
 CategoryChannel
 ~~~~~~~~~~~~~~~~~
 
-.. attributetable:: CategoryChannel
+.. attributetable CategoryChannel
 
-.. autoclass:: CategoryChannel()
-    :members:
-    :inherited-members:
+.. autoclass CategoryChannel()
+    members
+    inherited-members
 
 DMChannel
 ~~~~~~~~~
 
-.. attributetable:: DMChannel
+.. attributetable DMChannel
 
-.. autoclass:: DMChannel()
-    :members:
-    :inherited-members:
-    :exclude-members: history, typing
+.. autoclass DMChannel()
+    members
+    inherited-members
+    exclude-members history, typing
 
-    .. automethod:: history
-        :async-for:
+    .. automethod history
+        async-for
 
-    .. automethod:: typing
-        :async-with:
+    .. automethod typing
+        async-with
 
 GroupChannel
 ~~~~~~~~~~~~
 
-.. attributetable:: GroupChannel
+.. attributetable GroupChannel
 
-.. autoclass:: GroupChannel()
-    :members:
-    :inherited-members:
-    :exclude-members: history, typing
+.. autoclass GroupChannel()
+    members
+    inherited-members
+    exclude-members history, typing
 
-    .. automethod:: history
-        :async-for:
+    .. automethod history
+        async-for
 
-    .. automethod:: typing
-        :async-with:
+    .. automethod typing
+        async-with
 
 PartialInviteGuild
 ~~~~~~~~~~~~~~~~~~~
 
-.. attributetable:: PartialInviteGuild
+.. attributetable PartialInviteGuild
 
-.. autoclass:: PartialInviteGuild()
-    :members:
+.. autoclass PartialInviteGuild()
+    members
 
 PartialInviteChannel
 ~~~~~~~~~~~~~~~~~~~~~
 
-.. attributetable:: PartialInviteChannel
+.. attributetable PartialInviteChannel
 
-.. autoclass:: PartialInviteChannel()
-    :members:
+.. autoclass PartialInviteChannel()
+    members
 
 Invite
 ~~~~~~~
 
-.. attributetable:: Invite
+.. attributetable Invite
 
-.. autoclass:: Invite()
-    :members:
+.. autoclass Invite()
+    members
 
 Template
 ~~~~~~~~~
 
-.. attributetable:: Template
+.. attributetable Template
 
-.. autoclass:: Template()
-    :members:
+.. autoclass Template()
+    members
 
 WelcomeScreen
 ~~~~~~~~~~~~~~~
 
-.. attributetable:: WelcomeScreen
+.. attributetable WelcomeScreen
 
-.. autoclass:: WelcomeScreen()
-    :members:
+.. autoclass WelcomeScreen()
+    members
 
 WelcomeChannel
 ~~~~~~~~~~~~~~~
 
-.. attributetable:: WelcomeChannel
+.. attributetable WelcomeChannel
 
-.. autoclass:: WelcomeChannel()
-    :members:
+.. autoclass WelcomeChannel()
+    members
 
 WidgetChannel
 ~~~~~~~~~~~~~~~
 
-.. attributetable:: WidgetChannel
+.. attributetable WidgetChannel
 
-.. autoclass:: WidgetChannel()
-    :members:
+.. autoclass WidgetChannel()
+    members
 
 WidgetMember
 ~~~~~~~~~~~~~
 
-.. attributetable:: WidgetMember
+.. attributetable WidgetMember
 
-.. autoclass:: WidgetMember()
-    :members:
-    :inherited-members:
+.. autoclass WidgetMember()
+    members
+    inherited-members
 
 Widget
 ~~~~~~~
 
-.. attributetable:: Widget
+.. attributetable Widget
 
-.. autoclass:: Widget()
-    :members:
+.. autoclass Widget()
+    members
 
 StickerPack
 ~~~~~~~~~~~~~
 
-.. attributetable:: StickerPack
+.. attributetable StickerPack
 
-.. autoclass:: StickerPack()
-    :members:
+.. autoclass StickerPack()
+    members
 
 StickerItem
 ~~~~~~~~~~~~~
 
-.. attributetable:: StickerItem
+.. attributetable StickerItem
 
-.. autoclass:: StickerItem()
-    :members:
+.. autoclass StickerItem()
+    members
 
 Sticker
 ~~~~~~~~~~~~~~~
 
-.. attributetable:: Sticker
+.. attributetable Sticker
 
-.. autoclass:: Sticker()
-    :members:
+.. autoclass Sticker()
+    members
 
 StandardSticker
 ~~~~~~~~~~~~~~~~
 
-.. attributetable:: StandardSticker
+.. attributetable StandardSticker
 
-.. autoclass:: StandardSticker()
-    :members:
+.. autoclass StandardSticker()
+    members
 
 GuildSticker
 ~~~~~~~~~~~~~
 
-.. attributetable:: GuildSticker
+.. attributetable GuildSticker
 
-.. autoclass:: GuildSticker()
-    :members:
+.. autoclass GuildSticker()
+    members
 
 RawMessageDeleteEvent
 ~~~~~~~~~~~~~~~~~~~~~~~
 
-.. attributetable:: RawMessageDeleteEvent
+.. attributetable RawMessageDeleteEvent
 
-.. autoclass:: RawMessageDeleteEvent()
-    :members:
+.. autoclass RawMessageDeleteEvent()
+    members
 
 RawBulkMessageDeleteEvent
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. attributetable:: RawBulkMessageDeleteEvent
+.. attributetable RawBulkMessageDeleteEvent
 
-.. autoclass:: RawBulkMessageDeleteEvent()
-    :members:
+.. autoclass RawBulkMessageDeleteEvent()
+    members
 
 RawMessageUpdateEvent
 ~~~~~~~~~~~~~~~~~~~~~~
 
-.. attributetable:: RawMessageUpdateEvent
+.. attributetable RawMessageUpdateEvent
 
-.. autoclass:: RawMessageUpdateEvent()
-    :members:
+.. autoclass RawMessageUpdateEvent()
+    members
 
 RawReactionActionEvent
 ~~~~~~~~~~~~~~~~~~~~~~~
 
-.. attributetable:: RawReactionActionEvent
+.. attributetable RawReactionActionEvent
 
-.. autoclass:: RawReactionActionEvent()
-    :members:
+.. autoclass RawReactionActionEvent()
+    members
 
 RawReactionClearEvent
 ~~~~~~~~~~~~~~~~~~~~~~
 
-.. attributetable:: RawReactionClearEvent
+.. attributetable RawReactionClearEvent
 
-.. autoclass:: RawReactionClearEvent()
-    :members:
+.. autoclass RawReactionClearEvent()
+    members
 
 RawReactionClearEmojiEvent
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. attributetable:: RawReactionClearEmojiEvent
+.. attributetable RawReactionClearEmojiEvent
 
-.. autoclass:: RawReactionClearEmojiEvent()
-    :members:
+.. autoclass RawReactionClearEmojiEvent()
+    members
 
 RawIntegrationDeleteEvent
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. attributetable:: RawIntegrationDeleteEvent
+.. attributetable RawIntegrationDeleteEvent
 
-.. autoclass:: RawIntegrationDeleteEvent()
-    :members:
+.. autoclass RawIntegrationDeleteEvent()
+    members
 
 PartialWebhookGuild
 ~~~~~~~~~~~~~~~~~~~~
 
-.. attributetable:: PartialWebhookGuild
+.. attributetable PartialWebhookGuild
 
-.. autoclass:: PartialWebhookGuild()
-    :members:
+.. autoclass PartialWebhookGuild()
+    members
 
 PartialWebhookChannel
 ~~~~~~~~~~~~~~~~~~~~~~~
 
-.. attributetable:: PartialWebhookChannel
+.. attributetable PartialWebhookChannel
 
-.. autoclass:: PartialWebhookChannel()
-    :members:
+.. autoclass PartialWebhookChannel()
+    members
 
-.. _discord_api_data:
+.. _discord_api_data
 
 Data Classes
 --------------
 
 Some classes are just there to be data containers, this lists them.
 
-Unlike :ref:`models <discord_api_models>` you are allowed to create
+Unlike ref`models <discord_api_models>` you are allowed to create
 most of these yourself, even if they can also be used to hold attributes.
 
-Nearly all classes here have :ref:`py:slots` defined which means that it is
+Nearly all classes here have ref`pyslots` defined which means that it is
 impossible to have dynamic attributes to the data classes.
 
-The only exception to this rule is :class:`Object`, which is made with
+The only exception to this rule is class`Object`, which is made with
 dynamic attributes in mind.
 
 
 Object
 ~~~~~~~
 
-.. attributetable:: Object
+.. attributetable Object
 
-.. autoclass:: Object
-    :members:
+.. autoclass Object
+    members
 
 Embed
 ~~~~~~
 
-.. attributetable:: Embed
+.. attributetable Embed
 
-.. autoclass:: Embed
-    :members:
+.. autoclass Embed
+    members
 
 AllowedMentions
 ~~~~~~~~~~~~~~~~~
 
-.. attributetable:: AllowedMentions
+.. attributetable AllowedMentions
 
-.. autoclass:: AllowedMentions
-    :members:
+.. autoclass AllowedMentions
+    members
 
 MessageReference
 ~~~~~~~~~~~~~~~~~
 
-.. attributetable:: MessageReference
+.. attributetable MessageReference
 
-.. autoclass:: MessageReference
-    :members:
+.. autoclass MessageReference
+    members
 
 PartialMessage
 ~~~~~~~~~~~~~~~~~
 
-.. attributetable:: PartialMessage
+.. attributetable PartialMessage
 
-.. autoclass:: PartialMessage
-    :members:
+.. autoclass PartialMessage
+    members
 
 SelectOption
 ~~~~~~~~~~~~~
 
-.. attributetable:: SelectOption
+.. attributetable SelectOption
 
-.. autoclass:: SelectOption
-    :members:
+.. autoclass SelectOption
+    members
 
 Intents
 ~~~~~~~~~~
 
-.. attributetable:: Intents
+.. attributetable Intents
 
-.. autoclass:: Intents
-    :members:
+.. autoclass Intents
+    members
 
 MemberCacheFlags
 ~~~~~~~~~~~~~~~~~~
 
-.. attributetable:: MemberCacheFlags
+.. attributetable MemberCacheFlags
 
-.. autoclass:: MemberCacheFlags
-    :members:
+.. autoclass MemberCacheFlags
+    members
 
 ApplicationFlags
 ~~~~~~~~~~~~~~~~~
 
-.. attributetable:: ApplicationFlags
+.. attributetable ApplicationFlags
 
-.. autoclass:: ApplicationFlags
-    :members:
+.. autoclass ApplicationFlags
+    members
 
 File
 ~~~~~
 
-.. attributetable:: File
+.. attributetable File
 
-.. autoclass:: File
-    :members:
+.. autoclass File
+    members
 
 Colour
 ~~~~~~
 
-.. attributetable:: Colour
+.. attributetable Colour
 
-.. autoclass:: Colour
-    :members:
+.. autoclass Colour
+    members
 
 BaseActivity
 ~~~~~~~~~~~~~~
 
-.. attributetable:: BaseActivity
+.. attributetable BaseActivity
 
-.. autoclass:: BaseActivity
-    :members:
+.. autoclass BaseActivity
+    members
 
 Activity
 ~~~~~~~~~
 
-.. attributetable:: Activity
+.. attributetable Activity
 
-.. autoclass:: Activity
-    :members:
+.. autoclass Activity
+    members
 
 Game
 ~~~~~
 
-.. attributetable:: Game
+.. attributetable Game
 
-.. autoclass:: Game
-    :members:
+.. autoclass Game
+    members
 
 Streaming
 ~~~~~~~~~~~
 
-.. attributetable:: Streaming
+.. attributetable Streaming
 
-.. autoclass:: Streaming
-    :members:
+.. autoclass Streaming
+    members
 
 CustomActivity
 ~~~~~~~~~~~~~~~
 
-.. attributetable:: CustomActivity
+.. attributetable CustomActivity
 
-.. autoclass:: CustomActivity
-    :members:
+.. autoclass CustomActivity
+    members
 
 Permissions
 ~~~~~~~~~~~~
 
-.. attributetable:: Permissions
+.. attributetable Permissions
 
-.. autoclass:: Permissions
-    :members:
+.. autoclass Permissions
+    members
 
 PermissionOverwrite
 ~~~~~~~~~~~~~~~~~~~~
 
-.. attributetable:: PermissionOverwrite
+.. attributetable PermissionOverwrite
 
-.. autoclass:: PermissionOverwrite
-    :members:
+.. autoclass PermissionOverwrite
+    members
 
 ShardInfo
 ~~~~~~~~~~~
 
-.. attributetable:: ShardInfo
+.. attributetable ShardInfo
 
-.. autoclass:: ShardInfo()
-    :members:
+.. autoclass ShardInfo()
+    members
 
 SystemChannelFlags
 ~~~~~~~~~~~~~~~~~~~~
 
-.. attributetable:: SystemChannelFlags
+.. attributetable SystemChannelFlags
 
-.. autoclass:: SystemChannelFlags()
-    :members:
+.. autoclass SystemChannelFlags()
+    members
 
 MessageFlags
 ~~~~~~~~~~~~
 
-.. attributetable:: MessageFlags
+.. attributetable MessageFlags
 
-.. autoclass:: MessageFlags()
-    :members:
+.. autoclass MessageFlags()
+    members
 
 PublicUserFlags
 ~~~~~~~~~~~~~~~
 
-.. attributetable:: PublicUserFlags
+.. attributetable PublicUserFlags
 
-.. autoclass:: PublicUserFlags()
-    :members:
+.. autoclass PublicUserFlags()
+    members
 
-.. _discord_ui_kit:
+.. _discord_ui_kit
 
 Bot UI Kit
 -------------
@@ -4137,40 +4137,40 @@ The library has helpers to help create component-based UIs.
 View
 ~~~~~~~
 
-.. attributetable:: nextcord.ui.View
+.. attributetable nextcord.ui.View
 
-.. autoclass:: nextcord.ui.View
-    :members:
+.. autoclass nextcord.ui.View
+    members
 
 Item
 ~~~~~~~
 
-.. attributetable:: nextcord.ui.Item
+.. attributetable nextcord.ui.Item
 
-.. autoclass:: nextcord.ui.Item
-    :members:
+.. autoclass nextcord.ui.Item
+    members
 
 Button
 ~~~~~~~
 
-.. attributetable:: nextcord.ui.Button
+.. attributetable nextcord.ui.Button
 
-.. autoclass:: nextcord.ui.Button
-    :members:
-    :inherited-members:
+.. autoclass nextcord.ui.Button
+    members
+    inherited-members
 
-.. autofunction:: nextcord.ui.button
+.. autofunction nextcord.ui.button
 
 Select
 ~~~~~~~
 
-.. attributetable:: nextcord.ui.Select
+.. attributetable nextcord.ui.Select
 
-.. autoclass:: nextcord.ui.Select
-    :members:
-    :inherited-members:
+.. autoclass nextcord.ui.Select
+    members
+    inherited-members
 
-.. autofunction:: nextcord.ui.select
+.. autofunction nextcord.ui.select
 
 
 Exceptions
@@ -4178,56 +4178,56 @@ Exceptions
 
 The following exceptions are thrown by the library.
 
-.. autoexception:: DiscordException
+.. autoexception DiscordException
 
-.. autoexception:: ClientException
+.. autoexception ClientException
 
-.. autoexception:: LoginFailure
+.. autoexception LoginFailure
 
-.. autoexception:: NoMoreItems
+.. autoexception NoMoreItems
 
-.. autoexception:: HTTPException
-    :members:
+.. autoexception HTTPException
+    members
 
-.. autoexception:: Forbidden
+.. autoexception Forbidden
 
-.. autoexception:: NotFound
+.. autoexception NotFound
 
-.. autoexception:: DiscordServerError
+.. autoexception DiscordServerError
 
-.. autoexception:: InvalidData
+.. autoexception InvalidData
 
-.. autoexception:: InvalidArgument
+.. autoexception InvalidArgument
 
-.. autoexception:: GatewayNotFound
+.. autoexception GatewayNotFound
 
-.. autoexception:: ConnectionClosed
+.. autoexception ConnectionClosed
 
-.. autoexception:: PrivilegedIntentsRequired
+.. autoexception PrivilegedIntentsRequired
 
-.. autoexception:: InteractionResponded
+.. autoexception InteractionResponded
 
-.. autoexception:: nextcord.opus.OpusError
+.. autoexception nextcord.opus.OpusError
 
-.. autoexception:: nextcord.opus.OpusNotLoaded
+.. autoexception nextcord.opus.OpusNotLoaded
 
 Exception Hierarchy
 ~~~~~~~~~~~~~~~~~~~~~
 
-.. exception_hierarchy::
+.. exception_hierarchy
 
-    - :exc:`Exception`
-        - :exc:`DiscordException`
-            - :exc:`ClientException`
-                - :exc:`InvalidData`
-                - :exc:`InvalidArgument`
-                - :exc:`LoginFailure`
-                - :exc:`ConnectionClosed`
-                - :exc:`PrivilegedIntentsRequired`
-                - :exc:`InteractionResponded`
-            - :exc:`NoMoreItems`
-            - :exc:`GatewayNotFound`
-            - :exc:`HTTPException`
-                - :exc:`Forbidden`
-                - :exc:`NotFound`
-                - :exc:`DiscordServerError`
+    - exc`Exception`
+        - exc`DiscordException`
+            - exc`ClientException`
+                - exc`InvalidData`
+                - exc`InvalidArgument`
+                - exc`LoginFailure`
+                - exc`ConnectionClosed`
+                - exc`PrivilegedIntentsRequired`
+                - exc`InteractionResponded`
+            - exc`NoMoreItems`
+            - exc`GatewayNotFound`
+            - exc`HTTPException`
+                - exc`Forbidden`
+                - exc`NotFound`
+                - exc`DiscordServerError`

--- a/docs/discord.rst
+++ b/docs/discord.rst
@@ -5,7 +5,7 @@
 Creating a Bot Account
 ========================
 
-In order to work with the library and the Discord API in general, we must first create a Discord Bot account.
+To work with the library and the Discord API in general, we must first create a Discord Bot account.
 
 Creating a Bot account is a pretty straightforward process.
 
@@ -50,9 +50,9 @@ Creating a Bot account is a pretty straightforward process.
 
         If you accidentally leaked your token, click the "Regenerate" button as soon
         as possible. This revokes your old token and re-generates a new one.
-        Now you need to use the new token to login.
+        Now you need to use the new token to log in.
 
-And that's it. You now have a bot account and you can login with that token.
+And that's it. You now have a bot account and you can log in with that token.
 
 .. _discord_invite_bot:
 

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -35,8 +35,8 @@ You can only use ``await`` inside ``async def`` functions and nowhere else.
 What does "blocking" mean?
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-In asynchronous programming a blocking call is essentially all the parts of the function that are not ``await``. Do not
-despair however, because not all forms of blocking are bad! Using blocking calls is inevitable, but you must work to make
+In asynchronous programming, a blocking call is essentially all the parts of the function that are not ``await``. Do not
+despair, however, because not all forms of blocking are bad! Using blocking calls is inevitable, but you must work to make
 sure that you don't excessively block functions. Remember, if you block for too long then your bot will freeze since it has
 not stopped the function's execution at that point to do other things.
 
@@ -236,7 +236,7 @@ technically in another thread, we must take caution in calling thread-safe opera
 us, :mod:`asyncio` comes with a :func:`asyncio.run_coroutine_threadsafe` function that allows us to call
 a coroutine from another thread.
 
-However, this function returns a :class:`~concurrent.futures.Future` and to actually call it we have to fetch its result. Putting all of
+However, this function returns a :class:`~concurrent.futures.Future` and to call it we have to fetch its result. Putting all of
 this together we can do the following: ::
 
     def my_after(error):

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -17,7 +17,7 @@ for Discord, forked from discord.py.
 - Modern Pythonic API using ``async``\/``await`` syntax
 - Sane rate limit handling that prevents 429s
 - Command extension to aid with bot creation
-- Easy to use with an object oriented design
+- Easy to use with an object-oriented design
 - Optimised for both speed and memory
 
 Getting started

--- a/docs/intents.rst
+++ b/docs/intents.rst
@@ -7,7 +7,7 @@
 A Primer to Gateway Intents
 =============================
 
-In version 1.5 comes the introduction of :class:`Intents`. This is a radical change in how bots are written. An intent basically allows a bot to subscribe to specific buckets of events. The events that correspond to each intent is documented in the individual attribute of the :class:`Intents` documentation.
+In version 1.5 comes the introduction of :class:`Intents`. This is a radical change in how bots are written. Put simply, an intent allows a bot to subscribe to specific buckets of events. The events that correspond to each intent are documented in the individual attribute of the :class:`Intents` documentation.
 
 These intents are passed to the constructor of :class:`Client` or its subclasses (:class:`AutoShardedClient`, :class:`~.AutoShardedBot`, :class:`~.Bot`) with the ``intents`` argument.
 
@@ -59,7 +59,7 @@ Privileged Intents
 
 With the API change requiring bot authors to specify intents, some intents were restricted further and require more manual steps. These intents are called **privileged intents**.
 
-A privileged intent is one that requires you to go to the developer portal and manually enable it. To enable privileged intents do the following:
+A privileged intent is an intent that requires you to go to the developer portal and manually enable it. To enable privileged intents, do the following:
 
 1. Make sure you're logged on to the `Discord website <https://discord.com>`_.
 2. Navigate to the `application page <https://discord.com/developers/applications>`_.
@@ -112,7 +112,7 @@ Member Intent
 Member Cache
 -------------
 
-Along with intents, Discord now further restricts the ability to cache members and expects bot authors to cache as little as is necessary. However, to properly maintain a cache the :attr:`Intents.members` intent is required in order to track the members who left and properly evict them.
+Along with intents, Discord now further restricts the ability to cache members and expects bot authors to cache as little as is necessary. However, to properly maintain a cache the :attr:`Intents.members` intent is required to track the members who left and properly evict them.
 
 To aid with member cache where we don't need members to be cached, the library now has a :class:`MemberCacheFlags` flag to control the member cache. The documentation page for the class goes over the specific policies that are possible.
 
@@ -155,7 +155,7 @@ Some common issues relating to the mandatory intent change.
 Where'd my members go?
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
-Due to an :ref:`API change <intents_member_cache>` Discord is now forcing developers who want member caching to explicitly opt-in to it. This is a Discord mandated change and there is no way to bypass it. In order to get members back you have to explicitly enable the :ref:`members privileged intent <privileged_intents>` and change the :attr:`Intents.members` attribute to true.
+Due to an :ref:`API change <intents_member_cache>` Discord is now forcing developers who want member caching to explicitly opt-in to it. This is a Discord mandated change and there is no way to bypass it. To get members back, you have to explicitly enable the :ref:`members privileged intent <privileged_intents>` and change the :attr:`Intents.members` attribute to true.
 
 For example:
 
@@ -185,7 +185,7 @@ The second solution is to disable member chunking by setting ``chunk_guilds_at_s
 
 To illustrate the slowdown caused by the API change, take a bot who is in 840 guilds and 95 of these guilds are "large" (over 250 members).
 
-Under the original system this would result in 2 requests to fetch the member list (75 guilds, 20 guilds) roughly taking 60 seconds. With :attr:`Intents.members` but not :attr:`Intents.presences` this requires 840 requests, with a rate limit of 120 requests per 60 seconds means that due to waiting for the rate limit it totals to around 7 minutes of waiting for the rate limit to fetch all the members. With both :attr:`Intents.members` and :attr:`Intents.presences` we mostly get the old behaviour so we're only required to request for the 95 guilds that are large, this is slightly less than our rate limit so it's close to the original timing to fetch the member list.
+Under the original system, this would result in 2 requests to fetch the member list (75 guilds, 20 guilds) roughly taking 60 seconds. With :attr:`Intents.members` but not :attr:`Intents.presences` this requires 840 requests, with a rate limit of 120 requests per 60 seconds means that due to waiting for the rate limit it totals to around 7 minutes of waiting for the rate limit to fetch all the members. With both :attr:`Intents.members` and :attr:`Intents.presences` we mostly get the old behaviour so we're only required to request for the 95 large guilds, this is slightly less than our rate limit so it's close to the original timing to fetch the member list.
 
 Unfortunately due to this change being required from Discord there is nothing that the library can do to mitigate this.
 

--- a/docs/intro.rst
+++ b/docs/intro.rst
@@ -53,7 +53,7 @@ Virtual Environments
 ~~~~~~~~~~~~~~~~~~~~~
 
 Sometimes you want to keep libraries from polluting system installs or use a different version of
-libraries than the ones installed on the system. You might also not have permissions to install libraries system-wide.
+libraries than the ones installed on the system. You might also not have permission to install libraries system-wide.
 For this purpose, the standard library as of Python 3.3 comes with a concept called "Virtual Environment"s to
 help maintain these separate versions.
 

--- a/docs/migrating.rst
+++ b/docs/migrating.rst
@@ -8,10 +8,10 @@ Migrating to v1.0
 v1.0 is one of the biggest breaking changes in the library due to a complete
 redesign.
 
-The amount of changes are so massive and long that for all intents and purposes, it is a completely
+The number of changes is so massive and long that for all intents and purposes, it is a completely
 new library.
 
-Part of the redesign involves making things more easy to use and natural. Things are done on the
+Part of the redesign involves making things easier to use and natural. Things are done on the
 :ref:`models <discord_api_models>` instead of requiring a :class:`Client` instance to do any work.
 
 Python Version Change
@@ -384,7 +384,7 @@ They will be enumerated here.
 - :attr:`Member.avatar_url` and :attr:`User.avatar_url` now return the default avatar if a custom one is not set.
 - :attr:`Message.embeds` is now a list of :class:`Embed` instead of :class:`dict` objects.
 - :attr:`Message.attachments` is now a list of :class:`Attachment` instead of :class:`dict` object.
-- :attr:`Guild.roles` is now sorted through hierarchy. The first element is always the ``@everyone`` role.
+- :attr:`Guild.roles` is now sorted through a hierarchy. The first element is always the ``@everyone`` role.
 
 **Added**
 
@@ -407,7 +407,7 @@ They will be enumerated here.
 - :meth:`Guild.vanity_invite` to fetch the guild's vanity invite.
 - :meth:`Guild.audit_logs` to fetch the guild's audit logs.
 - :attr:`Message.webhook_id` to fetch the message's webhook ID.
-- :attr:`Message.activity` and :attr:`Message.application` for Rich Presence related information.
+- :attr:`Message.activity` and :attr:`Message.application` for Rich Presence-related information.
 - :meth:`TextChannel.is_nsfw` to check if a text channel is NSFW.
 - :meth:`Colour.from_rgb` to construct a :class:`Colour` from RGB tuple.
 - :meth:`Guild.get_role` to get a role by its ID.
@@ -433,7 +433,7 @@ This supports everything that the old ``send_message`` supported such as embeds:
     e = nextcord.Embed(title='foo')
     await channel.send('Hello', embed=e)
 
-There is a caveat with sending files however, as this functionality was expanded to support multiple
+There is a caveat with sending files, however, as this functionality was expanded to support multiple
 file attachments, you must now use a :class:`File` pseudo-namedtuple to upload a single file. ::
 
     # before
@@ -703,7 +703,7 @@ Upgraded Dependencies
 
 Following v1.0 of the library, we've updated our requirements to :doc:`aiohttp <aio:index>` v2.0 or higher.
 
-Since this is a backwards incompatible change, it is recommended that you see the
+Since this is a backward-incompatible change, it is recommended that you see the
 `changes <http://aiohttp.readthedocs.io/en/stable/changes.html#rc1-2017-03-15>`_
 and the :doc:`aio:migration_to_2xx` pages for details on the breaking changes in
 :doc:`aiohttp <aio:index>`.
@@ -767,7 +767,7 @@ In v1.0, the auto reconnection logic has been powered up significantly.
 the reconnect logic. When enabled, the client will automatically reconnect in all instances of your internet going
 offline or Discord going offline with exponential back-off.
 
-:meth:`Client.run` and :meth:`Client.start` gains this keyword argument as well, but for most cases you will not
+:meth:`Client.run` and :meth:`Client.start` gains this keyword argument as well, but for most cases, you will not
 need to specify it unless turning it off.
 
 .. _migrating_1_0_commands:
@@ -848,7 +848,7 @@ Then you can use :meth:`~ext.commands.Bot.get_context` inside :func:`on_message`
             ctx = await self.get_context(message, cls=MyContext)
             await self.invoke(ctx)
 
-Now inside your commands you will have access to your custom context:
+Now inside your commands, you will have access to your custom context:
 
 .. code-block:: python3
 
@@ -861,7 +861,7 @@ Now inside your commands you will have access to your custom context:
 Removed Helpers
 +++++++++++++++++
 
-With the new :class:`.Context` changes, a lot of message sending helpers have been removed.
+With the new :class:`.Context` changes, a lot of message-sending helpers have been removed.
 
 For a full list of changes, see below:
 
@@ -908,7 +908,7 @@ Check Changes
 
 Prior to v1.0, :func:`~ext.commands.check`\s could only be synchronous. As of v1.0 checks can now be coroutines.
 
-Along with this change, a couple new checks were added.
+Along with this change, a couple of new checks were added.
 
 - :func:`~ext.commands.guild_only` replaces the old ``no_pm=True`` functionality.
 - :func:`~ext.commands.is_owner` uses the :meth:`Client.application_info` endpoint by default to fetch owner ID.
@@ -916,7 +916,7 @@ Along with this change, a couple new checks were added.
     - This is actually powered by a different function, :meth:`~ext.commands.Bot.is_owner`.
     - You can set the owner ID yourself by setting :attr:`.Bot.owner_id`.
 
-- :func:`~ext.commands.is_nsfw` checks if the channel the command is in is a NSFW channel.
+- :func:`~ext.commands.is_nsfw` checks if the channel the command is in is an NSFW channel.
 
     - This is powered by the new :meth:`TextChannel.is_nsfw` method.
 
@@ -938,7 +938,7 @@ After: ::
     on_command_error(ctx, error)
 
 The extraneous ``command`` parameter in :func:`.on_command` and :func:`.on_command_completion`
-have been removed. The :class:`~ext.commands.Command` instance was not kept up-to date so it was incorrect. In order to get
+have been removed. The :class:`~ext.commands.Command` instance was not kept up-to-date so it was incorrect. In order to get
 the up to date :class:`~ext.commands.Command` instance, use the :attr:`.Context.command`
 attribute.
 
@@ -1009,7 +1009,7 @@ Cog Changes
 
 Cogs have completely been revamped. They are documented in :ref:`ext_commands_cogs` as well.
 
-Cogs are now required to have a base class, :class:`~.commands.Cog` for future proofing purposes. This comes with special methods to customise some behaviour.
+Cogs are now required to have a base class, :class:`~.commands.Cog` for future-proofing purposes. This comes with special methods to customise some behaviour.
 
 * :meth:`.Cog.cog_unload`
     - This is called when a cog needs to do some cleanup, such as cancelling a task.
@@ -1026,7 +1026,7 @@ Cogs are now required to have a base class, :class:`~.commands.Cog` for future p
 
 Those that were using listeners, such as ``on_message`` inside a cog will now have to explicitly mark them as such using the :meth:`.commands.Cog.listener` decorator.
 
-Along with that, cogs have gained the ability to have custom names through specifying it in the class definition line. More options can be found in the metaclass that facilitates all this, :class:`.commands.CogMeta`.
+Along with that, cogs have gained the ability to have custom names by specifying them in the class definition line. More options can be found in the metaclass that facilitates all this, :class:`.commands.CogMeta`.
 
 An example cog with every special method registered and a custom name is as follows:
 
@@ -1090,7 +1090,7 @@ Basically: ::
         pass
 
 The after invocation is hook always called, **regardless of an error in the command**. This makes it ideal for some error
-handling or clean up of certain resources such a database connection.
+handling or clean up of certain resources such as a database connection.
 
 The per-command registration is as follows: ::
 
@@ -1162,7 +1162,7 @@ After: ::
         async def convert(self, ctx, argument):
             return ctx.me
 
-The command framework also got a couple new converters:
+The command framework also got a couple of new converters:
 
 - :class:`~ext.commands.clean_content` this is akin to :attr:`Message.clean_content` which scrubs mentions.
 - :class:`~ext.commands.UserConverter` will now appropriately convert :class:`User` only.

--- a/docs/migrating_2.rst
+++ b/docs/migrating_2.rst
@@ -35,6 +35,6 @@ Meta Change
 | 106k guilds (without chunking)| 3300s                            | 3090s                            |
 +-------------------------------+----------------------------------+----------------------------------+
 
-- The public API should be completly typehinted
-- Almost all ``edit`` methods now return their updated counterpart rather than doing an in-place edit.
+- The public API should be completely type-hinted
+- Almost all ``edit`` methods now return their updated counterpart rather than doing an in-place edit
 

--- a/docs/migrating_to_async.rst
+++ b/docs/migrating_to_async.rst
@@ -58,7 +58,7 @@ for easier registration. For example:
         pass
 
 
-Be aware however, that this is still a coroutine and your other functions that are coroutines must
+Be aware, however, that this is still a coroutine and your other functions that are coroutines must
 be decorated with ``@asyncio.coroutine`` or be ``async def``.
 
 Event Changes
@@ -143,7 +143,7 @@ Some examples of previously valid behaviour that is now invalid
         # do something
 
 Since they are no longer :obj:`list`\s, they no longer support indexing or any operation other than iterating.
-In order to get the old behaviour you should explicitly cast it to a list.
+In order to get the old behaviour, you should explicitly cast it to a list.
 
 .. code-block:: python3
 
@@ -161,7 +161,7 @@ Enumerations
 Due to dropping support for versions lower than Python 3.4.2, the library can now use
 :doc:`py:library/enum` in places where it makes sense.
 
-The common places where this was changed was in the server region, member status, and channel type.
+The common places where this was changed were in the server region, member status, and channel type.
 
 Before:
 
@@ -180,7 +180,7 @@ After:
     channel.type == nextcord.ChannelType.text
 
 The main reason for this change was to reduce the use of finicky strings in the API as this
-could give users a false sense of power. More information can be found in the :ref:`discord-api-enums` page.
+could give users a false sense of power. More information can be found on the :ref:`discord-api-enums` page.
 
 Properties
 -----------
@@ -247,7 +247,7 @@ Forced Keyword Arguments
 -------------------------
 
 Since 3.0+ of Python, we can now force questions to take in forced keyword arguments. A keyword argument is when you
-explicitly specify the name of the variable and assign to it, for example: ``foo(name='test')``. Due to this support,
+explicitly specify the name of the variable and assign it, for example: ``foo(name='test')``. Due to this support,
 some functions in the library were changed to force things to take said keyword arguments. This is to reduce errors of
 knowing the argument order and the issues that could arise from them.
 
@@ -262,7 +262,7 @@ The following parameters are now exclusively keyword arguments:
     - ``allow``
     - ``deny``
 
-In the documentation you can tell if a function parameter is a forced keyword argument if it is after ``\*,``
+In the documentation, you can tell if a function parameter is a forced keyword argument if it is after ``\*,``
 in the function signature.
 
 .. _migrating-running:
@@ -289,7 +289,7 @@ After:
 
 .. warning::
 
-    Like in the older ``Client.run`` function, the newer one must be the one of
+    Like in the older ``Client.run`` function, the newer one must be one of
     the last functions to call. This is because the function is **blocking**. Registering
     events or doing anything after :meth:`Client.run` will not execute until the function
     returns.

--- a/docs/migrating_to_nextcord.rst
+++ b/docs/migrating_to_nextcord.rst
@@ -5,6 +5,6 @@
 Migrating to nextcord
 ======================
 
-Due to the `original discord.py repository <https://github.com/Rapptz/discord.py>`_ going to read only we decided
+Due to the `original discord.py repository <https://github.com/Rapptz/discord.py>`_ becoming read-only, we decided
 that it would be necessary to fork it and keep on developing further. We also wanted to change the name and voted on
-nextcord, in order of properly registering at pypi.
+nextcord in order to properly register it at pypi.

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -40,7 +40,7 @@ It looks something like this:
 Let's name this file ``example_bot.py``. Make sure not to name it ``nextcord`` as that'll conflict
 with the library.
 
-There's a lot going on here, so let's walk you through it step by step.
+A lot is going on here, so let's walk you through it step by step.
 
 1. The first line just imports the library, if this raises a `ModuleNotFoundError` or `ImportError`
    then head on over to :ref:`installing` section to properly install.

--- a/docs/version_guarantees.rst
+++ b/docs/version_guarantees.rst
@@ -5,7 +5,7 @@ Version Guarantees
 
 The library follows a `semantic versioning principle <https://semver.org/>`_ which means that the major version is updated every time there is an incompatible API change. However due to the lack of guarantees on the Discord side when it comes to breaking changes along with the fairly dynamic nature of Python it can be hard to discern what can be considered a breaking change and what isn't.
 
-The first thing to keep in mind is that breaking changes only apply to **publicly documented functions and classes**. If it's not listed in the documentation here then it is not part of the public API and is thus bound to change. This includes attributes that start with an underscore or functions without an underscore that are not documented.
+The first thing to keep in mind is that breaking changes only apply to **publicly documented functions and classes**. If it's not listed in the documentation here then it is not part of the public API and is thus bound to change. This includes attributes that start with an underscore or functions without underscores that are not documented.
 
 .. note::
 

--- a/docs/whats_new.rst
+++ b/docs/whats_new.rst
@@ -8,7 +8,7 @@
 Changelog
 ============
 
-This page keeps a detailed human friendly rendering of what's new and changed
+This page keeps a detailed human-friendly rendering of what's new and changed
 in specific versions.
 
 .. _vp2p0p0:


### PR DESCRIPTION
## Summary

Fixed 50+ spelling and grammar mistakes in the readme and documentation.

## Checklist

- [x] This PR is **not** a code change (e.g. documentation, README, ...)
