### PR TITLE
Feat: Add 'thread' field to messages.

### DIFF
--- a/nextcord/message.py
+++ b/nextcord/message.py
@@ -683,7 +683,7 @@ class Message(Hashable):
             self.guild = state._get_guild(utils._get_as_snowflake(data, 'guild_id'))
 
         thread_data = data.get('thread')
-        if self.guild and thread_data:
+        if thread_data:
             self.thread: Optional[Thread] = Thread(guild=self.guild, state=state, data=thread_data)
         else:
             self.thread: Optional[Thread] = None

--- a/nextcord/message.py
+++ b/nextcord/message.py
@@ -599,7 +599,7 @@ class Message(Hashable):
 
         .. versionadded:: 2.0
     thread: Optional[:class:`Thread`]
-        The thread created from this message, if any.
+        The thread created from a message, if any.
 
         .. versionadded:: 2.0
     guild: Optional[:class:`Guild`]

--- a/nextcord/message.py
+++ b/nextcord/message.py
@@ -598,6 +598,10 @@ class Message(Hashable):
         A list of components in the message.
 
         .. versionadded:: 2.0
+    thread: Optional[:class:`Thread`]
+        The thread created from this message, if any.
+
+        .. versionadded:: 2.0
     guild: Optional[:class:`Guild`]
         The guild that the message belongs to, if applicable.
     """
@@ -632,6 +636,7 @@ class Message(Hashable):
         'activity',
         'stickers',
         'components',
+        'thread',
         'guild',
     )
 
@@ -676,6 +681,12 @@ class Message(Hashable):
             self.guild = channel.guild  # type: ignore
         except AttributeError:
             self.guild = state._get_guild(utils._get_as_snowflake(data, 'guild_id'))
+
+        thread_data = data.get('thread')
+        if self.guild and thread_data:
+            self.thread: Optional[Thread] = Thread(guild=self.guild, state=state, data=thread_data)
+        else:
+            self.thread: Optional[Thread] = None
 
         try:
             ref = data['message_reference']


### PR DESCRIPTION
## Summary

Parse and use the `thread` field on messages, as documented [here](https://discord.com/developers/docs/resources/channel#message-object).

## Checklist

- If code changes were made then they have been tested.
- I have updated the documentation to reflect the changes.
- This PR adds something new (e.g. new method or parameters).
