### PR TITLE
Add Thread.create_timestamp

### DIFF
--- a/nextcord/threads.py
+++ b/nextcord/threads.py
@@ -55,6 +55,8 @@ if TYPE_CHECKING:
     from .role import Role
     from .permissions import Permissions
     from .state import ConnectionState
+    from datetime import datetime
+
 
 
 class Thread(Messageable, Hashable):
@@ -121,6 +123,11 @@ class Thread(Messageable, Hashable):
         Usually a value of 60, 1440, 4320 and 10080.
     archive_timestamp: :class:`datetime.datetime`
         An aware timestamp of when the thread's archived status was last updated in UTC.
+    create_timestamp: Optional[:class:`datetime.datetime`]
+        Returns the threads's creation time in UTC.
+        This is ``None`` if the thread was created before January 9th, 2021.
+
+        .. versionadded:: 2.0
     """
 
     __slots__ = (
@@ -143,6 +150,7 @@ class Thread(Messageable, Hashable):
         'archiver_id',
         'auto_archive_duration',
         'archive_timestamp',
+        "create_timestamp"
     )
 
     def __init__(self, *, guild: Guild, state: ConnectionState, data: ThreadPayload):
@@ -189,6 +197,7 @@ class Thread(Messageable, Hashable):
         self.archive_timestamp = parse_time(data['archive_timestamp'])
         self.locked = data.get('locked', False)
         self.invitable = data.get('invitable', True)
+        self.create_timestamp = parse_time(data.get('create_timestamp'))
 
     def _update(self, data):
         try:
@@ -202,6 +211,15 @@ class Thread(Messageable, Hashable):
             self._unroll_metadata(data['thread_metadata'])
         except KeyError:
             pass
+
+    @property
+    def created_at(self) -> Optional[datetime]:
+        """Optional[:class:`datetime.datetime`]: Returns the threads's creation time in UTC.
+        This is ``None`` if the thread was created before January 9th, 2021.
+        
+        .. versionadded:: 2.0
+        """
+        return self.create_timestamp
 
     @property
     def type(self) -> ChannelType:

--- a/nextcord/types/threads.py
+++ b/nextcord/types/threads.py
@@ -39,9 +39,9 @@ class ThreadMember(TypedDict):
 
 
 class _ThreadMetadataOptional(TypedDict, total=False):
-    archiver_id: Snowflake
     locked: bool
     invitable: bool
+    create_timestamp: str
 
 
 class ThreadMetadata(_ThreadMetadataOptional):


### PR DESCRIPTION

## Summary

Documented [here](https://github.com/discord/discord-api-docs/commit/53ee0109b874bde5ec2316379bf266bb332630a0
)
This PR adds `Thread.create_timestamp` and `Thread.created_at` as an "alias".

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
