### PR TITLE
Fix: member.edit without a timeout raising an error

### DIFF
--- a/nextcord/member.py
+++ b/nextcord/member.py
@@ -789,7 +789,7 @@ class Member(abc.Messageable, _UserTag):
             ).isoformat()
         elif isinstance(timeout, datetime.datetime):
             payload['communication_disabled_until'] = timeout.isoformat()
-        elif timeout is None:
+        elif timeout is MISSING or timeout is None:
             payload['communication_disabled_until'] = None
         else:
             raise TypeError(

--- a/nextcord/member.py
+++ b/nextcord/member.py
@@ -789,8 +789,10 @@ class Member(abc.Messageable, _UserTag):
             ).isoformat()
         elif isinstance(timeout, datetime.datetime):
             payload['communication_disabled_until'] = timeout.isoformat()
-        elif timeout is MISSING or timeout is None:
+        elif timeout is None:
             payload['communication_disabled_until'] = None
+        elif timeout is MISSING:
+            pass
         else:
             raise TypeError(
                 "Timeout must be a `datetime.datetime` or `datetime.timedelta`"


### PR DESCRIPTION


## Summary

Default value for `timeout` parameter is MISSING, but it's checking `if timeout is None`.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
