### PR TITLE
chore: Update darker github action to 1.4.0

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -9,8 +9,12 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
-      - uses: akaihola/darker@github-action-v1.3.2-2
+      - uses: akaihola/darker@1.4.0
         with:
           options: "--check --verbose"
           src: "./nextcord"
-          version: "1.3.2"
+          # TODO: Remove "version" on the next darker release.
+          # By default, this should use the same version of darker as written above,
+          # but v1.4.0 of the github action had a bug where darker 1.3.2 was still
+          # being used. See https://github.com/akaihola/darker/pull/282 for details.
+          version: "1.4.0"


### PR DESCRIPTION
darker <v1.4.0 is not compatible with [black 22.1+](https://pypi.org/project/black/#history) (released Jan 29th). This was breaking CI on master.

This PR uses the [1.4.0](https://github.com/akaihola/darker/releases/tag/1.4.0) tag of darker instead of [github-action-v1.3.2-2](https://github.com/akaihola/darker/releases/tag/github-action-v1.3.2-2), as the github action is part of the main darker codebase now.

Official instructions for the github action: https://github.com/akaihola/darker#github-actions-integration

## Summary

<!-- What is this pull request for? Does it fix any issues? -->

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
