### PR TITLE
fix: check if time parameter is semi-timezone-aware and raise excepti…

### DIFF
--- a/nextcord/ext/tasks/__init__.py
+++ b/nextcord/ext/tasks/__init__.py
@@ -599,6 +599,8 @@ class Loop(Generic[LF]):
         utc: datetime.timezone = datetime.timezone.utc,
     ) -> List[datetime.time]:
         if isinstance(time, dt):
+            if time.tzinfo is not None and time.tzinfo.utcoffset(None) is None:
+                raise TypeError("Incompatible timezone module used. Please use datetime.timezone instead.")
             inner = time if time.tzinfo is not None else time.replace(tzinfo=utc)
             return [inner]
         if not isinstance(time, Sequence):

--- a/nextcord/ext/tasks/__init__.py
+++ b/nextcord/ext/tasks/__init__.py
@@ -723,6 +723,11 @@ def loop(
 
             Duplicate times will be ignored, and only run once.
 
+        .. warning::
+
+            "Semi-aware" timezones cannot be used.
+            Using :func:`pytz.timezone` to pass ``tzinfo`` will raise an exception.
+
         .. versionadded:: 2.0
 
     count: Optional[:class:`int`]
@@ -742,7 +747,8 @@ def loop(
         An invalid value was given.
     TypeError
         The function was not a coroutine, an invalid value for the ``time`` parameter was passed,
-        or ``time`` parameter was passed in conjunction with relative time parameters.
+        ``time`` parameter was passed in conjunction with relative time parameters,
+        or an incompatible timezone module was used for the ``tzinfo`` parameter of ``time``.
     """
 
     def decorator(func: LF) -> Loop[LF]:


### PR DESCRIPTION
check if time parameter is semi-timezone-aware and raise exception (must not use a pytz timezone)

## Summary

Fixes an issue encountered in a thread. Some modules like pytz provide semi-aware timezones, which break. This is not a pytz issue not a datetime issue, read [this python bug report](https://bugs.python.org/issue38812) for reference.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
