### PR TITLE
fix: ScheduledEvent.edit missing arguments in http

### DIFF
--- a/nextcord/scheduled_events.py
+++ b/nextcord/scheduled_events.py
@@ -79,7 +79,7 @@ class ScheduledEventUser(Hashable):
     user: Optional[:class:`User`]
         The related user object. Blank if no member intents
     member: Optional[:class:`Member`]
-        The related member object, if requested with 
+        The related member object, if requested with
         :meth:`ScheduledEvent.fetch_users`.
     user_id: int
         The id of the interested user
@@ -267,7 +267,7 @@ class ScheduledEvent(Hashable):
         return user
 
     def _remove_user(self, user_id: int) -> None:
-        if  self._users.pop(user_id, None):
+        if self._users.pop(user_id, None):
             self.user_count -= 1
 
     def __str__(self) -> str:
@@ -299,11 +299,11 @@ class ScheduledEvent(Hashable):
         """List[:class:`ScheduledEventUser`]: The users who are interested in the event.
 
         .. note::
-            This may not be accurate or populated until 
+            This may not be accurate or populated until
             :meth:`~.ScheduledEvent.fetch_users` is called
         """
         return list(self._users.values())
- 
+
     async def delete(self) -> None:
         """|coro|
 
@@ -376,7 +376,7 @@ class ScheduledEvent(Hashable):
             payload['status'] = status.value
         if not payload:
             return self
-        data = await self._state.http.edit_event(reason=reason, **payload)
+        data = await self._state.http.edit_event(self.guild.id, self.id, reason=reason, **payload)
         return ScheduledEvent(guild=self.guild, state=self._state, data=data)
 
     def get_user(self, user_id: int) -> Optional[ScheduledEventUser]:
@@ -384,7 +384,7 @@ class ScheduledEvent(Hashable):
 
         .. note::
 
-            This may not be accurate or populated until 
+            This may not be accurate or populated until
             :meth:`ScheduledEvent.fetch_users` is called.
 
         Parameters


### PR DESCRIPTION
## Summary

Fixes ScheduledEvent.edit raising an exception because the call to the http function was missing guild_id and event_id parameters.
(Also fixes extra spaces in the file because editor is smart)

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [-] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
