### PR TITLE
Added Attachment support for slash commands.

### DIFF
--- a/nextcord/application_command.py
+++ b/nextcord/application_command.py
@@ -45,7 +45,7 @@ from .errors import InvalidCommandType
 from .interactions import Interaction
 from .guild import Guild
 from .member import Member
-from .message import Message
+from .message import Attachment, Message
 from .role import Role
 from .user import User
 from .utils import MISSING
@@ -189,7 +189,8 @@ class CommandOption(SlashOption):
         # TODO: Is this in the library at all currently? This includes Users and Roles.
         # Mentionable: CommandOptionType.mentionable
         float: ApplicationCommandOptionType.number,
-        Message: ApplicationCommandOptionType.integer  # TODO: This is janky, the user provides an ID or something? Ugh.
+        Message: ApplicationCommandOptionType.integer,  # TODO: This is janky, the user provides an ID or something? Ugh.
+        Attachment: ApplicationCommandOptionType.attachment
     }
     """Maps Python annotations/typehints to Discord Application Command type values."""
     def __init__(self, parameter: Parameter):
@@ -325,6 +326,9 @@ class CommandOption(SlashOption):
             return float(argument)
         elif self.type is Message:  # TODO: This is mostly a workaround for Message commands, switch to handles below.
             return state._get_message(int(argument))
+        elif self.type is ApplicationCommandOptionType.attachment:
+            resolved_attachment_data: dict = interaction.data["resolved"]["attachments"][argument]
+            return Attachment(data=resolved_attachment_data, state=state)
         return argument
 
     async def handle_message_argument(self, state: ConnectionState, argument: Any, interaction: Interaction):

--- a/nextcord/enums.py
+++ b/nextcord/enums.py
@@ -575,6 +575,7 @@ class ApplicationCommandOptionType(Enum):
     role = 8
     mentionable = 9
     number = 10  # A double, AKA floating point.
+    attachment = 11
 
 
 class VideoQualityMode(Enum):


### PR DESCRIPTION
## Summary

<!-- What is this pull request for? Does it fix any issues? -->
Adds the following to Slash:
* ApplicationCommandOptionType.attachment enum.
* Typehinting a parameter with nextcord.Attachment tells Discord that the parameter wants a file.
* Slash commands can now receive Attachment objects.

Fixes #439

I may have royally screwed up the previous version of this PR, sorry :(

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [X] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [X] This PR fixes an issue.
- [X] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
