### PR TITLE
Add raw_member_remove event

### DIFF
--- a/nextcord/http.py
+++ b/nextcord/http.py
@@ -498,27 +498,15 @@ class HTTPClient:
             payload["attachments"] = [{"filename": files[attachment["id"]].filename, **attachment} for attachment in attachments]
 
         form.append({'name': 'payload_json', 'value': utils._to_json(payload)})
-        if len(files) == 1 and False:
-            file = files[0]
+        for index, file in enumerate(files):
             form.append(
                 {
-                    'name': 'file',
+                    'name': f'files[{index}]',
                     'value': file.fp,
                     'filename': file.filename,
                     'content_type': 'application/octet-stream',
                 }
             )
-        else:
-            for index, file in enumerate(files):
-                print(index, file)
-                form.append(
-                    {
-                        'name': f'files[{index}]',
-                        'value': file.fp,
-                        'filename': file.filename,
-                        'content_type': 'application/octet-stream',
-                    }
-                )
 
         return self.request(route, form=form, files=files)
 

--- a/nextcord/message.py
+++ b/nextcord/message.py
@@ -47,6 +47,7 @@ from .guild import Guild
 from .mixins import Hashable
 from .sticker import StickerItem
 from .threads import Thread
+from .object import Object
 
 if TYPE_CHECKING:
     from .types.message import (
@@ -1184,6 +1185,9 @@ class Message(Hashable):
         delete_after: Optional[float] = None,
         allowed_mentions: Optional[AllowedMentions] = MISSING,
         view: Optional[View] = MISSING,
+        file: Optional[File] = MISSING,
+        files: Optional[List[File]] = MISSING,
+        append_files: Optional[bool] = MISSING
     ) -> Message:
         """|coro|
 
@@ -1231,6 +1235,14 @@ class Message(Hashable):
         view: Optional[:class:`~nextcord.ui.View`]
             The updated view to update this message with. If ``None`` is passed then
             the view is removed.
+        file: Optional[:class:`File`]
+            A new file to add to the message.
+        files: Optional[List[:class:`File`]]
+            A list of new files to add to the message.
+        append_files: Optional[:class:`bool`]
+            Whether to append files to the message.
+            If set to True (default), files will be appended to the message.
+            If set to False, files will override the current files on the message.
 
         Raises
         -------
@@ -1252,6 +1264,12 @@ class Message(Hashable):
 
         if embed is not MISSING and embeds is not MISSING:
             raise InvalidArgument('cannot pass both embed and embeds parameter to edit()')
+        if file is not MISSING and files is not MISSING:
+            raise InvalidArgument('cannot pass both file and files parameter to edit()')
+        if file is not MISSING and attachments is not MISSING:
+            raise InvalidArgument('cannot pass both file and attachments parameter to edit()')
+        if files is not MISSING and attachments is not MISSING:
+            raise InvalidArgument('cannot pass both files and fileattachments parameter to edit()')
 
         if embed is not MISSING:
             if embed is None:
@@ -1285,6 +1303,14 @@ class Message(Hashable):
                 payload['components'] = view.to_components()
             else:
                 payload['components'] = []
+
+        if file is not MISSING:
+            payload["files"] = [file]
+        elif files is not MISSING:
+            payload["files"] = files
+
+        if "files" in payload and append_files is not MISSING and not append_files:
+            payload["attachments"] = [{"id": i} for i in range(len(payload["files"]))]
 
         data = await self._state.http.edit_message(self.channel.id, self.id, **payload)
         message = Message(state=self._state, channel=self.channel, data=data)

--- a/nextcord/raw_models.py
+++ b/nextcord/raw_models.py
@@ -36,11 +36,13 @@ if TYPE_CHECKING:
         ReactionClearEvent,
         ReactionClearEmojiEvent,
         IntegrationDeleteEvent,
-        TypingEvent
+        TypingEvent,
+        MemberRemoveEvent
     )
     from .message import Message
     from .partial_emoji import PartialEmoji
     from .member import Member
+    from .user import User
 
 
 __all__ = (
@@ -285,7 +287,7 @@ class RawTypingEvent(_RawReprMixin):
     """Represents the payload for a :func:`on_raw_typing` event.
 
     .. versionadded:: 2.0
-    
+
     Attributes
     -----------
     channel_id: :class:`int`
@@ -312,3 +314,21 @@ class RawTypingEvent(_RawReprMixin):
             self.guild_id: Optional[int] = int(data['guild_id'])
         except KeyError:
             self.guild_id: Optional[int] = None
+
+
+class RawMemberRemoveEvent(_RawReprMixin):
+    """Represents the payload for a :func:`on_raw_member_remove` event.
+
+    .. versionadded:: 2.0
+
+    Attributes
+    -----------
+    guild_id: :class:`int`
+        The guild ID where the member left from.
+    user: :class:`User`
+        The user who left the guild."""
+    __slots__ = ("guild_id", "user")
+
+    def __init__(self, data: MemberRemoveEvent) -> None:
+        self.guild_id: int = int(data["guild_id"])
+        self.user: User = None

--- a/nextcord/raw_models.py
+++ b/nextcord/raw_models.py
@@ -328,6 +328,7 @@ class RawMemberRemoveEvent(_RawReprMixin):
         The guild ID where the member left from.
     user: :class:`User`
         The user who left the guild."""
+
     __slots__ = ("guild_id", "user")
 
     def __init__(self, data: MemberRemoveEvent) -> None:

--- a/nextcord/raw_models.py
+++ b/nextcord/raw_models.py
@@ -54,6 +54,7 @@ __all__ = (
     'RawReactionClearEmojiEvent',
     'RawIntegrationDeleteEvent',
     'RawTypingEvent',
+    "RawMemberRemoveEvent"
 )
 
 

--- a/nextcord/state.py
+++ b/nextcord/state.py
@@ -1267,6 +1267,11 @@ class ConnectionState:
             except AttributeError:
                 pass
 
+            raw = RawMemberRemoveEvent(data)
+            user = User(state=self, data=data["user"])
+            raw.user = user
+            self.dispatch("raw_member_remove", raw)
+
             user_id = int(data['user']['id'])
             member = guild.get_member(user_id)
             if member is not None:

--- a/nextcord/types/raw_models.py
+++ b/nextcord/types/raw_models.py
@@ -26,6 +26,7 @@ from typing import TypedDict, List
 from .snowflake import Snowflake
 from .member import Member
 from .emoji import PartialEmoji
+from .user import User
 
 
 class _MessageEventOptional(TypedDict, total=False):
@@ -96,3 +97,8 @@ class TypingEvent(_TypingEventOptional):
     channel_id: Snowflake
     user_id: Snowflake
     timestamp: int
+
+
+class MemberRemoveEvent(TypedDict):
+    guild_id: Snowflake
+    user: User


### PR DESCRIPTION
## Summary

Adds a raw_member_remove event, useful in case the member isn't cached (or chunking is disabled) which makes the client not fire an event at all when a member leaves a guild.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
