### PR TITLE
Make utils.get content-aware

### DIFF
--- a/nextcord/utils.py
+++ b/nextcord/utils.py
@@ -393,10 +393,9 @@ def _key_fmt(key: str) -> str:
     # ex. "_privateattr___subattr" -> "_privateattr_.subattr"
 
     if key.startswith("__") and key.endswith("__"):
-        return re.sub(r"((__){1}__(__){1})", "__.__", key)
+        return re.sub(r"_{6}", "__.__", key)
     else:
-        slices = re.split(r"(?=__)", key)
-        return "".join([s.replace("__", ".") for s in slices])
+        return re.sub(r"__(?!_)", ".", key)
 
 
 def get(iterable: Iterable[T], **attrs: Any) -> Optional[T]:

--- a/nextcord/utils.py
+++ b/nextcord/utils.py
@@ -384,6 +384,21 @@ def find(predicate: Callable[[T], Any], seq: Iterable[T]) -> Optional[T]:
     return None
 
 
+def _key_fmt(key: str) -> str:
+    # Private helper for `nextcord.utils.get`. Formats the attribute
+    # names in a content aware manner. When special variables are
+    # provided, double trailing and leading underscores are ignored.
+    # ex. "__class______name__" -> "__class__.__name__"
+    # In case of underscore conflicts, it will assume trailing underscores.
+    # ex. "_privateattr___subattr" -> "_privateattr_.subattr"
+
+    if key.startswith("__") and key.endswith("__"):
+        return re.sub(r"((__){1}__(__){1})", "__.__", key)
+    else:
+        slices = re.split(r"(?=__)", key)
+        return "".join([s.replace("__", ".") for s in slices])
+
+
 def get(iterable: Iterable[T], **attrs: Any) -> Optional[T]:
     r"""A helper that returns the first element in the iterable that meets
     all the traits passed in ``attrs``. This is an alternative for
@@ -435,13 +450,13 @@ def get(iterable: Iterable[T], **attrs: Any) -> Optional[T]:
     # Special case the single element call
     if len(attrs) == 1:
         k, v = attrs.popitem()
-        pred = attrget(k.replace('__', '.'))
+        pred = attrget(_key_fmt(k))
         for elem in iterable:
             if pred(elem) == v:
                 return elem
         return None
 
-    converted = [(attrget(attr.replace('__', '.')), value) for attr, value in attrs.items()]
+    converted = [(attrget(_key_fmt(attr)), value) for attr, value in attrs.items()]
 
     for elem in iterable:
         if _all(pred(elem) == value for pred, value in converted):


### PR DESCRIPTION
## Summary

This pull request aims to make `nextcord.utils.get` aware of the attribute names passed to it.

Prior to this change, `nextcord.utils.get` would blindly replace the `__` delimiter with `.` causing special variables (`__class__`, `__name__`, etc.) to throw an error. I've updated the `str.replace("__", "_")` to use regex to look for edge cases that contain special variables. If the name does not contain special variables, the regular expression will use a lookahead statement for underscores, and greedily replace them with `.`, assuming trailing underscores.

Previous behavior:
```py
>>> fmt("guild__name")
'guild.name'
>>> fmt("trailing___attr")
'trailing._attr'
>>> fmt("__class______name__")
'.class...name.'
```
New behavior:
```py
>>> fmt("guild__name")
'guild.name'
>>> fmt("trailing___attr")
'trailing_.attr'
>>> fmt("__class______name__")
'__class__.__name__'
>>> fmt("__class______name______type__")
'__class__.__name__.__type__'
```

Although these are pretty dramatic changes to behavior, it should be non-breaking. 

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
