### PR TITLE
Cache roles within ``Guild.fetch_roles``

### DIFF
--- a/nextcord/guild.py
+++ b/nextcord/guild.py
@@ -2424,7 +2424,7 @@ class Guild(Hashable):
 
         await self._state.http.delete_custom_emoji(self.id, emoji.id, reason=reason)
 
-    async def fetch_roles(self, *, cache: bool=False) -> List[Role]:
+    async def fetch_roles(self, *, cache: bool = False) -> List[Role]:
         """|coro|
 
         Retrieves all :class:`Role` that the guild has.

--- a/nextcord/guild.py
+++ b/nextcord/guild.py
@@ -2424,7 +2424,7 @@ class Guild(Hashable):
 
         await self._state.http.delete_custom_emoji(self.id, emoji.id, reason=reason)
 
-    async def fetch_roles(self) -> List[Role]:
+    async def fetch_roles(self, *, cache: bool=False) -> List[Role]:
         """|coro|
 
         Retrieves all :class:`Role` that the guild has.
@@ -2433,7 +2433,11 @@ class Guild(Hashable):
 
             This method is an API call. For general usage, consider :attr:`roles` instead.
 
-        .. versionadded:: 1.3
+        Parameters
+        ----------
+        cache: bool
+            Whether or not to also update this guilds
+            role cache. Defaults to ``False``.
 
         Raises
         -------
@@ -2446,7 +2450,13 @@ class Guild(Hashable):
             All roles in the guild.
         """
         data = await self._state.http.get_roles(self.id)
-        return [Role(guild=self, state=self._state, data=d) for d in data]
+        roles = [Role(guild=self, state=self._state, data=d) for d in data]
+        if cache:
+            self._roles: Dict[int, Role] = {}
+            for role in roles:
+                self._roles[role.id] = role
+
+        return roles
 
     @overload
     async def create_role(


### PR DESCRIPTION
## Summary

Currently when using ``Guild.fetch_roles``, the updated roles are not cached. This pr adds an additional param to allow for cache updates while defaulting to a backward compat change.

## Checklist

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
