### PR TITLE
feat: add timestamp object

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -4127,6 +4127,14 @@ PublicUserFlags
 .. autoclass:: PublicUserFlags()
     :members:
 
+TimeStamp
+~~~~~~~~~
+
+.. attributetable:: Timestamp
+
+.. autoclass:: Timestamp()
+    :members:
+
 .. _discord_ui_kit:
 
 Bot UI Kit

--- a/nextcord/__init__.py
+++ b/nextcord/__init__.py
@@ -60,6 +60,7 @@ from .stage_instance import *
 from .interactions import *
 from .components import *
 from .threads import *
+from .timestamp import *
 from .health_check import *
 
 class VersionInfo(NamedTuple):

--- a/nextcord/timestamp.py
+++ b/nextcord/timestamp.py
@@ -4,6 +4,8 @@ from datetime import datetime as dt
 
 @dataclass
 class Timestamp:
+    """A class to represent Discord's native timestamp format."""
+
     time: int
 
     @property

--- a/nextcord/timestamp.py
+++ b/nextcord/timestamp.py
@@ -1,0 +1,70 @@
+from dataclasses import dataclass
+from datetime import datetime as dt
+
+
+@dataclass
+class Timestamp:
+    time: int
+
+    @property
+    def datetime(self) -> dt:
+        """The datetime object of the timestamp."""
+
+        return dt.fromtimestamp(self.time)
+
+    @property
+    def short_time(self) -> str:
+        """The timestamp in short time format."""
+
+        return f"<t:{self.time}:t>"
+
+    @property
+    def long_time(self) -> str:
+        """The timestamp in long time format."""
+
+        return f"<t:{self.time}:T>"
+
+    @property
+    def short_date(self) -> str:
+        """The timestamp in short date format."""
+
+        return f"<t:{self.time}:d>"
+
+    @property
+    def long_date(self) -> str:
+        """The timestamp in long date format."""
+
+        return f"<t:{self.time}:D>"
+
+    @property
+    def short_date_time(self) -> str:
+        """The timestamp in short date/time format."""
+
+        return f"<t:{self.time}:f>"
+
+    @property
+    def long_date_time(self) -> str:
+        """The timestamp in long date/time format."""
+
+        return f"<t:{self.time}:F>"
+
+    @property
+    def relative_time(self) -> str:
+        """The timestamp in relative time format."""
+
+        return f"<t:{self.time}:R>"
+
+    @classmethod
+    def from_datetime(cls, datetime: dt) -> "Timestamp":
+        """Generate a timestamp from a datetime object."""
+
+        return cls(round(datetime.timestamp()))
+
+    @classmethod
+    def utcnow(cls) -> "Timestamp":
+        """Generate a timestamp from the current UNIX time."""
+
+        return cls(round(dt.utcnow().timestamp()))
+
+    def __repr__(self) -> str:
+        return f"<Timestamp time={self.time}>"


### PR DESCRIPTION
## Summary

This PR adds a `Timestamp` object to allow the suer of Discord's native timestamps.

## Checklist

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
