### PR TITLE
Slash no description fix

### DIFF
--- a/nextcord/application_command.py
+++ b/nextcord/application_command.py
@@ -237,7 +237,7 @@ class CommandOption(SlashOption):
     def description(self) -> str:
         """If no description is set, it returns the bare minimum that Discord demands."""
         if not self._description:
-            return " "
+            return "No description provided"
         else:
             return self._description
 
@@ -435,7 +435,7 @@ class ApplicationSubcommand:
     def description(self) -> str:
         """Returns the description of the command. If the description is MISSING, it returns the bare minimum needed."""
         if self._description is MISSING:  # Return Discords bare minimum for a command.
-            return " "
+            return "No description provided"
         else:
             return self._description
 
@@ -864,7 +864,8 @@ class ApplicationCommand(ApplicationSubcommand):
         """Returns the description of the command. If the description is MISSING, it returns the bare minimum needed."""
         if self._description is MISSING:  # Return Discord's bare minimum for a command.
             if self.type is ApplicationCommandType.chat_input:
-                return " "
+                # return " "
+                return super().description
             elif self.type in (ApplicationCommandType.user, ApplicationCommandType.message):
                 return ""
         else:

--- a/nextcord/application_command.py
+++ b/nextcord/application_command.py
@@ -864,7 +864,6 @@ class ApplicationCommand(ApplicationSubcommand):
         """Returns the description of the command. If the description is MISSING, it returns the bare minimum needed."""
         if self._description is MISSING:  # Return Discord's bare minimum for a command.
             if self.type is ApplicationCommandType.chat_input:
-                # return " "
                 return super().description
             elif self.type in (ApplicationCommandType.user, ApplicationCommandType.message):
                 return ""


### PR DESCRIPTION
## Summary

<!-- What is this pull request for? Does it fix any issues? -->
Discord, seemingly silently, made it so having the description of slash commands and options only be a whitespace character will fail. This PR fixes that by setting the default description to "No description provided"

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [X] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
