### PR TITLE
`Permissions.all()` uses `-1`

### DIFF
--- a/nextcord/permissions.py
+++ b/nextcord/permissions.py
@@ -147,7 +147,7 @@ class Permissions(BaseFlags):
         """A factory method that creates a :class:`Permissions` with all
         permissions set to ``True``.
         """
-        return cls(0b1111111111111111111111111111111111111111)
+        return cls(-1)
 
     @classmethod
     def all_channel(cls: Type[P]) -> P:


### PR DESCRIPTION
This does work, yes, but this should fix an issue with embedded activities and moderate members permissions

## Summary

<!-- What is this pull request for? Does it fix any issues? -->
Fixes multiple permissions issues with moderate members

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
