### PR TITLE
chore: bump version to 2.0.0a6

### DIFF
--- a/nextcord/__init__.py
+++ b/nextcord/__init__.py
@@ -14,7 +14,7 @@ __title__ = 'discord'
 __author__ = 'tag-epic & Rapptz'
 __license__ = 'MIT'
 __copyright__ = 'Copyright 2015-present Rapptz'
-__version__ = '2.0.0a5'
+__version__ = '2.0.0a6'
 
 __path__ = __import__('pkgutil').extend_path(__path__, __name__)
 


### PR DESCRIPTION
## Summary

Bumps the version to 2.0.0a6 for a new PyPI release fixing a bug

