### PR TITLE
fix: status not in list of valid_keys for edit event

### DIFF
--- a/nextcord/http.py
+++ b/nextcord/http.py
@@ -1999,7 +1999,8 @@ class HTTPClient:
             'scheduled_start_time',
             'scheduled_end_time',
             'description',
-            'entity_type'
+            'entity_type',
+            'status'
         }
         payload = {k: v for k, v in payload.items() if k in valid_keys}
         r = Route(


### PR DESCRIPTION
## Summary

You can't edit the status of an event rn because it isn't in the list of valid_keys.

Cough cough kwargs

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [-] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
