### PR TITLE
Prefer `static_format` over `format` with static assets

### DIFF
--- a/nextcord/asset.py
+++ b/nextcord/asset.py
@@ -313,10 +313,11 @@ class Asset(AssetMixin):
             if self._animated:
                 if format not in VALID_ASSET_FORMATS:
                     raise InvalidArgument(f'format must be one of {VALID_ASSET_FORMATS}')
-            else:
+                url = url.with_path(f'{path}.{format}')
+            elif static_format is MISSING:
                 if format not in VALID_STATIC_FORMATS:
                     raise InvalidArgument(f'format must be one of {VALID_STATIC_FORMATS}')
-            url = url.with_path(f'{path}.{format}')
+                url = url.with_path(f'{path}.{format}')
 
         if static_format is not MISSING and not self._animated:
             if static_format not in VALID_STATIC_FORMATS:


### PR DESCRIPTION
## Summary

Restoration of #56, which I accidentally closed because of force-pushing messiness.
Summary of old PR:

> In short: something like `Asset.replace(format='gif',static_format='png')` would break if it encountered a static asset, as static avatars cannot be stored in a GIF format and d.py preferred to use the `format` format vs. the `static_format` format, even with static assets. According to Danny, this was an intentional feature, but I personally do not see how keeping the old behavior would be beneficial to anyone at all.
> Link to issue here: #13
> Link to issue on `discord.py`: [#7345](https://github.com/Rapptz/discord.py/issues/7345)

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [x] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
