### PR TITLE
Fix double "@" in Guild.default_role.mention

### DIFF
--- a/nextcord/role.py
+++ b/nextcord/role.py
@@ -305,7 +305,10 @@ class Role(Hashable):
     @property
     def mention(self) -> str:
         """:class:`str`: Returns a string that allows you to mention a role."""
-        return f'<@&{self.id}>'
+        if self.id != self.guild.id:
+            return f'<@&{self.id}>'
+        else:
+            return '@everyone'
 
     @property
     def members(self) -> List[Member]:


### PR DESCRIPTION
It is Discord UI bug, however this fix works properly on android and win32

## Summary

<!-- What is this pull request for? Does it fix any issues? -->
When mentioning @everyone role via mention attribute, it has double "@"

Before:
![@@everyone](https://i.imgur.com/2i4GAw1.png)
After:
![@everyone](https://i.imgur.com/IlLdgbB.png)

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
