### PR TITLE
Add client to interaction class

### DIFF
--- a/nextcord/interactions.py
+++ b/nextcord/interactions.py
@@ -177,7 +177,7 @@ class Interaction:
                 pass
 
     @property
-    def client(self):
+    def client(self) -> Client:
         """:class:`Client`: The client that handled the interaction."""
         return self._client
 

--- a/nextcord/interactions.py
+++ b/nextcord/interactions.py
@@ -122,7 +122,6 @@ class Interaction:
         'guild_locale',
         'token',
         'version',
-        '_client',
         '_permissions',
         '_state',
         '_session',
@@ -135,7 +134,6 @@ class Interaction:
     def __init__(self, *, data: InteractionPayload, state: ConnectionState):
         self._state: ConnectionState = state
         self._session: ClientSession = state.http._HTTPClient__session
-        self._client: Client = state._get_client()
         self._original_message: Optional[InteractionMessage] = None
         self._from_data(data)
 
@@ -179,7 +177,7 @@ class Interaction:
     @property
     def client(self) -> Client:
         """:class:`Client`: The client that handled the interaction."""
-        return self._client
+        return self._state._get_client()
 
     @property
     def guild(self) -> Optional[Guild]:

--- a/nextcord/interactions.py
+++ b/nextcord/interactions.py
@@ -107,11 +107,6 @@ class Interaction:
         for 15 minutes.
     data: :class:`dict`
         The raw interaction data.
-    client: :class:`Client`
-        The client that handled the interaction. Can be a subclass
-        of :class:`Client` such as :class:`~ext.commands.Bot`.
-    bot: :class:`Client`:
-        An alias for ``client``.
     """
 
     __slots__: Tuple[str, ...] = (
@@ -183,12 +178,7 @@ class Interaction:
 
     @property
     def client(self):
-        """:class:`Client`: Returns the client that handled the interaction. An alias exists under ``bot``."""
-        return self._client
-
-    @property
-    def bot(self):
-        """:class:`Client`: Returns the client that handled the interaction. An alias exists under ``client``."""
+        """:class:`Client`: Returns the client that handled the interaction."""
         return self._client
 
     @property

--- a/nextcord/interactions.py
+++ b/nextcord/interactions.py
@@ -178,7 +178,7 @@ class Interaction:
 
     @property
     def client(self):
-        """:class:`Client`: Returns the client that handled the interaction."""
+        """:class:`Client`: The client that handled the interaction."""
         return self._client
 
     @property

--- a/nextcord/interactions.py
+++ b/nextcord/interactions.py
@@ -65,6 +65,7 @@ if TYPE_CHECKING:
     from .ui.view import View
     from .channel import VoiceChannel, StageChannel, TextChannel, CategoryChannel, StoreChannel, PartialMessageable
     from .threads import Thread
+    from .client import Client
 
     InteractionChannel = Union[
         VoiceChannel, StageChannel, TextChannel, CategoryChannel, StoreChannel, Thread, PartialMessageable
@@ -106,6 +107,11 @@ class Interaction:
         for 15 minutes.
     data: :class:`dict`
         The raw interaction data.
+    client: :class:`Client`
+        The client that handled the interaction. Can be a subclass
+        of :class:`Client` such as :class:`~ext.commands.Bot`.
+    bot: :class:`Client`:
+        An alias for ``client``.
     """
 
     __slots__: Tuple[str, ...] = (
@@ -121,6 +127,7 @@ class Interaction:
         'guild_locale',
         'token',
         'version',
+        '_client',
         '_permissions',
         '_state',
         '_session',
@@ -133,6 +140,7 @@ class Interaction:
     def __init__(self, *, data: InteractionPayload, state: ConnectionState):
         self._state: ConnectionState = state
         self._session: ClientSession = state.http._HTTPClient__session
+        self._client: Client = state._get_client()
         self._original_message: Optional[InteractionMessage] = None
         self._from_data(data)
 
@@ -172,6 +180,16 @@ class Interaction:
                 self.user = User(state=self._state, data=data['user'])
             except KeyError:
                 pass
+
+    @property
+    def client(self):
+        """:class:`Client`: Returns the client that handled the interaction. An alias exists under ``bot``."""
+        return self._client
+
+    @property
+    def bot(self):
+        """:class:`Client`: Returns the client that handled the interaction. An alias exists under ``client``."""
+        return self._client
 
     @property
     def guild(self) -> Optional[Guild]:


### PR DESCRIPTION
## Summary

Adds `client` as an attribute of `Interaction`

This functionality is part of the changes in PR #348 but, with permission from @TAG-Epic, I am adding this in its own PR so it can be merged sooner so that https://github.com/nextcord/nextcord-ext-menus/pull/27 can be released.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
