### PR TITLE
Docs: removed bare except

### DIFF
--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -244,8 +244,8 @@ this together we can do the following: ::
         fut = asyncio.run_coroutine_threadsafe(coro, client.loop)
         try:
             fut.result()
-        except:
-            # an error happened sending the message
+        except nextcord.Forbidden:
+            # Missing permissions to send message to that channel
             pass
 
     voice.play(nextcord.FFmpegPCMAudio(url), after=my_after)


### PR DESCRIPTION
## Summary

I noticed the doc suggest to use a bare except in the faq. This should not be done for several reasons (e.g. Keyboard Interrupts getting caught) so this would change it

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
