### PR TITLE
Small grammar fix in docstring

### DIFF
--- a/nextcord/guild.py
+++ b/nextcord/guild.py
@@ -895,7 +895,7 @@ class Guild(Hashable):
 
     @property
     def member_count(self) -> Optional[int]:
-        """Optional[:class:`int`]: Returns the true member count, if availible.
+        """Optional[:class:`int`]: Returns the true member count, if available.
 
         .. warning::
 


### PR DESCRIPTION
## Summary

There was a grammar error in the docstring of Guild.member_count, which this PR fixes

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
