### PR TITLE
feat: Send files with interaction response

### DIFF
--- a/nextcord/abc.py
+++ b/nextcord/abc.py
@@ -1338,8 +1338,6 @@ class Messageable:
             embed = embed.to_dict()
 
         elif embeds is not None:
-            if len(embeds) > 10:
-                raise InvalidArgument('embeds parameter must be a list of up to 10 elements')
             embeds = [embed.to_dict() for embed in embeds]
 
         if stickers is not None:
@@ -1396,10 +1394,8 @@ class Messageable:
                 file.close()
 
         elif files is not None:
-            if len(files) > 10:
-                raise InvalidArgument('files parameter must be a list of up to 10 elements')
-            elif not all(isinstance(file, File) for file in files):
-                raise InvalidArgument('files parameter must be a list of File')
+            if not all(isinstance(file, File) for file in files):
+                raise TypeError('Files parameter must be a list of type File')
 
             try:
                 data = await state.http.send_files(

--- a/nextcord/interactions.py
+++ b/nextcord/interactions.py
@@ -666,14 +666,19 @@ class InteractionResponse:
 
         parent = self._parent
         adapter = async_context.get()
-        await adapter.create_interaction_response(
-            parent.id,
-            parent.token,
-            session=parent._session,
-            type=InteractionResponseType.channel_message.value,
-            data=payload,
-            files=files,
-        )
+        try:
+            await adapter.create_interaction_response(
+                parent.id,
+                parent.token,
+                session=parent._session,
+                type=InteractionResponseType.channel_message.value,
+                data=payload,
+                files=files,
+            )
+        finally:
+            if files:
+                for file in files:
+                    file.close()
 
         if view is not MISSING:
             if ephemeral and view.timeout is None:

--- a/nextcord/interactions.py
+++ b/nextcord/interactions.py
@@ -633,27 +633,24 @@ class InteractionResponse:
         }
 
         if embed is not MISSING and embeds is not MISSING:
-            raise TypeError('cannot mix embed and embeds keyword arguments')
+            raise TypeError('Cannot mix embed and embeds keyword arguments')
 
         if embed is not MISSING:
             embeds = [embed]
 
         if embeds:
             if len(embeds) > 10:
-                raise ValueError('embeds cannot exceed maximum of 10 elements')
+                raise ValueError('Embeds cannot exceed maximum of 10 elements')
             payload['embeds'] = [e.to_dict() for e in embeds]
 
         if file is not MISSING and files is not MISSING:
-            raise TypeError('cannot mix file and files keyword arguments')
+            raise TypeError('Cannot mix file and files keyword arguments')
 
         if file is not MISSING:
             files = [file]
 
-        if files:
-            if len(files) > 10:
-                raise ValueError('files cannot exceed maximum of 10 elements')
-            if any(not isinstance(f, File) for f in files):
-                raise TypeError('files must be an instance of File')
+        if files and any(not isinstance(f, File) for f in files):
+            raise TypeError('Files must be an instance of File')
 
         if content is not None:
             payload['content'] = str(content)

--- a/nextcord/interactions.py
+++ b/nextcord/interactions.py
@@ -639,8 +639,6 @@ class InteractionResponse:
             embeds = [embed]
 
         if embeds:
-            if any(not isinstance(embed, Embed) for embed in embeds):
-                raise TypeError('Embeds must be of type Embed')
             payload['embeds'] = [e.to_dict() for e in embeds]
 
         if file is not MISSING and files is not MISSING:
@@ -649,8 +647,8 @@ class InteractionResponse:
         if file is not MISSING:
             files = [file]
 
-        if files and any(not isinstance(f, File) for f in files):
-            raise TypeError('Files must be of type File')
+        if files and not all(isinstance(f, File) for f in files):
+            raise TypeError('Files parameter must be a list of type File')
 
         if content is not None:
             payload['content'] = str(content)

--- a/nextcord/interactions.py
+++ b/nextcord/interactions.py
@@ -39,6 +39,7 @@ from .errors import (
 from .channel import PartialMessageable, ChannelType
 
 from .file import File
+from .embeds import Embed
 from .user import User
 from .member import Member
 from .message import Message, Attachment
@@ -61,7 +62,6 @@ if TYPE_CHECKING:
     from .state import ConnectionState
     from .mentions import AllowedMentions
     from aiohttp import ClientSession
-    from .embeds import Embed
     from .ui.view import View
     from .channel import VoiceChannel, StageChannel, TextChannel, CategoryChannel, StoreChannel, PartialMessageable
     from .threads import Thread
@@ -639,8 +639,8 @@ class InteractionResponse:
             embeds = [embed]
 
         if embeds:
-            if len(embeds) > 10:
-                raise ValueError('Embeds cannot exceed maximum of 10 elements')
+            if any(not isinstance(embed, Embed) for embed in embeds):
+                raise TypeError('Embeds must be of type Embed')
             payload['embeds'] = [e.to_dict() for e in embeds]
 
         if file is not MISSING and files is not MISSING:
@@ -650,7 +650,7 @@ class InteractionResponse:
             files = [file]
 
         if files and any(not isinstance(f, File) for f in files):
-            raise TypeError('Files must be an instance of File')
+            raise TypeError('Files must be of type File')
 
         if content is not None:
             payload['content'] = str(content)

--- a/nextcord/webhook/async_.py
+++ b/nextcord/webhook/async_.py
@@ -467,8 +467,6 @@ def handle_message_parameters(
 
     payload = {}
     if embeds is not MISSING:
-        if len(embeds) > 10:
-            raise InvalidArgument('embeds has a maximum of 10 elements.')
         payload['embeds'] = [e.to_dict() for e in embeds]
 
     if embed is not MISSING:

--- a/nextcord/webhook/async_.py
+++ b/nextcord/webhook/async_.py
@@ -349,6 +349,7 @@ class AsyncWebhookAdapter:
         session: aiohttp.ClientSession,
         type: int,
         data: Optional[Dict[str, Any]] = None,
+        files: Optional[List[File]] = None,
     ) -> Response[None]:
         payload: Dict[str, Any] = {
             'type': type,
@@ -357,6 +358,29 @@ class AsyncWebhookAdapter:
         if data is not None:
             payload['data'] = data
 
+        multipart = []
+
+        if files:
+            multipart.append({'name': 'payload_json'})
+            payload['attachments'] = []
+            for index, file in enumerate(files):
+                payload['attachments'].append(
+                    {
+                        'id': index,
+                        'filename': file.filename,
+                    }
+                )
+                multipart.append(
+                    {
+                        'name': f'files[{index}]',
+                        'value': file.fp,
+                        'filename': file.filename,
+                        'content_type': 'application/octet-stream',
+                    }
+                )
+            multipart[0]['value'] = utils._to_json(payload)
+            payload = None
+
         route = Route(
             'POST',
             '/interactions/{webhook_id}/{webhook_token}/callback',
@@ -364,7 +388,7 @@ class AsyncWebhookAdapter:
             webhook_token=token,
         )
 
-        return self.request(route, session=session, payload=payload)
+        return self.request(route, session=session, payload=payload, multipart=multipart, files=files)
 
     def get_original_interaction_response(
         self,


### PR DESCRIPTION
## Summary

Fixes #353 

Support for attachments in interaction response

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)

Example code used for testing:

```py
@client.slash_command(guild_ids=[TESTING_GUILD_ID])
async def example1(interaction: Interaction):
    await interaction.response.send_message(
        "First example slash command!",
        embed=nextcord.Embed(
            title="Example 1",
            description="This is an example of a basic slash command.",
        ),
        file=nextcord.File("nextcord-logo.png"),
    )
```
```py
@client.slash_command(guild_ids=[TESTING_GUILD_ID])
async def example2(interaction: Interaction, arg1: str):
    await interaction.response.send_message(
        "Second example slash command!",
        view=Google(arg1),
        files=[
            nextcord.File("nextcord-logo.png"),
            nextcord.File("nextcord-logo2.png"),
        ]
    )
```

![image](https://user-images.githubusercontent.com/20955511/149833176-689998b7-1e6c-4db7-993b-245ea2e66004.png)