### PR TITLE
Fix embed.url description.

### DIFF
--- a/nextcord/embeds.py
+++ b/nextcord/embeds.py
@@ -142,7 +142,7 @@ class Embed:
         The description of the embed.
         This can be set during initialisation.
     url: :class:`str`
-        The hyperlink of the title of the embed.
+        The hyperlink of the embed title.
         This can be set during initialisation.
         This makes no effect if there is no ``title`` field.
     timestamp: :class:`datetime.datetime`


### PR DESCRIPTION
## Summary
Embed.url was defined as 'The url of the embed', which incorrectly described its usage as to hyperlink the title of the embed.
Fix by changing the description.

## Checklist
- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
