### PR TITLE
Message embed parameter gets now send as embeds

### DIFF
--- a/nextcord/abc.py
+++ b/nextcord/abc.py
@@ -1335,7 +1335,8 @@ class Messageable:
             raise InvalidArgument('cannot pass both embed and embeds parameter to send()')
 
         if embed is not None:
-            embed = embed.to_dict()
+            embeds = [embed.to_dict()]
+            embed = None
 
         elif embeds is not None:
             embeds = [embed.to_dict() for embed in embeds]


### PR DESCRIPTION
## Summary

Discord Docs say embed field is depreceated so sending embed field as embeds
(https://discord.com/developers/docs/resources/channel#create-message)

All other parts of the libary i could find already do so

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
