### PR TITLE
docs: fix error in bullet list

### DIFF
--- a/docs/ext/commands/api.rst
+++ b/docs/ext/commands/api.rst
@@ -643,7 +643,7 @@ Exception Hierarchy
                     - :exc:`~.commands.PartialEmojiConversionFailure`
                     - :exc:`~.commands.BadBoolArgument`
                     - :exc:`~.commands.ThreadNotFound`
-                    ~ :exc:`~.commands.ScheduledEventNotFound`
+                    - :exc:`~.commands.ScheduledEventNotFound`
                     - :exc:`~.commands.FlagError`
                         - :exc:`~.commands.BadFlagArgument`
                         - :exc:`~.commands.MissingFlagArgument`


### PR DESCRIPTION
## Summary

Fixes error in `make -C docs html`

```
/nextcord/docs/ext/commands/api.rst:646: WARNING: Bullet list ends without a blank line; unexpected unindent.
/nextcord/docs/ext/commands/api.rst:648: ERROR: Unexpected indentation.
```

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
