### PR TITLE
docs: Revert custom url

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -2,7 +2,7 @@
    :alt: Nextcord
 
 .. image:: https://discord.com/api/guilds/881118111967883295/embed.png
-   :target: https://discord.gg/nextcord
+   :target: https://discord.gg/ZebatWssCB
    :alt: Discord server invite
 .. image:: https://img.shields.io/pypi/v/nextcord.svg
    :target: https://pypi.python.org/pypi/nextcord


### PR DESCRIPTION
Reverts invite link to non-custom url.

Was changed but invite no longer works: https://github.com/nextcord/nextcord/commit/5f195c360f3060938e2445ef0a255956c1271633