### PR TITLE
:meth: reload_extension docstring Spelling

### DIFF
--- a/nextcord/ext/commands/bot.py
+++ b/nextcord/ext/commands/bot.py
@@ -834,7 +834,7 @@ class BotBase(GroupMixin):
         self._call_module_finalizers(lib, name)
 
     def reload_extension(self, name: str, *, package: Optional[str] = None) -> None:
-        """Atomically reloads an extension.
+        """ Automatically reloads an extension.
 
         This replaces the extension with the same extension, only refreshed. This is
         equivalent to a :meth:`unload_extension` followed by a :meth:`load_extension`

--- a/nextcord/ext/commands/bot.py
+++ b/nextcord/ext/commands/bot.py
@@ -834,7 +834,7 @@ class BotBase(GroupMixin):
         self._call_module_finalizers(lib, name)
 
     def reload_extension(self, name: str, *, package: Optional[str] = None) -> None:
-        """ Automatically reloads an extension.
+        """Automatically reloads an extension.
 
         This replaces the extension with the same extension, only refreshed. This is
         equivalent to a :meth:`unload_extension` followed by a :meth:`load_extension`


### PR DESCRIPTION

## Summary
https://github.com/nextcord/nextcord/edit/master/nextcord/ext/commands/bot.py#L837 

1 word in doc string misspelled 

(from what i see)

<!-- What is this pull request for? Does it fix any issues? -->

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
