### PR TITLE
feat: Add message content intent and additional flags

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -4330,7 +4330,6 @@ Cogs
 
 .. autoclass:: ClientCog
     :members:
-
 Decorators
 ~~~~~~~~~~
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -4330,6 +4330,7 @@ Cogs
 
 .. autoclass:: ClientCog
     :members:
+
 Decorators
 ~~~~~~~~~~
 

--- a/docs/intents.rst
+++ b/docs/intents.rst
@@ -11,7 +11,7 @@ In version 1.5 comes the introduction of :class:`Intents`. This is a radical cha
 
 These intents are passed to the constructor of :class:`Client` or its subclasses (:class:`AutoShardedClient`, :class:`~.AutoShardedBot`, :class:`~.Bot`) with the ``intents`` argument.
 
-If intents are not passed, then the library defaults to every intent being enabled except the privileged intents, currently :attr:`Intents.members` and :attr:`Intents.presences`.
+If intents are not passed, then the library defaults to every intent being enabled except the privileged intents, currently :attr:`Intents.members`, :attr:`Intents.presences`, and :attr:`Intents.message_content`.
 
 What intents are needed?
 --------------------------
@@ -106,6 +106,18 @@ Member Intent
 - Whether you want to track user updates such as usernames, avatars, discriminators, etc.
 - Whether you want to request the guild member list through :meth:`Guild.chunk` or :meth:`Guild.fetch_members`.
 - Whether you want high accuracy member cache under :attr:`Guild.members`.
+
+.. _need_message_content_intent:
+
+Message Content
++++++++++++++++++
+
+- Whether you want to read :attr:`Message.content`, :attr:`Message.embeds`, :attr:`Message.attachments`, or :attr:`Message.components` in most messages.
+
+.. note::
+
+    Without this intent, the attributes above will appear empty (either an empty string or empty array depending on the data type) in most messages.
+    The bot will always be able to get these attributes from messages the bot sends, messages the bot receives in DMs, and messages in which the bot is mentioned.
 
 .. _intents_member_cache:
 

--- a/nextcord/flags.py
+++ b/nextcord/flags.py
@@ -878,14 +878,21 @@ class Intents(BaseFlags):
 
     @flag_value
     def message_content(self):
-        """:class:`bool`: Whether most message content related events are enabled.
+        """:class:`bool`: Whether most message content can be accessed.
 
-        This corresponds to the following attributes and classes in terms of cache:
+        Without this intent, the following attributes and classes may appear empty - either an
+        empty string or empty array depending on the data type:
 
         - :attr:`Message.content`
         - :attr:`Message.embeds`
         - :attr:`Message.attachments`
         - :attr:`Message.components`
+
+        A bot will always be able to get these attributes from:
+
+        - Messages the bot sends
+        - Messages the bot receives in DMs
+        - Messages in which the bot is mentioned
         """
         return 1 << 15
 

--- a/nextcord/flags.py
+++ b/nextcord/flags.py
@@ -912,8 +912,6 @@ class Intents(BaseFlags):
         - :func:`on_guild_scheduled_event_create`
         - :func:`on_guild_scheduled_event_delete`
         - :func:`on_guild_scheduled_event_update`
-        - :func:`on_guild_scheduled_event_user_add`
-        - :func:`on_guild_scheduled_event_user_remove`
 
         This does not correspond to any attributes or classes in the library in terms of cache.
         """

--- a/nextcord/flags.py
+++ b/nextcord/flags.py
@@ -492,11 +492,12 @@ class Intents(BaseFlags):
     @classmethod
     def default(cls: Type[Intents]) -> Intents:
         """A factory method that creates a :class:`Intents` with everything enabled
-        except :attr:`presences` and :attr:`members`.
+        except :attr:`presences`, :attr:`members`, and :attr:`message_content`.
         """
         self = cls.all()
         self.presences = False
         self.members = False
+        self.message_content = False
         return self
 
     @flag_value
@@ -876,6 +877,19 @@ class Intents(BaseFlags):
         return 1 << 14
 
     @flag_value
+    def message_content(self):
+        """:class:`bool`: Whether most message content related events are enabled.
+
+        This corresponds to the following attributes and classes in terms of cache:
+
+        - :attr:`Message.content`
+        - :attr:`Message.embeds`
+        - :attr:`Message.attachments`
+        - :attr:`Message.components`
+        """
+        return 1 << 15
+
+    @flag_value
     def scheduled_events(self):
         """:class:`bool`: Whether scheduled events related events are enabled.
 
@@ -884,6 +898,8 @@ class Intents(BaseFlags):
         - :func:`on_guild_scheduled_event_create`
         - :func:`on_guild_scheduled_event_delete`
         - :func:`on_guild_scheduled_event_update`
+        - :func:`on_guild_scheduled_event_user_add`
+        - :func:`on_guild_scheduled_event_user_remove`
 
         This does not correspond to any attributes or classes in the library in terms of cache.
         """
@@ -1089,3 +1105,17 @@ class ApplicationFlags(BaseFlags):
     def embedded(self):
         """:class:`bool`: Returns ``True`` if the application is embedded within the Discord client."""
         return 1 << 17
+
+    @flag_value
+    def gateway_message_content(self):
+        """:class:`bool`: Returns ``True`` if the application is allowed to receive message content
+        over the gateway.
+        """
+        return 1 << 18
+
+    @flag_value
+    def gateway_message_content_limited(self):
+        """:class:`bool`: Returns ``True`` if the application is allowed to receive limited
+        message content over the gateway.
+        """
+        return 1 << 19

--- a/nextcord/flags.py
+++ b/nextcord/flags.py
@@ -880,7 +880,7 @@ class Intents(BaseFlags):
     def message_content(self):
         """:class:`bool`: Whether most message content can be accessed.
 
-        Without this intent, the following attributes and classes may appear empty - either an
+        Without this intent, the following attributes may appear empty - either an
         empty string or empty array depending on the data type:
 
         - :attr:`Message.content`
@@ -893,6 +893,13 @@ class Intents(BaseFlags):
         - Messages the bot sends
         - Messages the bot receives in DMs
         - Messages in which the bot is mentioned
+
+        For more information go to the :ref:`message content intent documentation <need_message_content_intent>`.
+
+        .. note::
+
+            As of April 30, 2022, this requires opting in explicitly via the developer portal as well.
+            Bots in over 100 guilds will need to apply to Discord for verification.
         """
         return 1 << 15
 


### PR DESCRIPTION
## Summary

Adds MESSAGE_CONTENT intent and GATEWAY_MESSAGE_CONTENT, GATEWAY_MESSAGE_CONTENT_LIMITED application flags.

In v9, these are given by default, but without this change, in v10, the bot will throw an error if Message Content Intent is disabled in the portal.

This fixes intents to work correctly after migrating to v10

References:

- https://github.com/discord/discord-api-docs/blob/77ee0f906a3d9d2aff0bb3c285913e9db25d98dd/docs/resources/Application.md
- https://github.com/discord/discord-api-docs/blob/3891389606ef8710e7c54d65ae79d0c5313f0247/docs/topics/Gateway.md
- https://github.com/discord/discord-api-docs/discussions/4510
- https://support-dev.discord.com/hc/en-us/articles/4404772028055

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
