### PR TITLE
Add tag property to BaseUser

### DIFF
--- a/nextcord/user.py
+++ b/nextcord/user.py
@@ -256,6 +256,11 @@ class BaseUser(_UserTag):
         is returned instead.
         """
         return self.name
+    
+    @property
+    def tag(self) -> str:
+        """:class:`str` Returns the user's tag (username and discriminator)."""
+        return f"{self.name}#{self.discriminator}"
 
     def mentioned_in(self, message: Message) -> bool:
         """Checks if the user is mentioned in the specified message.


### PR DESCRIPTION
Add tag property to BaseUser, displaying the user's entire tag (username + discriminator)

## Summary

It adds a new property to the BaseUser class, making it easier to print out the user's entire tag

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [x] This PR is a breaking change (e.g. methods or parameters removed/renamed)
