### PR TITLE
Specifies nextcord logger instead of discord

### DIFF
--- a/docs/logging.rst
+++ b/docs/logging.rst
@@ -30,7 +30,7 @@ outputting them to the console the following snippet can be used::
     import nextcord
     import logging
 
-    logger = logging.getLogger('discord')
+    logger = logging.getLogger('nextcord')
     logger.setLevel(logging.DEBUG)
     handler = logging.FileHandler(filename='nextcord.log', encoding='utf-8', mode='w')
     handler.setFormatter(logging.Formatter('%(asctime)s:%(levelname)s:%(name)s: %(message)s'))


### PR DESCRIPTION
Signed-off-by: Alex Schoenhofen <alexanderschoenhofen@gmail.com>

## Summary

Docs specify changing the logging level of the "discord" logger, when it should be "nextcord"

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
