### PR TITLE
Feature: Group's hook & check inheritance

### DIFF
--- a/nextcord/ext/commands/core.py
+++ b/nextcord/ext/commands/core.py
@@ -283,9 +283,8 @@ class Command(_BaseCommand, Generic[CogT, P, T]):
 
         .. note::
             You can define a ``pre_invoke`` or ``after_invoke`` on this
-            command in conjunction with ``inherit_hooks=True`` however
-            the one defined for this command will not be replaced by
-            the parent hook.
+            command in conjunction with ``inherit_hooks=True``, however
+            it will override the parent hook if applicable
 
         .. versionadded:: 2.0.0
     """

--- a/nextcord/ext/commands/core.py
+++ b/nextcord/ext/commands/core.py
@@ -407,7 +407,8 @@ class Command(_BaseCommand, Generic[CogT, P, T]):
         except AttributeError:
             pass
         else:
-            self.before_invoke(inherited_before_invoke)
+            if inherited_before_invoke:
+                self.before_invoke(inherited_before_invoke)
 
         inherited_after_invoke: Optional[Hook] = None
         try:
@@ -415,7 +416,8 @@ class Command(_BaseCommand, Generic[CogT, P, T]):
         except AttributeError:
             pass
         else:
-            self.after_invoke(inherited_after_invoke)
+            if inherited_after_invoke:
+                self.after_invoke(inherited_after_invoke)
 
         self.checks.extend(self.parent.checks)  # type: ignore
 

--- a/nextcord/ext/commands/core.py
+++ b/nextcord/ext/commands/core.py
@@ -277,7 +277,7 @@ class Command(_BaseCommand, Generic[CogT, P, T]):
 
 
         .. versionadded:: 2.0
-    inherit_hooks: :class:`bool`
+    inherit_hooks: :class:`bool`, default=False
         If ``True`` and this command has a parent :class:`Group` then this command
         will inherit all checks, pre_invoke and after_invoke's defined on the the :class:`Group`
 

--- a/nextcord/ext/commands/core.py
+++ b/nextcord/ext/commands/core.py
@@ -398,7 +398,11 @@ class Command(_BaseCommand, Generic[CogT, P, T]):
             self.after_invoke(after_invoke)
 
         # Attempt to bind to parent hooks if applicable
-        if not kwargs.get("inherit_hooks", False) or not self.parent:
+        if not kwargs.get("inherit_hooks", False):
+            return
+
+        # We should be binding hooks
+        if not self.parent:
             return
 
         inherited_before_invoke: Optional[Hook] = None

--- a/nextcord/ext/commands/core.py
+++ b/nextcord/ext/commands/core.py
@@ -282,9 +282,7 @@ class Command(_BaseCommand, Generic[CogT, P, T]):
         will inherit all checks, pre_invoke and after_invoke's defined on the the :class:`Group`
 
         .. note::
-            You can define a ``pre_invoke`` or ``after_invoke`` on this
-            command in conjunction with ``inherit_hooks=True``, however
-            it will override the parent hook if applicable
+            Any ``pre_invoke`` or ``after_invoke``'s defined on this will override parent ones.
 
         .. versionadded:: 2.0.0
     """


### PR DESCRIPTION
## Summary

Add's the ability for commands in groups to inherit checks, pre_invoke and after_invoke calls

#123

## Checklist

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
