### PR TITLE
Cython compatibility

### DIFF
--- a/docs/extensions/attributetable.py
+++ b/docs/extensions/attributetable.py
@@ -3,6 +3,7 @@ from sphinx.locale import _
 from docutils import nodes
 from sphinx import addnodes
 
+import asyncio
 from collections import OrderedDict, namedtuple
 import importlib
 import inspect
@@ -193,7 +194,7 @@ def get_class_results(lookup, modulename, name, fullname):
 
         if value is not None:
             doc = value.__doc__ or ''
-            if inspect.iscoroutinefunction(value) or doc.startswith('|coro|'):
+            if asyncio.iscoroutinefunction(value) or doc.startswith('|coro|'):
                 key = _('Methods')
                 badge = attributetablebadge('async', 'async')
                 badge['badge-type'] = _('coroutine')

--- a/nextcord/ext/commands/cog.py
+++ b/nextcord/ext/commands/cog.py
@@ -23,6 +23,7 @@ DEALINGS IN THE SOFTWARE.
 """
 from __future__ import annotations
 
+import asyncio
 import inspect
 import nextcord.utils
 
@@ -141,7 +142,7 @@ class CogMeta(type):
                     if elem.startswith(('cog_', 'bot_')):
                         raise TypeError(no_bot_cog.format(base, elem))
                     commands[elem] = value
-                elif inspect.iscoroutinefunction(value):
+                elif asyncio.iscoroutinefunction(value):
                     try:
                         getattr(value, '__cog_listener__')
                     except AttributeError:
@@ -304,7 +305,7 @@ class Cog(nextcord.ClientCog, metaclass=CogMeta):
             actual = func
             if isinstance(actual, staticmethod):
                 actual = actual.__func__
-            if not inspect.iscoroutinefunction(actual):
+            if not asyncio.iscoroutinefunction(actual):
                 raise TypeError('Listener function must be a coroutine function.')
             actual.__cog_listener__ = True
             to_assign = name or actual.__name__

--- a/nextcord/ext/commands/core.py
+++ b/nextcord/ext/commands/core.py
@@ -1754,7 +1754,7 @@ def check(predicate: Check) -> Callable[[T], T]:
 
         return func
 
-    if inspect.iscoroutinefunction(predicate):
+    if asyncio.iscoroutinefunction(predicate):
         decorator.predicate = predicate
     else:
         @functools.wraps(predicate)

--- a/nextcord/ext/tasks/__init__.py
+++ b/nextcord/ext/tasks/__init__.py
@@ -131,7 +131,7 @@ class Loop(Generic[LF]):
         self._last_iteration: datetime.datetime = MISSING
         self._next_iteration = None
 
-        if not inspect.iscoroutinefunction(self.coro):
+        if not asyncio.iscoroutinefunction(self.coro):
             raise TypeError(f'Expected coroutine function, not {type(self.coro).__name__!r}.')
 
     async def _call_loop_function(self, name: str, *args: Any, **kwargs: Any) -> None:
@@ -488,7 +488,7 @@ class Loop(Generic[LF]):
             The function was not a coroutine.
         """
 
-        if not inspect.iscoroutinefunction(coro):
+        if not asyncio.iscoroutinefunction(coro):
             raise TypeError(f'Expected coroutine function, received {coro.__class__.__name__!r}.')
 
         self._before_loop = coro
@@ -516,7 +516,7 @@ class Loop(Generic[LF]):
             The function was not a coroutine.
         """
 
-        if not inspect.iscoroutinefunction(coro):
+        if not asyncio.iscoroutinefunction(coro):
             raise TypeError(f'Expected coroutine function, received {coro.__class__.__name__!r}.')
 
         self._after_loop = coro
@@ -542,7 +542,7 @@ class Loop(Generic[LF]):
         TypeError
             The function was not a coroutine.
         """
-        if not inspect.iscoroutinefunction(coro):
+        if not asyncio.iscoroutinefunction(coro):
             raise TypeError(f'Expected coroutine function, received {coro.__class__.__name__!r}.')
 
         self._error = coro  # type: ignore

--- a/nextcord/member.py
+++ b/nextcord/member.py
@@ -25,7 +25,7 @@ DEALINGS IN THE SOFTWARE.
 from __future__ import annotations
 
 import datetime
-import inspect
+import asyncio
 import itertools
 import sys
 from operator import attrgetter
@@ -178,7 +178,7 @@ def flatten_user(cls):
             # probably a member function by now
             def generate_function(x):
                 # We want sphinx to properly show coroutine functions as coroutines
-                if inspect.iscoroutinefunction(value):
+                if asyncio.iscoroutinefunction(value):
 
                     async def general(self, *args, **kwargs):  # type: ignore
                         return await getattr(self._user, x)(*args, **kwargs)

--- a/nextcord/ui/button.py
+++ b/nextcord/ui/button.py
@@ -25,7 +25,7 @@ DEALINGS IN THE SOFTWARE.
 from __future__ import annotations
 
 from typing import Callable, Optional, TYPE_CHECKING, Tuple, Type, TypeVar, Union
-import inspect
+import asyncio
 import os
 
 
@@ -272,7 +272,7 @@ def button(
     """
 
     def decorator(func: ItemCallbackType) -> ItemCallbackType:
-        if not inspect.iscoroutinefunction(func):
+        if not asyncio.iscoroutinefunction(func):
             raise TypeError('button function must be a coroutine function')
 
         func.__discord_ui_model_type__ = Button

--- a/nextcord/ui/select.py
+++ b/nextcord/ui/select.py
@@ -24,7 +24,7 @@ DEALINGS IN THE SOFTWARE.
 
 from __future__ import annotations
 from typing import List, Optional, TYPE_CHECKING, Tuple, TypeVar, Type, Callable, Union
-import inspect
+import asyncio
 import os
 
 from .item import Item, ItemCallbackType
@@ -339,7 +339,7 @@ def select(
     """
 
     def decorator(func: ItemCallbackType) -> ItemCallbackType:
-        if not inspect.iscoroutinefunction(func):
+        if not asyncio.iscoroutinefunction(func):
             raise TypeError('select function must be a coroutine function')
 
         func.__discord_ui_model_type__ = Select


### PR DESCRIPTION
## Summary

This PR is supposed to fix some incompatibilities with Cython and Nextcord. 
The first of these is that Cython stores coros internally with the same `co_flags` as a regular function. Since `inspect.iscoroutinefunction` is used a bunch in nextcord to ensure listeners work right, "Pure Python" compiled with Cython cannot use nextcord. Cython *does* add a flag elsewhere that `asyncio.iscoroutinefunction` does check for (see [this](https://github.com/cython/cython/issues/2273#issuecomment-414032693)). I replaced all calls to inspect's impl with asyncio's impl, altering imports where necessary.

This is a draft for now, because I don't want to merge it until I can make a bot using Cython. Once the first obstacle is fixed, I'm sure there will be more.

## Checklist

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)

**I don't know how to test this yet, I was wondering if you guys would be able to point me in the right direction**
