### PR TITLE
Added Installing Seperate Ext's Into The ``setup.py``

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -54,6 +54,9 @@ extras_require = {
     ],
     'events': [
         'nextcord-ext-events',
+    ],
+    'alternatives': [
+        'nextcord-ext-alternatives',
     ]
 }
 

--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ extras_require = {
     'ipc': [
         'nextcord-ext-ipc',
     ],
-    'ipc': [
+    'events': [
         'nextcord-ext-events',
     ]
 }

--- a/setup.py
+++ b/setup.py
@@ -51,6 +51,9 @@ extras_require = {
     ],
     'ipc': [
         'nextcord-ext-ipc',
+    ],
+    'ipc': [
+        'nextcord-ext-events',
     ]
 }
 

--- a/setup.py
+++ b/setup.py
@@ -45,6 +45,12 @@ extras_require = {
         'aiodns>=1.1',
         'Brotli',
         'cchardet'
+    ],
+    'menus': [
+        'nextcord-ext-menus',
+    ],
+    'ipc': [
+        'nextcord-ext-ipc',
     ]
 }
 

--- a/unaliased-setup.py
+++ b/unaliased-setup.py
@@ -54,6 +54,9 @@ extras_require = {
     ],
     'events': [
         'nextcord-ext-events',
+    ],
+    'alternatives': [
+        'nextcord-ext-alternatives',
     ]
 }
 

--- a/unaliased-setup.py
+++ b/unaliased-setup.py
@@ -45,7 +45,12 @@ extras_require = {
         'aiodns>=1.1',
         'Brotli',
         'cchardet'
-    ]
+    ],
+    'menus': [
+        'nextcord-ext-menus',
+    ],
+    'ipc': [
+        'nextcord-ext-ipc',
 }
 
 packages = [

--- a/unaliased-setup.py
+++ b/unaliased-setup.py
@@ -51,6 +51,10 @@ extras_require = {
     ],
     'ipc': [
         'nextcord-ext-ipc',
+    ]
+    'events': [
+        'nextcord-ext-events',
+    ]
 }
 
 packages = [

--- a/unaliased-setup.py
+++ b/unaliased-setup.py
@@ -51,7 +51,7 @@ extras_require = {
     ],
     'ipc': [
         'nextcord-ext-ipc',
-    ]
+    ],
     'events': [
         'nextcord-ext-events',
     ]


### PR DESCRIPTION
## Summary

Made It So if You Do
``pip install nextcord[ipc]`` Or ``pip install nextcord[menus]`` it would install the separate python projects for those

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] This PR adds Something To Setup.py
