### PR TITLE
Feature: Cog's can now have external config

### DIFF
--- a/docs/ext/commands/api.rst
+++ b/docs/ext/commands/api.rst
@@ -601,6 +601,9 @@ Exceptions
 .. autoexception:: nextcord.ext.commands.NoEntryPointError
     :members:
 
+.. autoexception:: nextcord.ext.commands.InvalidSetupArguments
+    :members:
+
 .. autoexception:: nextcord.ext.commands.ExtensionFailed
     :members:
 
@@ -669,6 +672,7 @@ Exception Hierarchy
             - :exc:`~.commands.ExtensionAlreadyLoaded`
             - :exc:`~.commands.ExtensionNotLoaded`
             - :exc:`~.commands.NoEntryPointError`
+            - :exc:`~.commands.InvalidSetupArguments`
             - :exc:`~.commands.ExtensionFailed`
             - :exc:`~.commands.ExtensionNotFound`
     - :exc:`~.ClientException`

--- a/nextcord/__init__.py
+++ b/nextcord/__init__.py
@@ -13,7 +13,7 @@ __title__ = 'discord'
 __author__ = 'tag-epic & Rapptz'
 __license__ = 'MIT'
 __copyright__ = 'Copyright 2015-present Rapptz'
-__version__ = '2.0.0a3'
+__version__ = '2.0.0a4'
 
 __path__ = __import__('pkgutil').extend_path(__path__, __name__)
 

--- a/nextcord/__init__.py
+++ b/nextcord/__init__.py
@@ -13,7 +13,7 @@ __title__ = 'discord'
 __author__ = 'tag-epic & Rapptz'
 __license__ = 'MIT'
 __copyright__ = 'Copyright 2015-present Rapptz'
-__version__ = '2.0.0a4'
+__version__ = '2.0.0a3'
 
 __path__ = __import__('pkgutil').extend_path(__path__, __name__)
 

--- a/nextcord/ext/commands/bot.py
+++ b/nextcord/ext/commands/bot.py
@@ -732,7 +732,7 @@ class BotBase(GroupMixin):
             A mapping of kwargs to values to be passed to your
             cog's ``__init__`` method as key word arguments.
 
-            .. versionadded:: 2.0.0a4
+            .. versionadded:: 2.0.0
 
         Raises
         --------

--- a/nextcord/ext/commands/bot.py
+++ b/nextcord/ext/commands/bot.py
@@ -678,8 +678,11 @@ class BotBase(GroupMixin):
         sig = list(sig.parameters.keys())
         total_params = len(sig)
         has_kwargs = total_params != 1
-        if extras and not has_kwargs:
-            raise errors.InvalidSetupArguments(key)
+        if extras:
+            if not has_kwargs:
+                raise errors.InvalidSetupArguments(key)
+            elif not isinstance(extras, dict):
+                raise TypeError("Expected 'extras' to be a dictionary")
 
         try:
             if has_kwargs:

--- a/nextcord/ext/commands/bot.py
+++ b/nextcord/ext/commands/bot.py
@@ -677,7 +677,7 @@ class BotBase(GroupMixin):
         params = inspect.signature(setup).parameters
         has_kwargs = len(params) > 1
 
-        if extras:
+        if extras is not None:
             if not has_kwargs:
                 raise errors.InvalidSetupArguments(key)
             elif not isinstance(extras, dict):

--- a/nextcord/ext/commands/bot.py
+++ b/nextcord/ext/commands/bot.py
@@ -653,7 +653,12 @@ class BotBase(GroupMixin):
                 if _is_submodule(name, module):
                     del sys.modules[module]
 
-    def _load_from_module_spec(self, spec: importlib.machinery.ModuleSpec, key: str) -> None:
+    def _load_from_module_spec(
+            self,
+            spec: importlib.machinery.ModuleSpec,
+            key: str,
+            extras: Dict[str, Any] = None
+    ) -> None:
         # precondition: key not in self.__extensions
         lib = importlib.util.module_from_spec(spec)
         sys.modules[key] = lib
@@ -669,8 +674,20 @@ class BotBase(GroupMixin):
             del sys.modules[key]
             raise errors.NoEntryPointError(key)
 
+        sig = inspect.signature(setup)
+        sig = list(sig.parameters.keys())
+        total_params = len(sig)
+        has_kwargs = total_params != 1
+        if extras and not has_kwargs:
+            raise errors.InvalidSetupArguments(key)
+
         try:
-            setup(self)
+            if has_kwargs:
+                # Fix mutable defaults
+                extras = extras or {}
+                setup(self, **extras)
+            else:
+                setup(self)
         except Exception as e:
             del sys.modules[key]
             self._remove_module_references(lib.__name__)
@@ -685,7 +702,13 @@ class BotBase(GroupMixin):
         except ImportError:
             raise errors.ExtensionNotFound(name)
 
-    def load_extension(self, name: str, *, package: Optional[str] = None) -> None:
+    def load_extension(
+            self,
+            name: str,
+            *,
+            package: Optional[str] = None,
+            extras: Dict[str, Any] = None
+    ) -> None:
         """Loads an extension.
 
         An extension is a python module that contains commands, cogs, or
@@ -707,6 +730,11 @@ class BotBase(GroupMixin):
             Defaults to ``None``.
 
             .. versionadded:: 1.7
+        extras: Optional[:class:`dict`]
+            A mapping of kwargs to values to be passed to your
+            cog's ``__init__`` method as key word arguments.
+
+            .. versionadded:: 2.0.0a4
 
         Raises
         --------
@@ -720,6 +748,9 @@ class BotBase(GroupMixin):
             The extension does not have a setup function.
         ExtensionFailed
             The extension or its setup function had an execution error.
+        InvalidSetupArguments
+            ``load_extension`` was given ``extras`` but the ``setup``
+            function did not take any additional arguments.
         """
 
         name = self._resolve_name(name, package)
@@ -730,7 +761,7 @@ class BotBase(GroupMixin):
         if spec is None:
             raise errors.ExtensionNotFound(name)
 
-        self._load_from_module_spec(spec, name)
+        self._load_from_module_spec(spec, name, extras=extras)
 
     def unload_extension(self, name: str, *, package: Optional[str] = None) -> None:
         """Unloads an extension.

--- a/nextcord/ext/commands/bot.py
+++ b/nextcord/ext/commands/bot.py
@@ -682,7 +682,7 @@ class BotBase(GroupMixin):
             if not has_kwargs:
                 raise errors.InvalidSetupArguments(key)
             elif not isinstance(extras, dict):
-                raise TypeError("Expected 'extras' to be a dictionary")
+                raise errors.ExtensionFailed(key, TypeError("Expected 'extras' to be a dictionary"))
 
         try:
             if has_kwargs:

--- a/nextcord/ext/commands/bot.py
+++ b/nextcord/ext/commands/bot.py
@@ -683,8 +683,8 @@ class BotBase(GroupMixin):
             elif not isinstance(extras, dict):
                 raise errors.ExtensionFailed(key, TypeError("Expected 'extras' to be a dictionary"))
 
+        extras = extras or {}
         try:
-            extras = extras or {}
             setup(self, **extras)
         except Exception as e:
             del sys.modules[key]

--- a/nextcord/ext/commands/errors.py
+++ b/nextcord/ext/commands/errors.py
@@ -90,6 +90,7 @@ __all__ = (
     'ExtensionAlreadyLoaded',
     'ExtensionNotLoaded',
     'NoEntryPointError',
+    'InvalidSetupArguments',
     'ExtensionFailed',
     'ExtensionNotFound',
     'CommandRegistrationError',

--- a/nextcord/ext/commands/errors.py
+++ b/nextcord/ext/commands/errors.py
@@ -860,7 +860,8 @@ class NoEntryPointError(ExtensionError):
         super().__init__(f"Extension {name!r} has no 'setup' function.", name=name)
 
 class InvalidSetupArguments(ExtensionError):
-    """An exception raised when an extension contains a ``setup`` function which does except ``kwargs`` but ``kwargs`` were passed.
+    """An exception raised when an extension contains a ``setup`` function which does
+     except ``kwargs`` but ``kwargs`` were passed.
 
     This inherits from :exc:`ExtensionError`
     """

--- a/nextcord/ext/commands/errors.py
+++ b/nextcord/ext/commands/errors.py
@@ -859,6 +859,14 @@ class NoEntryPointError(ExtensionError):
     def __init__(self, name: str) -> None:
         super().__init__(f"Extension {name!r} has no 'setup' function.", name=name)
 
+class InvalidSetupArguments(ExtensionError):
+    """An exception raised when an extension contains a ``setup`` function which does except ``kwargs`` but ``kwargs`` were passed.
+
+    This inherits from :exc:`ExtensionError`
+    """
+    def __init__(self, name: str) -> None:
+        super().__init__(f"Extension {name!r} does not take 'kwargs' but 'kwargs' were given.", name=name)
+
 class ExtensionFailed(ExtensionError):
     """An exception raised when an extension failed to load during execution of the module or ``setup`` entry point.
 


### PR DESCRIPTION
## Summary

It resolves #129 by implementing the ability to have keyword arguments passed through

See the thread under nc-development for testing

## Checklist

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
