### PR TITLE
fix: Return the correct timeout in _expires_at

### DIFF
--- a/nextcord/ui/view.py
+++ b/nextcord/ui/view.py
@@ -248,9 +248,7 @@ class View:
 
             None if no timeout is set.
         """
-        if self.timeout and self.__timeout_expiry is not None:
-            return self.__timeout_expiry
-        return None
+        return self.__timeout_expiry
 
     def add_item(self, item: Item) -> None:
         """Adds an item to the view.

--- a/nextcord/ui/view.py
+++ b/nextcord/ui/view.py
@@ -239,8 +239,17 @@ class View:
 
     @property
     def _expires_at(self) -> Optional[float]:
-        if self.timeout:
-            return time.monotonic() + self.timeout
+        """The monotonic time this view times out at.
+
+        Returns
+        -------
+        Optional[float]
+            When this view times out.
+
+            None if no timeout is set.
+        """
+        if self.timeout and self.__timeout_expiry is not None:
+            return self.__timeout_expiry
         return None
 
     def add_item(self, item: Item) -> None:


### PR DESCRIPTION
## Summary

This pull request fixes the `View._expires_at` decor so that it returns the correct timeout.

If you wish to check this yourself
```python
        from discord import ui
        import asyncio

        class MF(ui.View):
            @ui.button(label="reset or something")
            async def a(self, _, __):
                self.first = (self._expires_at, self._View__timeout_expiry)
                await asyncio.sleep(2)
                self.second = (self._expires_at, self._View__timeout_expiry)
                print(self.first, self.second, sep="\n")

        await ctx.send("a", view=MF())
```

They *should* be the same values both times, however, they are not. This PR resolves that.

Current output:
```
(34118.328, 34118.328)
(34120.343, 34118.328)
```

## Checklist


- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
