### PR TITLE
Add support for scheduled event cover image

### DIFF
--- a/nextcord/guild.py
+++ b/nextcord/guild.py
@@ -3139,7 +3139,8 @@ class Guild(Hashable):
         privacy_level: ScheduledEventPrivacyLevel = ScheduledEventPrivacyLevel.guild_only,
         end_time: datetime.datetime = MISSING,
         description: str = MISSING,
-        reason: Optional[str] = None
+        image: bytes = MISSING,
+        reason: Optional[str] = None,
     ) -> ScheduledEvent:
         """|coro|
 
@@ -3163,7 +3164,9 @@ class Guild(Hashable):
             The description for the event
         entity_type: :class:`ScheduledEventEntityType`
             The type of event
-
+        image: :class:`bytes`
+            A :term:`py:bytes-like object` representing the cover image.
+            
         Returns
         -------
         :class:`ScheduledEvent`
@@ -3183,6 +3186,8 @@ class Guild(Hashable):
             payload['scheduled_end_time'] = end_time.isoformat()
         if description is not MISSING:
             payload['description'] = description
+        if image is not MISSING:
+            payload['image'] = utils._bytes_to_base64_data(image)
         data = await self._state.http.create_event(self.id, reason=reason, **payload)
         return self._store_scheduled_event(data)
 

--- a/nextcord/http.py
+++ b/nextcord/http.py
@@ -1956,7 +1956,8 @@ class HTTPClient:
             'scheduled_start_time',
             'scheduled_end_time',
             'description',
-            'entity_type'
+            'entity_type',
+            "image",
         }
         payload = {k: v for k, v in payload.items() if k in valid_keys}
         r = Route(

--- a/nextcord/scheduled_events.py
+++ b/nextcord/scheduled_events.py
@@ -30,7 +30,7 @@ from .enums import ScheduledEventPrivacyLevel
 from .iterators import ScheduledEventUserIterator
 from .mixins import Hashable
 from .types.snowflake import Snowflake
-from .utils import MISSING, parse_time
+from .utils import MISSING, parse_time, _bytes_to_base64_data
 from .asset import Asset
 __all__: Tuple[str] = (
     'EntityMetadata',
@@ -331,7 +331,8 @@ class ScheduledEvent(Hashable):
         description: str = MISSING,
         type: Optional[ScheduledEventEntityType] = MISSING,
         status: Optional[ScheduledEventStatus] = MISSING,
-        reason: Optional[str] = None
+        reason: Optional[str] = None,
+        image: Optional[bytes] = MISSING
     ) -> ScheduledEvent:
         """|coro|
 
@@ -364,6 +365,9 @@ class ScheduledEvent(Hashable):
                 scheduled -> active ;
                 active -> completed ;
                 scheduled -> canceled
+        image: Optional[:class:`bytes`]
+            A :term:`py:bytes-like object` representing the cover image.
+            Could be ``None`` to denote removal of the cover image.
 
         Returns
         -------
@@ -389,6 +393,12 @@ class ScheduledEvent(Hashable):
             payload['type'] = type.value
         if status is not MISSING:
             payload['status'] = status.value
+        if image is not MISSING:
+            if image is None:
+                payload['image'] = image
+            else:
+                payload['image'] = _bytes_to_base64_data(image)
+
         if not payload:
             return self
         data = await self._state.http.edit_event(self.guild.id, self.id, reason=reason, **payload)


### PR DESCRIPTION
## Summary

This PR adds a kwarg called `image` to `Guild.create_scheduled_event()` and `ScheduledEvent.edit()` that allows users to set or remove the event cover image. Fixes #485 

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
