### PR TITLE
[URGENT] fix: custom activities can have no emotes AAAA

### DIFF
--- a/nextcord/activity.py
+++ b/nextcord/activity.py
@@ -761,7 +761,8 @@ class CustomActivity(BaseActivity):
         else:
             raise TypeError(f'Expected str, PartialEmoji, or None, received {type(emoji)!r} instead.')
 
-        self.emoji._state = self._state
+        if self.emoji is not None:
+            self.emoji._state = self._state
 
     @property
     def type(self) -> ActivityType:


### PR DESCRIPTION
## Summary

Fixes custom activities which can contain no emotes, exception on startup when using nextcord master branch

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [-] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
