### PR TITLE
Add join_notification_replies SystemChannelFlags

### DIFF
--- a/nextcord/flags.py
+++ b/nextcord/flags.py
@@ -216,6 +216,14 @@ class SystemChannelFlags(BaseFlags):
         .. versionadded:: 2.0
         """
         return 4
+    
+    @flag_value
+    def join_notification_replies(self):
+        """:class:`bool`: Returns ``True`` if the button to reply with a sticker to member join notifications is shown.
+
+        .. versionadded:: 2.0
+        """
+        return 8
 
 
 @fill_with_flags()


### PR DESCRIPTION
## Summary

This pull request adds the `join_notification_replies` flag to `SystemChannelFlags`. This is the flag that controls whether or not members can reply with a sticker on member join messages.

This matches with https://discord.com/developers/docs/resources/guild#guild-object-system-channel-flags

## Checklist

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [x] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
