### PR TITLE
Fix remove_application_command popping keys instead of values

### DIFF
--- a/nextcord/state.py
+++ b/nextcord/state.py
@@ -523,7 +523,7 @@ class ConnectionState:
         signature_set = command.get_rollout_signatures()
         for signature in signature_set:
             self._application_command_signatures.pop(signature, None)
-        for cmd_id in command.command_ids:
+        for cmd_id in command.command_ids.values():
             self._application_command_ids.pop(cmd_id, None)
         self._application_commands.remove(command)
 


### PR DESCRIPTION
## Summary

When removing a command via `remove_application_command`, it attempts to remove command ids from dictionary keys rather than values. This fix simply switches to removing by value instead.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
