### PR TITLE
Add interaction.send()

### DIFF
--- a/nextcord/interactions.py
+++ b/nextcord/interactions.py
@@ -392,14 +392,12 @@ class Interaction:
         """
 
         if not self.response.is_done():
-            await self.response.send_message(*args, **kwargs)
-        else:
-            if self.channel is not None:
-                await self.channel.send(*args, **kwargs)
-            else:
-                raise InvalidData(
-                    "Interaction.channel is None, this may occur in threads"
-                )
+            return await self.response.send_message(*args, **kwargs)
+        if self.channel is not None:
+            return await self.channel.send(*args, **kwargs)
+        raise InvalidData(
+            "Interaction.channel is None, this may occur in threads"
+        )
 
 
 class InteractionResponse:

--- a/nextcord/interactions.py
+++ b/nextcord/interactions.py
@@ -367,15 +367,15 @@ class Interaction:
     async def send(self, *args, **kwargs) -> Optional[Message]:
         """|coro|
 
-        This is a fallback function for help when sending messages in
+        This is a shorthand function for helping in sending messages in
         response to an interaction. If the response
-        :property:`InteractionResponse.is_done()` then a messahe os sent
-        to the :property:`Interaction.channel` instead.
+        :meth:`InteractionResponse.is_done()` then the message is sent
+        via the :attr:`Interaction.channel` instead.
 
         .. warning::
 
             Ephemeral messages should not be sent with this as if
-            the :property:`Interaction.channel` is fallen back to,
+            the :attr:`Interaction.channel` is fallen back to,
             ephemeral messages cannot be sent with this.
 
         Returns
@@ -387,7 +387,7 @@ class Interaction:
         Raises
         ------
         InvalidData
-            Somehow :property:`Interaction.channel` was ``None``,
+            Somehow :attr:`Interaction.channel` was ``None``,
             this may occur in threads.
         """
 

--- a/nextcord/interactions.py
+++ b/nextcord/interactions.py
@@ -34,7 +34,8 @@ from .errors import (
     InteractionResponded,
     HTTPException,
     ClientException,
-    InvalidData
+    InvalidData,
+    InvalidArgument
 )
 from .channel import PartialMessageable, ChannelType
 
@@ -397,6 +398,34 @@ class Interaction:
             return await self.channel.send(*args, **kwargs)
         raise InvalidData(
             "Interaction.channel is None, this may occur in threads"
+        )
+
+    async def edit(self, *args, **kwargs) -> Optional[Message]:
+        """|coro|
+
+        This is a shorthand function for helping in editing messages in
+        response to an interaction. If the response
+        :meth:`InteractionResponse.is_done()` then the message is edited
+        via the :attr:`Interaction.message` instead.
+
+        Returns
+        -------
+        Optional[:class:`Message`]
+            Message if the interaction has been responded to and the
+            interaction's message was edited w/o using response. Else ``None``
+
+        Raises
+        ------
+        InvalidArgument
+            :attr:`Interaction.message` was ``None``,
+            this may occur in threads.
+        """
+        if not self.response.is_done():
+            return await self.response.edit_message(*args, **kwargs)
+        if self.message is not None:
+            return await self.message.edit(*args, **kwargs)
+        raise InvalidArgument(
+            "Interaction.message is None, this method is only for views"
         )
 
 


### PR DESCRIPTION
this was discussed at https://canary.discord.com/channels/881118111967883295/881124672056467456/903322918413541377

this has been tested by me too

## Summary

<!-- What is this pull request for? Does it fix any issues? -->
Adds ``interaction.send``, a fallback function for ``interaction.response.send_message`` and ``interaction.channel.send``, useful for everyone: converting and not having to make sure an interaction hasnt been responded to yet like in an interaction_check for a ``View``

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
