### PR TITLE
fix: provide a copy of after in voice_state_update event

### DIFF
--- a/nextcord/state.py
+++ b/nextcord/state.py
@@ -1626,6 +1626,7 @@ class ConnectionState:
                     asyncio.create_task(logging_coroutine(coro, info='Voice Protocol voice state update handler'))
 
             member, before, after = guild._update_voice_state(data, channel_id)  # type: ignore
+            after = copy.copy(after)
             if member is not None:
                 if flags.voice:
                     if channel_id is None and flags._voice_only and member.id != self_id:


### PR DESCRIPTION
## Summary

No issue was created since I encountered it, but parameters passed to `on_voice_state_update` are `before` and `after`.
However `after` was a reference to `Member.voice`, which means, when using `Member.move_to()` **inside** `on_voice_state_update` event, `after` would immediately get modified.

Example:
```py
@bot.event
async def on_voice_state_update(member, before, after):
    # Let's say before is None and after is "Channel1"
    print(after.channel.name)  # prints Channel1
    chan = bot.get_channel(1234567890101112)  # Let's say that's "Channel2"
    await member.move_to(chan)
    print(after.channel.name)  # prints Channel2
```
## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
