### PR TITLE
feat(member): allow edit to take a timedelta

### DIFF
--- a/nextcord/member.py
+++ b/nextcord/member.py
@@ -666,7 +666,10 @@ class Member(abc.Messageable, _UserTag):
         roles: List[abc.Snowflake] = MISSING,
         voice_channel: Optional[VocalGuildChannel] = MISSING,
         reason: Optional[str] = None,
-        timeout: Optional[datetime.datetime] = MISSING,
+        timeout: Optional[Union[
+            datetime.datetime,
+            datetime.timedelta
+        ]] = MISSING,
     ) -> Optional[Member]:
         """|coro|
 
@@ -718,9 +721,21 @@ class Member(abc.Messageable, _UserTag):
             Pass ``None`` to kick them from voice.
         reason: Optional[:class:`str`]
             The reason for editing this member. Shows up on the audit log.
-        timeout: Optional[:class:`datetime.datetime`]
+        timeout: Optional[Union[:class:`~datetime.datetime`, :class:`~datetime.timedelta`]
             The time until the member should not be timed out.
             Set this to None to disable their timeout.
+
+            Example
+            -------
+            .. code-block:: py
+
+                from datetime import timedelta
+
+                ...
+
+                await member.edit(timeout=timedelta(hours=1))
+
+            .. versionadded:: 2.0
 
         Raises
         -------
@@ -778,11 +793,19 @@ class Member(abc.Messageable, _UserTag):
         if roles is not MISSING:
             payload['roles'] = tuple(r.id for r in roles)
 
-        if timeout is not MISSING:
-            if timeout is not None:
-                payload['communication_disabled_until'] = timeout.isoformat()
-            else:
-                payload['communication_disabled_until'] = None
+        if isinstance(timeout, datetime.timedelta):
+            payload['communication_disabled_until'] = (
+                utils.utcnow() + timeout
+            ).isoformat()
+        elif isinstance(timeout, datetime.datetime):
+            payload['communication_disabled_until'] = timeout.isoformat()
+        elif timeout is None:
+            payload['communication_disabled_until'] = None
+        else:
+            raise TypeError(
+                "Timeout must be a `datetime.datetime` or `datetime.timedelta`"
+                f"not {timeout.__class__.__name__}"
+            )
 
         if payload:
             data = await http.edit_member(guild_id, self.id, reason=reason, **payload)

--- a/nextcord/member.py
+++ b/nextcord/member.py
@@ -725,16 +725,6 @@ class Member(abc.Messageable, _UserTag):
             The time until the member should not be timed out.
             Set this to None to disable their timeout.
 
-            Example
-            -------
-            .. code-block:: py
-
-                from datetime import timedelta
-
-                ...
-
-                await member.edit(timeout=timedelta(hours=1))
-
             .. versionadded:: 2.0
 
         Raises


### PR DESCRIPTION
## Summary

<!-- What is this pull request for? Does it fix any issues? -->
`Member.edit`'s timeout kwarg can now take a `datetime.timedelta`

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
