### PR TITLE
AppCmd association now checks option length.

### DIFF
--- a/nextcord/application_command.py
+++ b/nextcord/application_command.py
@@ -1073,7 +1073,11 @@ class ApplicationCommand(ApplicationSubcommand):
         if not check_dictionary_values(cmd_payload, raw_payload, "default_permission", "description", "type", "name"):
             return False
 
+        if len(cmd_payload.get("options", [])) != len(raw_payload.get("options", [])):
+            return False
+
         for cmd_option in cmd_payload.get("options", []):
+            # I absolutely do not trust Discord or us ordering things nicely, so check through both.
             found_correct_value = False
             for raw_option in raw_payload.get("options", []):
                 if cmd_option["name"] == raw_option["name"]:
@@ -1083,6 +1087,7 @@ class ApplicationCommand(ApplicationSubcommand):
                     # check_dictionary_values.
                     if not deep_dictionary_check(cmd_option, raw_option):
                         return False
+                    break
             if not found_correct_value:
                 return False
         return True


### PR DESCRIPTION
## Summary

<!-- What is this pull request for? Does it fix any issues? -->
When removing an option/parameter, the association checks do not detect a change and will not update Discord with the new command.
This PR makes it so it now checks the length of the options between the local and Discord command.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [X] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [X] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
