### PR TITLE
Should fix #7

### DIFF
--- a/nextcord/state.py
+++ b/nextcord/state.py
@@ -1336,6 +1336,8 @@ class ConnectionState:
             user_id = utils._get_as_snowflake(data, 'user_id')
             if isinstance(channel, DMChannel):
                 member = channel.recipient
+                if member is None:
+                    member = self.get_user(user_id)
 
             elif isinstance(channel, (Thread, TextChannel)) and guild is not None:
                 # user_id won't be None


### PR DESCRIPTION
## Summary

Close #7 

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)

I am not sure why the others prefered to implement a raw event instead of just looking it up in the users array. Looking for input why Danny did not liked to just look it up
