### PR TITLE
Slash fixes

### DIFF
--- a/nextcord/application_command.py
+++ b/nextcord/application_command.py
@@ -304,11 +304,11 @@ class CommandOption(SlashOption):
             return state._get_message(int(argument))
         return argument
 
-    async def handle_message_argument(self, *args: List[Any]):
+    async def handle_message_argument(self, state: ConnectionState, argument: Any, interaction: Interaction):
         """For possible future use, will handle arguments specific to Message Commands (Context Menu type.)"""
         raise NotImplementedError  # TODO: Even worth doing? We pass in what we know already.
 
-    async def handle_user_argument(self, *args: List[Any]):
+    async def handle_user_argument(self, state: ConnectionState, argument: Any, interaction: Interaction):
         """For possible future use, will handle arguments specific to User Commands (Context Menu type.)"""
         raise NotImplementedError  # TODO: Even worth doing? We pass in what we know already.
 
@@ -330,8 +330,10 @@ class CommandOption(SlashOption):
         # when possible minimizes the payload size and makes checks between registered and found commands easier.
         if self.required:
             ret["required"] = self.required
-        if self.required is not MISSING:
+        elif self.required is False:
             pass  # Discord doesn't currently provide Required if it's False due to it being default.
+        elif self.required is MISSING and self.default:
+            pass  # If required isn't explicitly set and a default exists, don't say that this param is required.
         else:
             # While this violates Discord's default and our goal (not specified should return minimum or nothing), a
             # parameter being optional by default goes against traditional programming. A parameter not explicitly
@@ -339,10 +341,11 @@ class CommandOption(SlashOption):
             ret["required"] = True
 
         if self.choices:
+            # Discord returns the names as strings, might as well do it here so payload comparison is easy.
             if isinstance(self.choices, dict):
-                ret["choices"] = [{"name": key, "value": value} for key, value in self.choices.items()]
+                ret["choices"] = [{"name": str(key), "value": value} for key, value in self.choices.items()]
             else:
-                ret["choices"] = [{"name": value, "value": value} for value in self.choices]
+                ret["choices"] = [{"name": str(value), "value": value} for value in self.choices]
         if self.channel_types:
             # noinspection PyUnresolvedReferences
             ret["channel_types"] = [channel_type.value for channel_type in self.channel_types]
@@ -413,6 +416,10 @@ class ApplicationSubcommand:
         else:
             return self._description
 
+    @description.setter
+    def description(self, new_desc: str):
+        self._description = new_desc
+
     @property
     def callback(self) -> Optional[Callable]:
         """Returns the callback associated with this ApplicationCommand."""
@@ -424,6 +431,12 @@ class ApplicationSubcommand:
             raise TypeError("Callback must be a coroutine.")
         self._callback = callback
         return self
+
+    @property
+    def self_argument(self) -> Optional:
+        """Returns the argument used for ``self``. Optional is used because :class:`ClientCog` isn't strictly correct.
+        """
+        return self._self_argument
 
     def set_self_argument(self, self_arg: ClientCog) -> ApplicationSubcommand:
         """Sets the `self` argument, used when the callback is inside a class."""
@@ -495,7 +508,8 @@ class ApplicationSubcommand:
         self.verify_content()
         ret = {
             "type": self.type.value,
-            "name": self.name,
+            # Might as well stringify the name, will come in handy if people try using numbers
+            "name": str(self.name),
             "description": self.description,
         }
         if self.children:
@@ -560,7 +574,10 @@ class ApplicationSubcommand:
             for option in uncalled_options.values():
                 if option.functional_name in autocomplete_kwargs:
                     kwargs[option.functional_name] = option.default
-            await self.invoke_autocomplete(interaction, focused_option, focused_option_value, **kwargs)
+            value = await self.invoke_autocomplete(interaction, focused_option, focused_option_value, **kwargs)
+            # Handles when the autocomplete callback returns something and didn't run the autocomplete function.
+            if value and not interaction.response.is_done():
+                await interaction.response.send_autocomplete(value)
         else:
             raise TypeError(f"{self.error_name} Autocomplete is not handled by this type of command.")
 
@@ -570,7 +587,7 @@ class ApplicationSubcommand:
             focused_option: CommandOption,
             focused_option_value: Any,
             **kwargs
-    ) -> None:
+    ) -> Any:
         """|coro|
         Invokes the autocomplete callback of the given option.
 
@@ -589,9 +606,11 @@ class ApplicationSubcommand:
             Keyword arguments to forward to the autocomplete callback.
         """
         if self._self_argument:
-            await focused_option.autocomplete_function(self._self_argument, interaction, focused_option_value, **kwargs)
+            return await focused_option.autocomplete_function(
+                self._self_argument, interaction, focused_option_value, **kwargs
+            )
         else:
-            await focused_option.autocomplete_function(interaction, focused_option_value, **kwargs)
+            return await focused_option.autocomplete_function(interaction, focused_option_value, **kwargs)
 
     async def call(self, state: ConnectionState, interaction: Interaction, option_data: List[Dict[str, Any]]) -> None:
         """|coro|
@@ -946,9 +965,13 @@ class ApplicationCommand(ApplicationSubcommand):
         #  It's not that I'm unhappy adding things to the cache, it's having to manually do it like this.
         # The interaction gives us message data, might as well use it and add it to the cache.
         channel, guild = self._state._get_guild_channel(message_data)
+
         message = Message(channel=channel, data=message_data, state=self._state)
-        if not self._state._get_message(message.id) and self._state._messages is not None:
-            self._state._messages.append(message)
+        if cached_message := self._state._get_message(message.id):
+            return cached_message
+        else:
+            if self._state._messages is not None:
+                self._state._messages.append(message)
         return message
 
     def _handle_resolved_user(self, user_data: dict) -> User:
@@ -1108,12 +1131,12 @@ class ApplicationCommand(ApplicationSubcommand):
 
     async def call_autocomplete_from_interaction(self, interaction: Interaction):
         if not self._state:
-            raise NotImplementedError("State hasn't been set yet, this isn't handled yet!")
+            raise NotImplementedError("State hasn't been set, this isn't handled yet!")
         await self.call_autocomplete(self._state, interaction, interaction.data.get("options", {}))
 
     async def call_from_interaction(self, interaction: Interaction) -> None:
         if not self._state:
-            raise NotImplementedError("State hasn't been set yet, this isn't handled yet!")
+            raise NotImplementedError("State hasn't been set, this isn't handled yet!")
         await self.call(self._state, interaction, interaction.data.get("options", {}))
 
     async def call(self, state: ConnectionState, interaction: Interaction, option_data: List[Dict[str, Any]]) -> None:

--- a/nextcord/client.py
+++ b/nextcord/client.py
@@ -1805,6 +1805,25 @@ class Client:
     def get_application_command(self, command_id: int) -> Optional[ApplicationCommand]:
         return self._connection.get_application_command(command_id)
 
+    def get_all_application_commands(self) -> Set[ApplicationCommand]:
+        """Returns a copied set of all added :class:`ApplicationCommand` objects."""
+        return self._connection.application_commands
+
+    def get_application_commands(self, rollout: bool = False) -> List[ApplicationCommand]:
+        """Gets registered global commands.
+
+        Parameters
+        ----------
+        rollout: :class:`bool`
+            Whether unregistered/unassociated commands should be returned as well. Defaults to ``False``
+
+        Returns
+        -------
+        List[:class:`ApplicationCommand`]
+            List of :class:`ApplicationCommand` objects that are global.
+        """
+        return self._connection.get_global_application_commands(rollout=rollout)
+
     def add_application_command(
             self,
             command: ApplicationCommand,
@@ -1881,14 +1900,6 @@ class Client:
                     ret[guild_id].add(command)
         return ret
 
-    async def register_bulk_application_commands(self) -> None:
-        # TODO: Using Bulk upsert seems to delete all commands
-        # It might be good to keep this around as a reminder for future work. Bulk upsert seem to delete everything
-        # that isn't part of that bulk upsert, for both global and guild commands. While useful, this will
-        # update/overwrite existing commands, which may (needs testing) wipe out all permissions associated with those
-        # commands. Look for an opportunity to use bulk upsert.
-        raise NotImplementedError
-
     async def on_connect(self) -> None:
         self.add_startup_application_commands()
         await self.rollout_application_commands()
@@ -1904,14 +1915,16 @@ class Client:
 
     async def on_guild_available(self, guild: Guild) -> None:
         try:
-            if (await guild.rollout_application_commands(
+            if self._rollout_all_guilds or self._connection.get_guild_application_commands(guild.id, rollout=True):
+                _log.info(f"nextcord.Client: Rolling out commands to guild {guild.name}|{guild.id}")
+                await guild.rollout_application_commands(
                     associate_known=self._rollout_associate_known,
                     delete_unknown=self._rollout_delete_unknown,
                     update_known=self._rollout_update_known
-            )):
-                pass
+                )
             else:
-                _log.info(f"No locally added commands explicitly registered for {guild.name}|{guild.id}, not checking.")
+                _log.info(f"nextcord.Client: No locally added commands explicitly registered for "
+                          f"{guild.name}|{guild.id}, not checking.")
         except Forbidden as e:
             _log.warning(f"nextcord.Client: Forbidden error for {guild.name}|{guild.id}, is the commands Oauth scope "
                          f"enabled? {e}")

--- a/nextcord/guild.py
+++ b/nextcord/guild.py
@@ -3169,6 +3169,19 @@ class Guild(Hashable):
         data = await self._state.http.create_event(self.id, reason=reason, **payload)
         return self._store_scheduled_event(data)
 
+    def get_application_commands(self, rollout: bool = False):
+        """Gets all application commands registered for this guild.
+
+        Parameters
+        ----------
+        rollout: :class:`bool`
+
+        Returns
+        -------
+
+        """
+        return self._state.get_guild_application_commands(guild_id=self.id, rollout=rollout)
+
     def add_application_command(
             self,
             app_cmd: ApplicationCommand,
@@ -3199,7 +3212,7 @@ class Guild(Hashable):
             delete_unknown: bool = True,
             update_known: bool = True,
             register_new: bool = True
-    ) -> bool:
+    ) -> None:
         """|coro|
         Rolls out application commands to the guild, associating, deleting, updating, and/or newly
         registering as needed.
@@ -3212,24 +3225,16 @@ class Guild(Hashable):
         delete_unknown
         update_known
         register_new
-
-        Returns
-        -------
-        :class:`bool`
-            ``False`` if no commands that specify a guild have been added to the bot. ``True`` otherwise.
         """
-        if self._state.get_guild_application_commands(self.id, rollout=True):
-            guild_payload = await self._state.http.get_guild_commands(self._state.application_id, self.id)
-            await self.deploy_application_commands(
-                data=guild_payload,
-                associate_known=associate_known,
-                delete_unknown=delete_unknown,
-                update_known=update_known
-            )
-            if register_new:
-                await self.register_new_application_commands(data=guild_payload)
-            return True
-        return False
+        guild_payload = await self._state.http.get_guild_commands(self._state.application_id, self.id)
+        await self.deploy_application_commands(
+            data=guild_payload,
+            associate_known=associate_known,
+            delete_unknown=delete_unknown,
+            update_known=update_known
+        )
+        if register_new:
+            await self.register_new_application_commands(data=guild_payload)
 
     async def delete_unknown_application_commands(self, data: Optional[List[dict]] = None) -> None:
         await self._state.delete_unknown_application_commands(data=data, guild_id=self.id)


### PR DESCRIPTION

## Summary

<!-- What is this pull request for? Does it fix any issues? -->
* Reverted command check inside Guild.rollout_applicaiton_commands, added it to Client.on_guild_available. Fixed rollout_all_guilds kwarg.
* Fixed payload mismatch issue by forcing option names to be strings.
* Fixed optional params being broken.
* Added functions to get global commands and all added ApplicationCommand objects.
* Self argument for the callback of ApplicationCommand now gettable via .self_argument
* Added Guild.get_application_commands() to get commands added to the guild.
* Added ability for autocomplete callbacks to return a dict or Iterable instead of calling Interaction.response.send_autocomplete()
* Messages commands will now return the cached message object if it exists.
* Fully commented out and moved register_bulk_application_commands() to state.py

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [X] If code changes were made then they have been tested.
    - Note: Git had a conflict in guild.py, I'm *pretty sure* I resolved it correctly but ehhhhh...
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [X] This PR adds something new (e.g. new method or parameters).
- [X] This PR is a breaking change (e.g. methods or parameters removed/renamed)
    - For Slash functions.
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
