### PR TITLE
Add check for confirming datetime instance, as well as adding a timeout method to member.py

### DIFF
--- a/nextcord/member.py
+++ b/nextcord/member.py
@@ -667,6 +667,13 @@ class Member(abc.Messageable, _UserTag):
 
         Times out this member.
 
+        .. note::
+
+            This is a more direct method of timing out a member.
+            You can also time out members using :meth:`Member.edit`.
+
+        .. versionadded:: 2.0
+
         Parameters
         -----------
         timeout: Optional[Union[:class:`~datetime.datetime`, :class:`~datetime.timedelta`]]
@@ -674,13 +681,6 @@ class Member(abc.Messageable, _UserTag):
             Set this to None to disable their timeout.
         reason: Optional[:class:`str`]
             The reason for editing this member. Shows up on the audit log.
-
-        .. note::
-
-            This is a more direct method of timing out a member.
-            You can also time out members using :meth:`Member.edit`.
-
-        .. versionadded:: 2.0
         """
         await self.edit(timeout=timeout, reason=reason)
 

--- a/nextcord/member.py
+++ b/nextcord/member.py
@@ -657,8 +657,12 @@ class Member(abc.Messageable, _UserTag):
         """
         await self.guild.kick(self, reason=reason)
         
-    async def timeout(self, timeout: Union[datetime.datetime, datetime.timedelta],
-                      *, reason: Optional[str] = None):
+    async def timeout(
+        self,
+        timeout: Union[datetime.datetime, datetime.timedelta],
+        *,
+        reason: Optional[str] = None,
+    ) -> None:
         """|coro|
 
         Times out this member.

--- a/nextcord/utils.py
+++ b/nextcord/utils.py
@@ -1014,6 +1014,8 @@ def format_dt(dt: datetime.datetime, /, style: Optional[TimestampStyle] = None) 
     :class:`str`
         The formatted string.
     """
+    if not isinstance(dt, datetime.datetime):
+        raise InvalidArgument("'dt' must be of type 'datetime.datetime'")
     if style is None:
         return f'<t:{int(dt.timestamp())}>'
     return f'<t:{int(dt.timestamp())}:{style}>'


### PR DESCRIPTION
## Summary

Just checks if the argument `dt` is an instance of `datetime` to prevent confusion.
Adds a timeout method to member.py as a direct method instead of having to go through `Member.edit`

## Checklist

- [x ] If code changes were made then they have been tested.
    - [  ] I have updated the documentation to reflect the changes.
- [  ] This PR fixes an issue.
- [  ] This PR adds something new (e.g. new method or parameters).
- [  ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [  ] This PR is **not** a code change (e.g. documentation, README, ...)
