### PR TITLE
docs: Switch order of installation steps

### DIFF
--- a/docs/migrating_to_nextcord.rst
+++ b/docs/migrating_to_nextcord.rst
@@ -14,17 +14,7 @@ Porting from discord.py
 
 In order to port a bot using discord.py to nextcord, follow these steps:
 
-1. Install nextcord: 
-
-    .. code:: sh
-
-        # Linux/macOS
-        python3 -m pip install -U nextcord
-
-        # Windows
-        py -3 -m pip install -U nextcord
-
-2. Uninstall discord.py:
+1. Uninstall discord.py:
 
     .. code:: sh
 
@@ -33,6 +23,16 @@ In order to port a bot using discord.py to nextcord, follow these steps:
 
         # Windows
         py -3 -m pip uninstall discord.py
+
+2. Install nextcord: 
+
+    .. code:: sh
+
+        # Linux/macOS
+        python3 -m pip install -U nextcord
+
+        # Windows
+        py -3 -m pip install -U nextcord
 
 3. Update the following import statements:
 


### PR DESCRIPTION
## Summary

For compatibility with the discord alias, I believe it is recommended to uninstall discord.py _before_ installing nextcord.

The migration docs currently have the steps in the other order.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
