### PR TITLE
fix: allow deferring messages on component interactions

### DIFF
--- a/nextcord/interactions.py
+++ b/nextcord/interactions.py
@@ -467,7 +467,7 @@ class InteractionResponse:
         """
         return self._responded
 
-    async def defer(self, *, ephemeral: bool = False) -> None:
+    async def defer(self, *, ephemeral: bool = False, with_message: bool = False) -> None:
         """|coro|
 
         Defers the interaction response.
@@ -479,7 +479,13 @@ class InteractionResponse:
         -----------
         ephemeral: :class:`bool`
             Indicates whether the deferred message will eventually be ephemeral.
-            This only applies for interactions of type :attr:`InteractionType.application_command`.
+            This only applies for interactions of type :attr:`InteractionType.application_command` or when ``with_message`` is True
+        with_message: :class:`bool`
+            Indicates whether the response will be a message with thinking state (bot is thinking...).
+            This is always True for interactions of type :attr:`InteractionType.application_command`.
+            For interactions of type :attr:`InteractionType.component` this defaults to False.
+            
+            .. versionadded:: 2.0
 
         Raises
         -------
@@ -494,12 +500,12 @@ class InteractionResponse:
         defer_type: int = 0
         data: Optional[Dict[str, Any]] = None
         parent = self._parent
-        if parent.type is InteractionType.component:
-            defer_type = InteractionResponseType.deferred_message_update.value
-        elif parent.type is InteractionType.application_command:
+        if parent.type is InteractionType.application_command or with_message:
             defer_type = InteractionResponseType.deferred_channel_message.value
             if ephemeral:
                 data = {'flags': 64}
+        elif parent.type is InteractionType.component:
+            defer_type = InteractionResponseType.deferred_message_update.value
 
         if defer_type:
             adapter = async_context.get()


### PR DESCRIPTION
## Summary
<!-- What is this pull request for? Does it fix any issues? -->
Allows a type 5 defer on component interactions
## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
