### PR TITLE
feat: delete_after for deferred/webhook messages

### DIFF
--- a/nextcord/interactions.py
+++ b/nextcord/interactions.py
@@ -384,9 +384,12 @@ class Interaction:
         *,
         embed: Embed = MISSING,
         embeds: List[Embed] = MISSING,
+        file: File = MISSING,
+        files: List[File] = MISSING,
         view: View = MISSING,
         tts: bool = False,
-        ephemeral: bool = False
+        ephemeral: bool = False,
+        delete_after: Optional[float] = None,
     ) -> Optional[Union[Message, WebhookMessage]]:
         """|coro|
 
@@ -407,17 +410,23 @@ class Interaction:
                 content=content,
                 embed=embed,
                 embeds=embeds,
+                file=file,
+                files=files,
                 view=view,
                 tts=tts,
-                ephemeral=ephemeral
+                ephemeral=ephemeral,
+                delete_after=delete_after,
             )
         return await self.followup.send(
             content=content,  # type: ignore
             embed=embed,
             embeds=embeds,
+            file=file,
+            files=files,
             view=view,
             tts=tts,
-            ephemeral=ephemeral
+            ephemeral=ephemeral,
+            delete_after=delete_after,
         )
 
     async def edit(self, *args, **kwargs) -> Optional[Message]:


### PR DESCRIPTION
## Summary

Adds support for `delete_after` in `WebhookMessage.send`, `WebhookMessage.edit`

Since `interaction.followup` uses `WebhookMessage`, this allows deleting deferred interaction responses.

Similar functionality already exists for regular messages and Interaction messages (#384)

This PR also adds support for `file`, `files` and `delete_after` in `Interaction.send`

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)

![Peek 2022-01-26 11-05](https://user-images.githubusercontent.com/20955511/151222766-98fa9822-0377-4426-9838-8ef8bd879eae.gif)

Testing code:
```py
@client.slash_command(guild_ids=[TESTING_GUILD_ID])
async def delete_send(interaction: Interaction):
    await interaction.send("This message will be deleted.", delete_after=2)

@client.slash_command(guild_ids=[TESTING_GUILD_ID])
async def defer_delete_send(interaction: Interaction):
    await interaction.response.defer()
    await sleep(1)
    await interaction.send("This message will be deleted.", delete_after=2)

@client.slash_command(guild_ids=[TESTING_GUILD_ID])
async def defer_delete(interaction: Interaction):
    await interaction.response.defer()
    await sleep(1)
    await interaction.followup.send("This Webhook Message will be deleted", delete_after=2)

@client.slash_command(guild_ids=[TESTING_GUILD_ID])
async def defer_edit_delete(interaction: Interaction):
    await interaction.response.defer()
    await sleep(1)
    message = await interaction.followup.send("Webhook Message")
    await message.edit(content="Edited Webhook Message that will be deleted", delete_after=2)

@client.slash_command(guild_ids=[TESTING_GUILD_ID])
async def send_file(interaction: Interaction):
    await interaction.send("This message will be deleted.", file=nextcord.File("nextcord-logo.png"), delete_after=2)

@client.slash_command(guild_ids=[TESTING_GUILD_ID])
async def send_file_defer(interaction: Interaction):
    await interaction.response.defer()
    await sleep(1)
    await interaction.send("This message will be deleted.", file=nextcord.File("nextcord-logo.png"), delete_after=2)
```