### PR TITLE
fix: pass ConnectionState to CustomActivity, allowing to pass it to P…

### DIFF
--- a/nextcord/activity.py
+++ b/nextcord/activity.py
@@ -741,9 +741,9 @@ class CustomActivity(BaseActivity):
 
     __slots__ = ('name', 'emoji', 'state', "_state")
 
-    def __init__(self, _state: ConnectionState, name: Optional[str], *, emoji: Optional[PartialEmoji] = None, **extra: Any):
+    def __init__(self, name: Optional[str], *, _connection_state: Optional[ConnectionState] = None, emoji: Optional[PartialEmoji] = None, **extra: Any):
         super().__init__(**extra)
-        self._state = _state
+        self._state = _connection_state
         self.name: Optional[str] = name
         self.state: Optional[str] = extra.pop('state', None)
         if self.name == 'Custom Status':
@@ -835,7 +835,7 @@ def create_activity(state: ConnectionState, data: Optional[ActivityPayload]) -> 
             return Activity(**data)
         else:
             # we removed the name key from data already
-            return CustomActivity(_state=state, name=name, **data) # type: ignore
+            return CustomActivity(name=name, _connection_state=state, **data) # type: ignore
     elif game_type is ActivityType.streaming:
         if 'url' in data:
             # the url won't be None here

--- a/nextcord/activity.py
+++ b/nextcord/activity.py
@@ -98,6 +98,7 @@ if TYPE_CHECKING:
         ActivityAssets,
         ActivityButton,
     )
+    from .state import ConnectionState
 
 
 class BaseActivity:
@@ -738,10 +739,11 @@ class CustomActivity(BaseActivity):
         The emoji to pass to the activity, if any.
     """
 
-    __slots__ = ('name', 'emoji', 'state')
+    __slots__ = ('name', 'emoji', 'state', "_state")
 
-    def __init__(self, name: Optional[str], *, emoji: Optional[PartialEmoji] = None, **extra: Any):
+    def __init__(self, _state: ConnectionState, name: Optional[str], *, emoji: Optional[PartialEmoji] = None, **extra: Any):
         super().__init__(**extra)
+        self._state = _state
         self.name: Optional[str] = name
         self.state: Optional[str] = extra.pop('state', None)
         if self.name == 'Custom Status':
@@ -758,6 +760,8 @@ class CustomActivity(BaseActivity):
             self.emoji = emoji
         else:
             raise TypeError(f'Expected str, PartialEmoji, or None, received {type(emoji)!r} instead.')
+
+        self.emoji._state = self._state
 
     @property
     def type(self) -> ActivityType:
@@ -815,7 +819,7 @@ def create_activity(data: ActivityPayload) -> ActivityTypes:
 def create_activity(data: None) -> None:
     ...
 
-def create_activity(data: Optional[ActivityPayload]) -> Optional[ActivityTypes]:
+def create_activity(state: ConnectionState, data: Optional[ActivityPayload]) -> Optional[ActivityTypes]:
     if not data:
         return None
 
@@ -831,7 +835,7 @@ def create_activity(data: Optional[ActivityPayload]) -> Optional[ActivityTypes]:
             return Activity(**data)
         else:
             # we removed the name key from data already
-            return CustomActivity(name=name, **data) # type: ignore
+            return CustomActivity(_state=state, name=name, **data) # type: ignore
     elif game_type is ActivityType.streaming:
         if 'url' in data:
             # the url won't be None here

--- a/nextcord/client.py
+++ b/nextcord/client.py
@@ -393,7 +393,7 @@ class Client:
         If this is not passed via ``__init__`` then this is retrieved
         through the gateway when an event contains the data. Usually
         after :func:`~nextcord.on_connect` is called.
-        
+
         .. versionadded:: 2.0
         """
         return self._connection.application_id
@@ -533,7 +533,7 @@ class Client:
         """
 
         _log.info('logging in using static token')
-        
+
         if not isinstance(token, str):
             raise TypeError(f"The token provided was of type {type(token)} but was expected to be str")
 
@@ -743,7 +743,7 @@ class Client:
         """Optional[:class:`.BaseActivity`]: The activity being used upon
         logging in.
         """
-        return create_activity(self._connection._activity)
+        return create_activity(self._connection, self._connection._activity)
 
     @activity.setter
     def activity(self, value: Optional[ActivityTypes]) -> None:
@@ -754,7 +754,7 @@ class Client:
             self._connection._activity = value.to_dict() # type: ignore
         else:
             raise TypeError('activity must derive from BaseActivity.')
-    
+
     @property
     def status(self):
         """:class:`.Status`:
@@ -825,7 +825,7 @@ class Client:
 
         This is useful if you have a channel_id but don't want to do an API call
         to send messages to it.
-        
+
         .. versionadded:: 2.0
 
         Parameters
@@ -1688,7 +1688,7 @@ class Client:
 
         This method should be used for when a view is comprised of components
         that last longer than the lifecycle of the program.
-        
+
         .. versionadded:: 2.0
 
         Parameters
@@ -1720,7 +1720,7 @@ class Client:
     @property
     def persistent_views(self) -> Sequence[View]:
         """Sequence[:class:`.View`]: A sequence of persistent views added to the client.
-        
+
         .. versionadded:: 2.0
         """
         return self._connection.persistent_views

--- a/nextcord/member.py
+++ b/nextcord/member.py
@@ -30,6 +30,7 @@ import itertools
 import sys
 from operator import attrgetter
 from typing import Any, Dict, List, Literal, Optional, TYPE_CHECKING, Tuple, Type, TypeVar, Union, overload
+from functools import partial
 
 from . import abc
 
@@ -388,7 +389,7 @@ class Member(abc.Messageable, _UserTag):
         self._timeout = utils.parse_time(data.get('communication_disabled_until'))
 
     def _presence_update(self, data: PartialPresenceUpdate, user: UserPayload) -> Optional[Tuple[User, User]]:
-        self.activities = tuple(map(create_activity, data['activities']))
+        self.activities = tuple(map(lambda x: create_activity(self._state, x), data['activities']))
         self._client_status = {
             sys.intern(key): sys.intern(value) for key, value in data.get('client_status', {}).items()  # type: ignore
         }
@@ -617,7 +618,7 @@ class Member(abc.Messageable, _UserTag):
 
     @property
     def timeout(self) -> Optional[datetime.datetime]:
-        """Optional[:class:`datetime.datetime`]: A datetime object that represents 
+        """Optional[:class:`datetime.datetime`]: A datetime object that represents
         the time in which the member will be able to interact again.
 
         .. note::

--- a/nextcord/widget.py
+++ b/nextcord/widget.py
@@ -173,7 +173,7 @@ class WidgetMember(BaseUser):
         except KeyError:
             activity = None
         else:
-            activity = create_activity(game)
+            activity = create_activity(state, game)
 
         self.activity: Optional[Union[BaseActivity, Spotify]] = activity
 


### PR DESCRIPTION
…artialEmoji and save it

## Summary

Fixes Member.activity.emoji.save() raising DiscordException because it's missing a ConnectionState

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [-] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
