### PR TITLE
fix: add thread to message slots

### DIFF
--- a/nextcord/message.py
+++ b/nextcord/message.py
@@ -629,6 +629,7 @@ class Message(Hashable):
         'nonce',
         'pinned',
         'role_mentions',
+        'thread',
         'type',
         'flags',
         'reactions',


### PR DESCRIPTION
This fixes an AttributeError being raised when setting `thread` on a message.

## Summary

fixes #428 

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
