### PR TITLE
Add possibility to edit files on a message

### DIFF
--- a/nextcord/http.py
+++ b/nextcord/http.py
@@ -498,27 +498,15 @@ class HTTPClient:
             payload["attachments"] = [{"filename": files[attachment["id"]].filename, **attachment} for attachment in attachments]
 
         form.append({'name': 'payload_json', 'value': utils._to_json(payload)})
-        if len(files) == 1 and False:
-            file = files[0]
+        for index, file in enumerate(files):
             form.append(
                 {
-                    'name': 'file',
+                    'name': f'files[{index}]',
                     'value': file.fp,
                     'filename': file.filename,
                     'content_type': 'application/octet-stream',
                 }
             )
-        else:
-            for index, file in enumerate(files):
-                print(index, file)
-                form.append(
-                    {
-                        'name': f'files[{index}]',
-                        'value': file.fp,
-                        'filename': file.filename,
-                        'content_type': 'application/octet-stream',
-                    }
-                )
 
         return self.request(route, form=form, files=files)
 

--- a/nextcord/message.py
+++ b/nextcord/message.py
@@ -1236,11 +1236,11 @@ class Message(Hashable):
             The updated view to update this message with. If ``None`` is passed then
             the view is removed.
         file: Optional[:class:`File`]
-            A new file to add to the message.
+            If provided, a new file to add to the message.
 
             .. versionadded:: 2.0
         files: Optional[List[:class:`File`]]
-            A list of new files to add to the message.
+            If provided, a list of new files to add to the message.
 
             .. versionadded:: 2.0
         append_files: Optional[:class:`bool`]

--- a/nextcord/message.py
+++ b/nextcord/message.py
@@ -47,6 +47,7 @@ from .guild import Guild
 from .mixins import Hashable
 from .sticker import StickerItem
 from .threads import Thread
+from .object import Object
 
 if TYPE_CHECKING:
     from .types.message import (
@@ -1184,6 +1185,9 @@ class Message(Hashable):
         delete_after: Optional[float] = None,
         allowed_mentions: Optional[AllowedMentions] = MISSING,
         view: Optional[View] = MISSING,
+        file: Optional[File] = MISSING,
+        files: Optional[List[File]] = MISSING,
+        append_files: Optional[bool] = MISSING
     ) -> Message:
         """|coro|
 
@@ -1231,6 +1235,14 @@ class Message(Hashable):
         view: Optional[:class:`~nextcord.ui.View`]
             The updated view to update this message with. If ``None`` is passed then
             the view is removed.
+        file: Optional[:class:`File`]
+            A new file to add to the message.
+        files: Optional[List[:class:`File`]]
+            A list of new files to add to the message.
+        append_files: Optional[:class:`bool`]
+            Whether to append files to the message.
+            If set to True (default), files will be appended to the message.
+            If set to False, files will override the current files on the message.
 
         Raises
         -------
@@ -1252,6 +1264,12 @@ class Message(Hashable):
 
         if embed is not MISSING and embeds is not MISSING:
             raise InvalidArgument('cannot pass both embed and embeds parameter to edit()')
+        if file is not MISSING and files is not MISSING:
+            raise InvalidArgument('cannot pass both file and files parameter to edit()')
+        if file is not MISSING and attachments is not MISSING:
+            raise InvalidArgument('cannot pass both file and attachments parameter to edit()')
+        if files is not MISSING and attachments is not MISSING:
+            raise InvalidArgument('cannot pass both files and fileattachments parameter to edit()')
 
         if embed is not MISSING:
             if embed is None:
@@ -1285,6 +1303,14 @@ class Message(Hashable):
                 payload['components'] = view.to_components()
             else:
                 payload['components'] = []
+
+        if file is not MISSING:
+            payload["files"] = [file]
+        elif files is not MISSING:
+            payload["files"] = files
+
+        if "files" in payload and append_files is not MISSING and not append_files:
+            payload["attachments"] = [{"id": i} for i in range(len(payload["files"]))]
 
         data = await self._state.http.edit_message(self.channel.id, self.id, **payload)
         message = Message(state=self._state, channel=self.channel, data=data)

--- a/nextcord/message.py
+++ b/nextcord/message.py
@@ -1237,12 +1237,18 @@ class Message(Hashable):
             the view is removed.
         file: Optional[:class:`File`]
             A new file to add to the message.
+
+            .. versionadded:: 2.0
         files: Optional[List[:class:`File`]]
             A list of new files to add to the message.
+
+            .. versionadded:: 2.0
         append_files: Optional[:class:`bool`]
             Whether to append files to the message.
             If set to True (default), files will be appended to the message.
             If set to False, files will override the current files on the message.
+
+            .. versionadded:: 2.0
 
         Raises
         -------


### PR DESCRIPTION
## Summary

Adds multiple arguments to the `Message.edit()` function, now allowing to edit files when editing a message.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
