### PR TITLE
Slash fixes

### DIFF
--- a/nextcord/application_command.py
+++ b/nextcord/application_command.py
@@ -101,7 +101,8 @@ class SlashOption:
             name: str = MISSING,
             description: str = MISSING,
             required: bool = MISSING,
-            choices: Dict[str, Union[str, int, float]] = MISSING,
+            # choices: Dict[str, Union[str, int, float]] = MISSING,
+            choices: Union[Dict[str, Union[str, int, float]], Iterable[Union[str, int, float]]] = MISSING,
             channel_types: List[ChannelType] = MISSING,
             min_value: Union[int, float] = MISSING,
             max_value: Union[int, float] = MISSING,
@@ -116,14 +117,17 @@ class SlashOption:
 
         Parameters
         ----------
-        name: Optional[:class:`str`]
+        name: :class:`str`
             The name of the Option on Discords side. If left as None, it defaults to the parameter name.
-        description: Optional[:class:'str']
+        description: :class:'str'
             The description of the Option on Discords side. If left as None, it defaults to "".
-        required: Optional[:class:'bool']
+        required: :class:'bool'
             If a user is required to provide this argument before sending the command. Defaults to Discords choice. (False at this time)
-        choices: Optional[:class:`bool`]
-            Dictionary of choices. The keys are what the user sees, the values correspond to what is sent to us.
+        choices: Union[Dict[:class:`str`, Union[:class:`str`, :class:`int`, :class:`float`]], Iterable[Union[:class:`str`, :class:`int`, :class:`float`]]]
+            A list of choices that a user must choose.
+            If a :class:`dict` is given, the keys are what the users are able to see, the values are what is sent back
+            to the bot.
+            Otherwise, it is treated as an `Iterable` where what the user sees and is sent back to the bot are the same.
         channel_types: List[:class:`ChannelType`]
             List of `ChannelType` enums, limiting the users choice to only those channel types. The parameter must be
             typed as :class:`GuildChannel` for this to function.
@@ -144,7 +148,7 @@ class SlashOption:
         self.name: Optional[str] = name
         self.description: Optional[str] = description
         self.required: Optional[bool] = required
-        self.choices: Optional[dict] = choices
+        self.choices: Optional[Union[Iterable, dict]] = choices
         self.channel_types: Optional[List[ChannelType]] = channel_types
         self.min_value: Optional[Union[int, float]] = min_value
         self.max_value: Optional[Union[int, float]] = max_value
@@ -275,15 +279,20 @@ class CommandOption(SlashOption):
                 ApplicationCommandOptionType.integer, ApplicationCommandOptionType.number):
             raise ValueError("min_value or max_value can only be set if the type is integer or number.")
 
-    def handle_slash_argument(self, state: ConnectionState, argument: Any, interaction: Interaction) -> Any:
+    async def handle_slash_argument(self, state: ConnectionState, argument: Any, interaction: Interaction) -> Any:
         """Handles arguments, specifically for Slash Commands."""
         if self.type is ApplicationCommandOptionType.channel:
             return state.get_channel(int(argument))
         elif self.type is ApplicationCommandOptionType.user:
             if interaction.guild:
-                return interaction.guild.get_member(int(argument))
+                if not (member := interaction.guild.get_member(int(argument))):
+                    member = await interaction.guild.fetch_member(int(argument))
+                return member
             else:
-                return state.get_user(int(argument))
+                if not (user := state.get_user(int(argument))):
+                    data = await state.http.get_user(int(argument))
+                    user = User(state=state, data=data)
+                return user
         elif self.type is ApplicationCommandOptionType.role:
             return interaction.guild.get_role(int(argument))
         elif self.type is ApplicationCommandOptionType.integer:
@@ -294,11 +303,11 @@ class CommandOption(SlashOption):
             return state._get_message(int(argument))
         return argument
 
-    def handle_message_argument(self, *args: List[Any]):
+    async def handle_message_argument(self, *args: List[Any]):
         """For possible future use, will handle arguments specific to Message Commands (Context Menu type.)"""
         raise NotImplementedError  # TODO: Even worth doing? We pass in what we know already.
 
-    def handle_user_argument(self, *args: List[Any]):
+    async def handle_user_argument(self, *args: List[Any]):
         """For possible future use, will handle arguments specific to User Commands (Context Menu type.)"""
         raise NotImplementedError  # TODO: Even worth doing? We pass in what we know already.
 
@@ -329,7 +338,10 @@ class CommandOption(SlashOption):
             ret["required"] = True
 
         if self.choices:
-            ret["choices"] = [{"name": key, "value": value} for key, value in self.choices.items()]
+            if isinstance(self.choices, dict):
+                ret["choices"] = [{"name": key, "value": value} for key, value in self.choices.items()]
+            else:
+                ret["choices"] = [{"name": value, "value": value} for value in self.choices]
         if self.channel_types:
             # noinspection PyUnresolvedReferences
             ret["channel_types"] = [channel_type.value for channel_type in self.channel_types]
@@ -534,9 +546,9 @@ class ApplicationSubcommand:
                 if option := uncalled_options.get(arg_data["name"], None):
                     uncalled_options.pop(option.name)
                     if option.functional_name in autocomplete_kwargs:
-                        kwargs[option.functional_name] = option.handle_slash_argument(state, arg_data["value"], interaction)
+                        kwargs[option.functional_name] = await option.handle_slash_argument(state, arg_data["value"], interaction)
                 elif arg_data["name"] == focused_option.name:
-                    focused_option_value = focused_option.handle_slash_argument(state, arg_data["value"], interaction)
+                    focused_option_value = await focused_option.handle_slash_argument(state, arg_data["value"], interaction)
                 else:
                     # TODO: Handle this better.
                     raise NotImplementedError(
@@ -630,7 +642,7 @@ class ApplicationSubcommand:
             if arg_data["name"] in uncalled_args:
                 uncalled_args.pop(arg_data["name"])
                 kwargs[self.options[arg_data["name"]].functional_name] = \
-                    self.options[arg_data["name"]].handle_slash_argument(state, arg_data["value"], interaction)
+                    await self.options[arg_data["name"]].handle_slash_argument(state, arg_data["value"], interaction)
             else:
                 # TODO: Handle this better.
                 raise NotImplementedError(
@@ -690,7 +702,6 @@ class ApplicationSubcommand:
                         return func
                     return decorator
                 else:
-                    print(type(option.autocomplete))
                     raise ValueError(f"{self.error_name} autocomplete for kwarg {on_kwarg} not enabled, cannot add "
                                      f"autocomplete function.")
         if found is False:
@@ -913,6 +924,7 @@ class ApplicationCommand(ApplicationSubcommand):
         self.set_state(state)
         command_id = int(data["id"])
         if guild_id := data.get("guild_id", None):
+            guild_id = int(guild_id)
             self._command_ids[guild_id] = command_id
             self._guild_ids.add(guild_id)
             self.add_guild_rollout(guild_id)

--- a/nextcord/ext/commands/bot.py
+++ b/nextcord/ext/commands/bot.py
@@ -611,6 +611,10 @@ class BotBase(GroupMixin):
             help_command.cog = None
         cog._eject(self)
 
+        # TODO: This blind call to nextcord.Client is dumb.
+        super().remove_cog(cog)
+        # See Bot.add_cog() for the reason why.
+
         return cog
 
     @property

--- a/nextcord/guild.py
+++ b/nextcord/guild.py
@@ -2994,6 +2994,44 @@ class Guild(Hashable):
             update_known=update_known
         )
 
+    async def rollout_application_commands(
+            self,
+            associate_known: bool = True,
+            delete_unknown: bool = True,
+            update_known: bool = True,
+            register_new: bool = True
+    ) -> bool:
+        """|coro|
+        Rolls out application commands to the guild, associating, deleting, updating, and/or newly
+        registering as needed.
+
+        Parameters
+        ----------
+        associate_known: :class:`bool`
+            Whether commands on Discord that match a locally added command should be associated with each other.
+            Defaults to ``True``
+        delete_unknown
+        update_known
+        register_new
+
+        Returns
+        -------
+        :class:`bool`
+            ``False`` if no commands that specify a guild have been added to the bot. ``True`` otherwise.
+        """
+        if self._state.get_guild_application_commands(self.id, rollout=True):
+            guild_payload = await self._state.http.get_guild_commands(self._state.application_id, self.id)
+            await self.deploy_application_commands(
+                data=guild_payload,
+                associate_known=associate_known,
+                delete_unknown=delete_unknown,
+                update_known=update_known
+            )
+            if register_new:
+                await self.register_new_application_commands(data=guild_payload)
+            return True
+        return False
+
     async def delete_unknown_application_commands(self, data: Optional[List[dict]] = None) -> None:
         await self._state.delete_unknown_application_commands(data=data, guild_id=self.id)
 


### PR DESCRIPTION
SlashOption's choice param now takes an iterable.
rollout_all_guilds kwarg for Client now determines if all Guilds are rollout'd to instead of just the ones specified by the guild_ids param in commands. This is a fix towards the cloudflare ban.
handle_slash_argument is now async, and will auto-fetch user/member if they aren't found in the cache.
Added basic cog reloading support, fix application commands not actually getting removed.
Guild now has its own rollout command.

## Summary

<!-- What is this pull request for? Does it fix any issues? -->
Adds a fix towards #310, but the only real fix for that is fixing http.
Contains the same exact fix as #313, sorry.
When a member/user can't be gotten from the cache (hi intents!), slash commands will now attempt to fetch it.
Adds a variety of fixes and a few helpers for slash stuff.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [X] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [X] This PR fixes an issue.
- [X] This PR adds something new (e.g. new method or parameters).
- [X] This PR is a breaking change (e.g. methods or parameters removed/renamed) [for some inner slash stuff]
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
