### PR TITLE
Add raw_member_remove event

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -832,6 +832,18 @@ to handle it, which defaults to print a traceback and ignoring the exception.
     :param member: The member who joined or left.
     :type member: :class:`Member`
 
+.. function:: on_raw_member_remove(payload)
+
+    Called when a :class:`Member` leaves a :class:`Guild`. Unlike :func:`on_member_remove` this is called
+    regardless of the state of the internal message cache.
+
+    This requires :attr:`Intents.members` to be enabled.
+
+    .. versionadded:: 2.0
+
+    :param payload: The raw event payload data.
+    :type payload: :class:`RawMemberRemoveEvent`
+
 .. function:: on_member_update(before, after)
 
     Called when a :class:`Member` updates their profile.

--- a/nextcord/raw_models.py
+++ b/nextcord/raw_models.py
@@ -54,7 +54,7 @@ __all__ = (
     'RawReactionClearEmojiEvent',
     'RawIntegrationDeleteEvent',
     'RawTypingEvent',
-    "RawMemberRemoveEvent"
+    "RawMemberRemoveEvent",
 )
 
 

--- a/nextcord/raw_models.py
+++ b/nextcord/raw_models.py
@@ -36,11 +36,13 @@ if TYPE_CHECKING:
         ReactionClearEvent,
         ReactionClearEmojiEvent,
         IntegrationDeleteEvent,
-        TypingEvent
+        TypingEvent,
+        MemberRemoveEvent
     )
     from .message import Message
     from .partial_emoji import PartialEmoji
     from .member import Member
+    from .user import User
 
 
 __all__ = (
@@ -52,6 +54,7 @@ __all__ = (
     'RawReactionClearEmojiEvent',
     'RawIntegrationDeleteEvent',
     'RawTypingEvent',
+    "RawMemberRemoveEvent"
 )
 
 
@@ -285,7 +288,7 @@ class RawTypingEvent(_RawReprMixin):
     """Represents the payload for a :func:`on_raw_typing` event.
 
     .. versionadded:: 2.0
-    
+
     Attributes
     -----------
     channel_id: :class:`int`
@@ -312,3 +315,20 @@ class RawTypingEvent(_RawReprMixin):
             self.guild_id: Optional[int] = int(data['guild_id'])
         except KeyError:
             self.guild_id: Optional[int] = None
+
+
+class RawMemberRemoveEvent(_RawReprMixin):
+    """Represents the payload for a :func:`on_raw_member_remove` event.
+    .. versionadded:: 2.0
+    Attributes
+    -----------
+    guild_id: :class:`int`
+        The guild ID where the member left from.
+    user: :class:`User`
+        The user who left the guild."""
+
+    __slots__ = ("guild_id", "user")
+
+    def __init__(self, data: MemberRemoveEvent) -> None:
+        self.guild_id: int = int(data["guild_id"])
+        self.user: User = None

--- a/nextcord/raw_models.py
+++ b/nextcord/raw_models.py
@@ -37,7 +37,7 @@ if TYPE_CHECKING:
         ReactionClearEmojiEvent,
         IntegrationDeleteEvent,
         TypingEvent,
-        MemberRemoveEvent
+        MemberRemoveEvent,
     )
     from .message import Message
     from .partial_emoji import PartialEmoji

--- a/nextcord/raw_models.py
+++ b/nextcord/raw_models.py
@@ -325,7 +325,8 @@ class RawMemberRemoveEvent(_RawReprMixin):
     guild_id: :class:`int`
         The guild ID where the member left from.
     user: :class:`User`
-        The user who left the guild."""
+        The user who left the guild.
+    """
 
     __slots__ = ("guild_id", "user")
 

--- a/nextcord/state.py
+++ b/nextcord/state.py
@@ -1267,6 +1267,11 @@ class ConnectionState:
             except AttributeError:
                 pass
 
+            raw = RawMemberRemoveEvent(data)
+            user = User(state=self, data=data["user"])
+            raw.user = user
+            self.dispatch("raw_member_remove", raw)
+
             user_id = int(data['user']['id'])
             member = guild.get_member(user_id)
             if member is not None:

--- a/nextcord/types/raw_models.py
+++ b/nextcord/types/raw_models.py
@@ -26,6 +26,7 @@ from typing import TypedDict, List
 from .snowflake import Snowflake
 from .member import Member
 from .emoji import PartialEmoji
+from .user import User
 
 
 class _MessageEventOptional(TypedDict, total=False):
@@ -96,3 +97,8 @@ class TypingEvent(_TypingEventOptional):
     channel_id: Snowflake
     user_id: Snowflake
     timestamp: int
+
+
+class MemberRemoveEvent(TypedDict):
+    guild_id: Snowflake
+    user: User


### PR DESCRIPTION
## Summary

Adds a raw_member_remove event, useful in case the member isn't cached (or chunking is disabled) which makes the client not fire an event at all when a member leaves a guild.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
