### PR TITLE
Added `on_raw_typing` event

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -369,6 +369,19 @@ to handle it, which defaults to print a traceback and ignoring the exception.
     :param when: When the typing started as an aware datetime in UTC.
     :type when: :class:`datetime.datetime`
 
+.. function:: on_raw_typing(payload)
+
+    Called when someone begins typing a message. Unlike :func:`on_typing`, this is 
+    called regardless if the user can be found in the bot's cache or not.
+
+    If the typing event is occuring in a guild,
+    the member that started typing can be accessed via :attr:`RawTypingEvent.member`
+
+    This requires :attr:`Intents.typing` to be enabled.
+
+    :param payload: The raw typing payload.
+    :type payload: :class:`RawTypingEvent`
+
 .. function:: on_message(message)
 
     Called when a :class:`Message` is created and sent.
@@ -3860,6 +3873,14 @@ GuildSticker
 .. attributetable:: GuildSticker
 
 .. autoclass:: GuildSticker()
+    :members:
+
+RawTypingEvent
+~~~~~~~~~~~~~~~~~~~~~~~
+
+.. attributetable:: RawTypingEvent
+
+.. autoclass:: RawTypingEvent()
     :members:
 
 RawMessageDeleteEvent

--- a/nextcord/raw_models.py
+++ b/nextcord/raw_models.py
@@ -24,6 +24,7 @@ DEALINGS IN THE SOFTWARE.
 
 from __future__ import annotations
 
+import datetime
 from typing import TYPE_CHECKING, Optional, Set, List
 
 if TYPE_CHECKING:
@@ -34,7 +35,8 @@ if TYPE_CHECKING:
         MessageUpdateEvent,
         ReactionClearEvent,
         ReactionClearEmojiEvent,
-        IntegrationDeleteEvent
+        IntegrationDeleteEvent,
+        TypingEvent
     )
     from .message import Message
     from .partial_emoji import PartialEmoji
@@ -49,6 +51,7 @@ __all__ = (
     'RawReactionClearEvent',
     'RawReactionClearEmojiEvent',
     'RawIntegrationDeleteEvent',
+    'RawTypingEvent',
 )
 
 
@@ -276,3 +279,36 @@ class RawIntegrationDeleteEvent(_RawReprMixin):
             self.application_id: Optional[int] = int(data['application_id'])
         except KeyError:
             self.application_id: Optional[int] = None
+
+
+class RawTypingEvent(_RawReprMixin):
+    """Represents the payload for a :func:`on_raw_typing` event.
+
+    .. versionadded:: 2.0
+    
+    Attributes
+    -----------
+    channel_id: :class:`int`
+        The channel ID where the typing originated from.
+    user_id: :class:`int`
+        The ID of the user that started typing.
+    when: :class:`datetime.datetime`
+        When the typing started as an aware datetime in UTC.
+    guild_id: Optional[:class:`int`]
+        The guild ID where the typing originated from, if applicable.
+    member: Optional[:class:`Member`]
+        The member who started typing. Only available if the member started typing in a guild.
+    """
+
+    __slots__ = ("channel_id", "user_id", "when", "guild_id", "member")
+
+    def __init__(self, data: TypingEvent) -> None:
+        self.channel_id: int = int(data['channel_id'])
+        self.user_id: int = int(data['user_id'])
+        self.when: datetime.datetime = datetime.datetime.fromtimestamp(data.get('timestamp'), tz=datetime.timezone.utc)
+        self.member: Optional[Member] = None
+
+        try:
+            self.guild_id: Optional[int] = int(data['guild_id'])
+        except KeyError:
+            self.guild_id: Optional[int] = None

--- a/nextcord/state.py
+++ b/nextcord/state.py
@@ -1352,7 +1352,7 @@ class ConnectionState:
 
     def _get_typing_user(self, channel: Optional[MessageableChannel], user_id: int) -> Optional[Union[User, Member]]:
         if isinstance(channel, DMChannel):
-            return channel.recipient
+            return channel.recipient or self.get_user(user_id)
 
         elif isinstance(channel, (Thread, TextChannel)) and channel.guild is not None:
             return channel.guild.get_member(user_id)  # type: ignore

--- a/nextcord/state.py
+++ b/nextcord/state.py
@@ -1330,28 +1330,37 @@ class ConnectionState:
             asyncio.create_task(logging_coroutine(coro, info='Voice Protocol voice server update handler'))
 
     def parse_typing_start(self, data) -> None:
+        raw = RawTypingEvent(data)
+
+        member_data = data.get('member')
+        if member_data:
+            guild = self._get_guild(raw.guild_id)
+            if guild is not None:
+                raw.member = Member(data=member_data, guild=guild, state=self)
+            else:
+                raw.member = None
+        else:
+            raw.member = None
+        self.dispatch('raw_typing', raw)
+
         channel, guild = self._get_guild_channel(data)
         if channel is not None:
-            member = None
-            user_id = utils._get_as_snowflake(data, 'user_id')
-            if isinstance(channel, DMChannel):
-                member = channel.recipient
+            user = raw.member or self._get_typing_user(channel, raw.user_id)
 
-            elif isinstance(channel, (Thread, TextChannel)) and guild is not None:
-                # user_id won't be None
-                member = guild.get_member(user_id)  # type: ignore
+            if user is not None:
+                self.dispatch('typing', channel, user, raw.when)
 
-                if member is None:
-                    member_data = data.get('member')
-                    if member_data:
-                        member = Member(data=member_data, state=self, guild=guild)
+    def _get_typing_user(self, channel: Optional[MessageableChannel], user_id: int) -> Optional[Union[User, Member]]:
+        if isinstance(channel, DMChannel):
+            return channel.recipient
 
-            elif isinstance(channel, GroupChannel):
-                member = utils.find(lambda x: x.id == user_id, channel.recipients)
+        elif isinstance(channel, (Thread, TextChannel)) and channel.guild is not None:
+            return channel.guild.get_member(user_id)  # type: ignore
 
-            if member is not None:
-                timestamp = datetime.datetime.fromtimestamp(data.get('timestamp'), tz=datetime.timezone.utc)
-                self.dispatch('typing', channel, member, timestamp)
+        elif isinstance(channel, GroupChannel):
+            return utils.find(lambda x: x.id == user_id, channel.recipients)
+
+        return self.get_user(user_id)
 
     def _get_reaction_user(self, channel: MessageableChannel, user_id: int) -> Optional[Union[User, Member]]:
         if isinstance(channel, TextChannel):

--- a/nextcord/types/raw_models.py
+++ b/nextcord/types/raw_models.py
@@ -85,3 +85,14 @@ class _IntegrationDeleteEventOptional(TypedDict, total=False):
 class IntegrationDeleteEvent(_IntegrationDeleteEventOptional):
     id: Snowflake
     guild_id: Snowflake
+
+
+class _TypingEventOptional(TypedDict, total=False):
+    guild_id: Snowflake
+    member: Member
+
+
+class TypingEvent(_TypingEventOptional):
+    channel_id: Snowflake
+    user_id: Snowflake
+    timestamp: int


### PR DESCRIPTION
## Summary

Adds in an `on_raw_typing` event. This may be useful if the typing starts in a DM, as otherwise, d.py is unable to resolve the user and so unable to dispatch an `on_typing` event.
Note that even with #145, this event is still useful in case the typing itself comes from a user that comes outside of the bot's user cache, a likely possibility if `Intents.members` is disabled. In fact, this PR was made and adjusted with #145 in mind, at least in terms of the documentation's wording (there might be merge conflicts between this PR and that one - sorry!).

Closes #7.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue. (kind of? It's another solution to #7)
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
