### PR TITLE
Make SlashOption extend typing.Any

### DIFF
--- a/nextcord/application_command.py
+++ b/nextcord/application_command.py
@@ -37,7 +37,6 @@ from typing import (
     TYPE_CHECKING,
     Tuple,
     Union,
-    TYPE_CHECKING,
 )
 
 from .abc import GuildChannel

--- a/nextcord/application_command.py
+++ b/nextcord/application_command.py
@@ -53,6 +53,9 @@ from .utils import MISSING
 
 if TYPE_CHECKING:
     from .state import ConnectionState
+    _SlashOptionMetaBase = Any
+else:
+    _SlashOptionMetaBase = object
 
 
 __all__ = (
@@ -98,7 +101,7 @@ class ClientCog:
 
 
 # Extends Any so that type checkers won't complain that it's a default for a parameter of a different type
-class SlashOption(Any if TYPE_CHECKING else object):
+class SlashOption(_SlashOptionMetaBase):
     """Provides Discord with information about an option in a command.
 
     When this class is set as the default argument of a parameter in an Application Command, additional information

--- a/nextcord/application_command.py
+++ b/nextcord/application_command.py
@@ -96,7 +96,8 @@ class ClientCog:
         return self.__cog_to_register__
 
 
-class SlashOption:
+# Extends Any so that type checkers won't complain that it's a default for a parameter of a different type
+class SlashOption(Any):
     """Provides Discord with information about an option in a command.
 
     When this class is set as the default argument of a parameter in an Application Command, additional information

--- a/nextcord/application_command.py
+++ b/nextcord/application_command.py
@@ -37,6 +37,7 @@ from typing import (
     TYPE_CHECKING,
     Tuple,
     Union,
+    TYPE_CHECKING,
 )
 
 from .abc import GuildChannel
@@ -97,7 +98,7 @@ class ClientCog:
 
 
 # Extends Any so that type checkers won't complain that it's a default for a parameter of a different type
-class SlashOption(Any):
+class SlashOption(Any if TYPE_CHECKING else object):
     """Provides Discord with information about an option in a command.
 
     When this class is set as the default argument of a parameter in an Application Command, additional information


### PR DESCRIPTION
Currently static type checkers will complain that a SlashOption object is not a valid default parameter for a parameter of type `int`, `str`, or anything. E.g.

```py
@nextcord.slash_command(description="bla bla bla")
async def foo(
	self,
	interaction: nextcord.Interaction,
	bar: str = SlashOption(description="bla bla bla"), # SlashOption is not a valid default for parameter of type str
):
	pass
```

## Summary

<!-- What is this pull request for? Does it fix any issues? -->

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
