### PR TITLE
Add handler for message thread field update

### DIFF
--- a/nextcord/message.py
+++ b/nextcord/message.py
@@ -683,7 +683,7 @@ class Message(Hashable):
             self.guild = state._get_guild(utils._get_as_snowflake(data, 'guild_id'))
 
         thread_data = data.get('thread')
-        if self.guild and thread_data:
+        if thread_data:
             self.thread: Optional[Thread] = Thread(guild=self.guild, state=state, data=thread_data)
         else:
             self.thread: Optional[Thread] = None

--- a/nextcord/message.py
+++ b/nextcord/message.py
@@ -599,7 +599,7 @@ class Message(Hashable):
 
         .. versionadded:: 2.0
     thread: Optional[:class:`Thread`]
-        The thread created from this message, if any.
+        The thread created from a message, if any.
 
         .. versionadded:: 2.0
     guild: Optional[:class:`Guild`]

--- a/nextcord/message.py
+++ b/nextcord/message.py
@@ -59,7 +59,7 @@ if TYPE_CHECKING:
     )
 
     from .types.components import Component as ComponentPayload
-    from .types.threads import ThreadArchiveDuration
+    from .types.threads import ThreadArchiveDuration, Thread as ThreadPayload
     from .types.member import (
         Member as MemberPayload,
         UserWithMember as UserWithMemberPayload,
@@ -884,6 +884,12 @@ class Message(Hashable):
 
     def _handle_components(self, components: List[ComponentPayload]):
         self.components = [_component_factory(d) for d in components]
+
+    def _handle_thread(self, thread: Optional[ThreadPayload]) -> None:
+        if thread:
+            self.thread = Thread(guild=self.guild, state=self._state, data=thread)
+        else:
+            self.thread = None
 
     def _rebind_cached_references(self, new_guild: Guild, new_channel: Union[TextChannel, Thread]) -> None:
         self.guild = new_guild

--- a/nextcord/message.py
+++ b/nextcord/message.py
@@ -598,6 +598,10 @@ class Message(Hashable):
         A list of components in the message.
 
         .. versionadded:: 2.0
+    thread: Optional[:class:`Thread`]
+        The thread created from this message, if any.
+
+        .. versionadded:: 2.0
     guild: Optional[:class:`Guild`]
         The guild that the message belongs to, if applicable.
     """
@@ -632,6 +636,7 @@ class Message(Hashable):
         'activity',
         'stickers',
         'components',
+        'thread',
         'guild',
     )
 
@@ -676,6 +681,12 @@ class Message(Hashable):
             self.guild = channel.guild  # type: ignore
         except AttributeError:
             self.guild = state._get_guild(utils._get_as_snowflake(data, 'guild_id'))
+
+        thread_data = data.get('thread')
+        if self.guild and thread_data:
+            self.thread: Optional[Thread] = Thread(guild=self.guild, state=state, data=thread_data)
+        else:
+            self.thread: Optional[Thread] = None
 
         try:
             ref = data['message_reference']


### PR DESCRIPTION
## Summary

Parse and use the `thread` field on message update, not just when creating a new message.

For example, the following code:

```python
import nextcord

client = nextcord.Client(intents=nextcord.Intents.all())

@client.event
async def on_message_edit(before, after):
    await after.channel.send(str(after.thread))

client.run("token")
```

Would send `None` in any circumstance before this change, but will send the name of the thread created from the edited message (if any) after this change. This has been tested.

## Checklist

- [x] If code changes were made then they have been tested.
- [x] This PR fixes an issue.
