### PR TITLE
Fixed Bot.is_owner()'s type hint (added Member)

### DIFF
--- a/nextcord/ext/commands/bot.py
+++ b/nextcord/ext/commands/bot.py
@@ -316,7 +316,7 @@ class BotBase(GroupMixin):
         # type-checker doesn't distinguish between functions and methods
         return await nextcord.utils.async_all(f(ctx) for f in data)  # type: ignore
 
-    async def is_owner(self, user: nextcord.User) -> bool:
+    async def is_owner(self, user: Union[nextcord.User, nextcord.Member]) -> bool:
         """|coro|
 
         Checks if a :class:`~nextcord.User` or :class:`~nextcord.Member` is the owner of


### PR DESCRIPTION
## Summary

<!-- What is this pull request for? Does it fix any issues? -->
`Bot.is_owner()`'s doc says it can also take `nextcord.Member`, but the type hint in real code only had `nextcord.User`
## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
