### PR TITLE
Fixed dynamic cooldowns (BucketType.default case)

### DIFF
--- a/nextcord/ext/commands/cooldowns.py
+++ b/nextcord/ext/commands/cooldowns.py
@@ -234,11 +234,15 @@ class CooldownMapping:
         for k in dead_keys:
             del self._cache[k]
 
+    def _is_default(self) -> bool:
+        # This method can be overridden in subclasses
+        return self._type is BucketType.default
+
     def create_bucket(self, message: Message) -> Cooldown:
         return self._cooldown.copy()  # type: ignore
 
     def get_bucket(self, message: Message, current: Optional[float] = None) -> Cooldown:
-        if self._type is BucketType.default:
+        if self._is_default():
             return self._cooldown  # type: ignore
 
         self._verify_cache_integrity(current)
@@ -274,6 +278,10 @@ class DynamicCooldownMapping(CooldownMapping):
     @property
     def valid(self) -> bool:
         return True
+
+    def _is_default(self) -> bool:
+        # In dynamic mappings even default bucket types may have custom behavior
+        return False
 
     def create_bucket(self, message: Message) -> Cooldown:
         return self._factory(message)


### PR DESCRIPTION
## Summary

Dynamic cooldowns now work with default bucket types as well.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
