### PR TITLE
[pending] feat: add ability to get message returned when sending an interaction response

### DIFF
--- a/nextcord/interactions.py
+++ b/nextcord/interactions.py
@@ -406,6 +406,7 @@ class Interaction:
         view: View = MISSING,
         tts: bool = False,
         ephemeral: bool = False,
+        wait: bool = False,
         delete_after: Optional[float] = None,
     ) -> Optional[Union[InteractionMessage, WebhookMessage]]:
         """|coro|
@@ -423,7 +424,7 @@ class Interaction:
         """
 
         if not self.response.is_done():
-            await self.response.send_message(
+            return await self.response.send_message(
                 content=content,
                 embed=embed,
                 embeds=embeds,
@@ -432,9 +433,9 @@ class Interaction:
                 view=view,
                 tts=tts,
                 ephemeral=ephemeral,
+                wait=wait,
                 delete_after=delete_after,
             )
-            return await self.original_message()
         return await self.followup.send(
             content=content,  # type: ignore
             embed=embed,
@@ -444,6 +445,7 @@ class Interaction:
             view=view,
             tts=tts,
             ephemeral=ephemeral,
+            wait=wait,
             delete_after=delete_after,
         )
 
@@ -624,8 +626,9 @@ class InteractionResponse:
         view: View = MISSING,
         tts: bool = False,
         ephemeral: bool = False,
+        wait: bool = False,
         delete_after: Optional[float] = None,
-    ) -> None:
+    ) -> Optional[InteractionMessage]:
         """|coro|
 
         Responds to this interaction by sending a message.
@@ -653,10 +656,19 @@ class InteractionResponse:
             Indicates if the message should only be visible to the user who started the interaction.
             If a view is sent with an ephemeral message and it has no timeout set then the timeout
             is set to 15 minutes.
+        wait: :class:`bool`
+            Whether the server should wait before sending a response. This essentially
+            means that the return type of this function changes from ``None`` to
+            a :class:`InteractionMessage` if set to ``True``.
         delete_after: Optional[:class:`float`]
             If provided, the number of seconds to wait in the background
             before deleting the message we just sent. If the deletion fails,
             then it is silently ignored.
+
+        Returns
+        --------
+
+        An :class:`InteractionMessage` if ``wait`` is ``True``. Otherwise ``None``.
 
         Raises
         -------
@@ -730,6 +742,9 @@ class InteractionResponse:
         if delete_after is not None:
             await self._parent.delete_original_message(delay=delete_after)
 
+        if wait:
+            return await self._parent.original_message()
+
     async def edit_message(
         self,
         *,
@@ -738,8 +753,9 @@ class InteractionResponse:
         embeds: List[Embed] = MISSING,
         attachments: List[Attachment] = MISSING,
         view: Optional[View] = MISSING,
+        wait: bool = False,
         delete_after: Optional[float] = None,
-    ) -> None:
+    ) -> Optional[InteractionMessage]:
         """|coro|
 
         Responds to this interaction by editing the original message of
@@ -760,12 +776,20 @@ class InteractionResponse:
         view: Optional[:class:`~nextcord.ui.View`]
             The updated view to update this message with. If ``None`` is passed then
             the view is removed.
+        wait: :class:`bool`
+            Whether the server should wait before sending a response. This essentially
+            means that the return type of this function changes from ``None`` to
+            a :class:`InteractionMessage` if set to ``True``.
         delete_after: Optional[:class:`float`]
             If provided, the number of seconds to wait in the background
             before deleting the message we just sent. If the deletion fails,
             then it is silently ignored.
-        
 
+        Returns
+        --------
+
+        An :class:`InteractionMessage` if ``wait`` is ``True``. Otherwise ``None``.
+        
         Raises
         -------
         HTTPException
@@ -830,6 +854,9 @@ class InteractionResponse:
 
         if delete_after is not None:
             await self._parent.delete_original_message(delay=delete_after)
+
+        if wait:
+            return await self._parent.original_message()
 
         
 

--- a/nextcord/interactions.py
+++ b/nextcord/interactions.py
@@ -419,8 +419,8 @@ class Interaction:
         Returns
         -------
         Optional[:class:`InteractionMessage`, :class:`WebhookMessage`]
-            The :class:`InteractionMessage` that was sent, a :class:`WebhookMessage`
-            if the interaction has been responded to before.
+            The :class:`InteractionMessage` that was sent if ``wait`` is ``True`` and
+            the interaction has not been responded to, a :class:`WebhookMessage` otherwise.
         """
 
         if not self.response.is_done():
@@ -667,8 +667,8 @@ class InteractionResponse:
 
         Returns
         --------
-
-        An :class:`InteractionMessage` if ``wait`` is ``True``. Otherwise ``None``.
+        Optional[:class:`InteractionMessage`]
+            The message sent if ``wait`` is ``True``, otherwise ``None``.
 
         Raises
         -------
@@ -787,8 +787,8 @@ class InteractionResponse:
 
         Returns
         --------
-
-        An :class:`InteractionMessage` if ``wait`` is ``True``. Otherwise ``None``.
+        Optional[:class:`InteractionMessage`]
+            The message sent if ``wait`` is ``True``, otherwise ``None``.
         
         Raises
         -------

--- a/nextcord/interactions.py
+++ b/nextcord/interactions.py
@@ -418,7 +418,7 @@ class Interaction:
 
         Returns
         -------
-        Optional[:class:`InteractionMessage`, :class:`WebhookMessage`]
+        Optional[Union[:class:`InteractionMessage`, :class:`WebhookMessage`]]
             If the interaction has not been responded to, returns the :class:`InteractionMessage`
             that was sent if ``wait`` is ``True``, otherwise returns ``None``.
             If the interaction has been responded to, returns the :class:`WebhookMessage`.

--- a/nextcord/interactions.py
+++ b/nextcord/interactions.py
@@ -407,7 +407,7 @@ class Interaction:
         tts: bool = False,
         ephemeral: bool = False,
         delete_after: Optional[float] = None,
-    ) -> Optional[Union[Message, WebhookMessage]]:
+    ) -> Optional[Union[InteractionMessage, WebhookMessage]]:
         """|coro|
 
         This is a shorthand function for helping in sending messages in
@@ -417,13 +417,13 @@ class Interaction:
 
         Returns
         -------
-        Optional[:class:`Message`, :class:`WebhookMessage`]
-            The :class:`Message` that was sent, a :class:`WebhookMessage` if the
-            interaction has been responded to before.
+        Optional[:class:`InteractionMessage`, :class:`WebhookMessage`]
+            The :class:`InteractionMessage` that was sent, a :class:`WebhookMessage`
+            if the interaction has been responded to before.
         """
 
         if not self.response.is_done():
-            return await self.response.send_message(
+            await self.response.send_message(
                 content=content,
                 embed=embed,
                 embeds=embeds,
@@ -434,6 +434,7 @@ class Interaction:
                 ephemeral=ephemeral,
                 delete_after=delete_after,
             )
+            return await self.original_message()
         return await self.followup.send(
             content=content,  # type: ignore
             embed=embed,

--- a/nextcord/interactions.py
+++ b/nextcord/interactions.py
@@ -419,8 +419,9 @@ class Interaction:
         Returns
         -------
         Optional[:class:`InteractionMessage`, :class:`WebhookMessage`]
-            The :class:`InteractionMessage` that was sent if ``wait`` is ``True`` and
-            the interaction has not been responded to, a :class:`WebhookMessage` otherwise.
+            If the interaction has not been responded to, returns the :class:`InteractionMessage`
+            that was sent if ``wait`` is ``True``, otherwise returns ``None``.
+            If the interaction has been responded to, returns the :class:`WebhookMessage`.
         """
 
         if not self.response.is_done():


### PR DESCRIPTION
## Summary

This makes Interactions consistent with Webhooks by allowing the user to request the message be returned with `wait=True`.

Currently `Messageable.send` and `WebhookMessage.send` return their respective messages but `Interaction.response.send_message` never does.

For an interaction that was already sent, `Interaction.send` returns a `WebhookMessage`, but for an interaction response, nothing is returned. The docs were previously incorrect saying it would return a `Message` when really it returns `None`.

It would be useful if you could get the message at the same time as sending the interaction message.

So if you want the message, you could do:
```py
message = await interaction.send(..., wait=True)
```
Instead of
```py
await interaction.send(...)
message = await interaction.original_message()
```
This makes it easier for the user of the lib (similar to why we have `Interaction.send` in the first place)

**By adding a `wait` parameter, this allows requesting that the message be returned so that unnecessary API calls are not made unless specifically requested.**

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)

![image](https://user-images.githubusercontent.com/20955511/151592059-4a305562-d0a2-4fcb-b129-292148b874d6.png)

Test code:
```py
@client.slash_command(guild_ids=[TESTING_GUILD_ID])
async def send(interaction: Interaction):
    message = await interaction.send("Test", wait=True) # request message with wait=True
    await interaction.channel.send(f"A {type(message)} was sent")

@client.slash_command(guild_ids=[TESTING_GUILD_ID])
async def defer_send(interaction: Interaction):
    await interaction.response.defer()
    await sleep(1)
    message = await interaction.send("Test") # this can already return the Message even if wait is False
    await interaction.channel.send(f"A {type(message)} was sent")

@client.slash_command(guild_ids=[TESTING_GUILD_ID])
async def send_no_wait(interaction: Interaction):
    await interaction.send("Test") # returns None
```