### PR TITLE
docs: Fix broken links to dpy issues

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -50,6 +50,7 @@ autodoc_typehints = 'none'
 
 extlinks = {
     'issue': ('https://github.com/nextcord/nextcord/issues/%s', 'GH-'),
+    'dpyissue': ('https://github.com/Rapptz/discord.py/issues/%s', 'GH-'),
 }
 
 # Links used for cross-referencing stuff in other documentation

--- a/docs/migrating_to_async.rst
+++ b/docs/migrating_to_async.rst
@@ -12,7 +12,7 @@ fundamental changes in how the library operates.
 
 The biggest major change is that the library has dropped support to all versions prior to
 Python 3.4.2. This was made to support :mod:`asyncio`, in which more detail can be seen
-:issue:`in the corresponding issue <50>`. To reiterate this, the implication is that
+:dpyissue:`in the corresponding issue <50>`. To reiterate this, the implication is that
 **python version 2.7 and 3.3 are no longer supported**.
 
 Below are all the other major changes from v0.9.0 to v0.10.0.

--- a/docs/whats_new.rst
+++ b/docs/whats_new.rst
@@ -40,9 +40,9 @@ v1.7.2
 Bug Fixes
 ~~~~~~~~~~~
 
-- Fix ``fail_if_not_exists`` causing certain message references to not be usable within :meth:`abc.Messageable.send` and :meth:`Message.reply` (:issue:`6726`)
-- Fix :meth:`Guild.chunk` hanging when the user left the guild. (:issue:`6730`)
-- Fix loop sleeping after final iteration rather than before (:issue:`6744`)
+- Fix ``fail_if_not_exists`` causing certain message references to not be usable within :meth:`abc.Messageable.send` and :meth:`Message.reply` (:dpyissue:`6726`)
+- Fix :meth:`Guild.chunk` hanging when the user left the guild. (:dpyissue:`6730`)
+- Fix loop sleeping after final iteration rather than before (:dpyissue:`6744`)
 
 .. _vp1p7p1:
 
@@ -68,8 +68,8 @@ Development of v2.0 will have breaking changes and support for newer API feature
 New Features
 ~~~~~~~~~~~~~~
 
-- Add support for stage channels via :class:`StageChannel` (:issue:`6602`, :issue:`6608`)
-- Add support for :attr:`MessageReference.fail_if_not_exists` (:issue:`6484`)
+- Add support for stage channels via :class:`StageChannel` (:dpyissue:`6602`, :dpyissue:`6608`)
+- Add support for :attr:`MessageReference.fail_if_not_exists` (:dpyissue:`6484`)
     - By default, if the message you're replying to doesn't exist then the API errors out.
       This attribute tells the Discord API that it's okay for that message to be missing.
 
@@ -77,65 +77,65 @@ New Features
 - Add an easier way to move channels using :meth:`abc.GuildChannel.move`
 - Add :attr:`Permissions.use_slash_commands`
 - Add :attr:`Permissions.request_to_speak`
-- Add support for voice regions in voice channels via :attr:`VoiceChannel.rtc_region` (:issue:`6606`)
-- Add support for :meth:`PartialEmoji.url_as` (:issue:`6341`)
-- Add :attr:`MessageReference.jump_url` (:issue:`6318`)
-- Add :attr:`File.spoiler` (:issue:`6317`)
-- Add support for passing ``roles`` to :meth:`Guild.estimate_pruned_members` (:issue:`6538`)
-- Allow callable class factories to be used in :meth:`abc.Connectable.play` (:issue:`6478`)
-- Add a way to get mutual guilds from the client's cache via :attr:`User.mutual_guilds` (:issue:`2539`, :issue:`6444`)
-- :meth:`PartialMessage.edit` now returns a full :class:`Message` upon success (:issue:`6309`)
-- Add :attr:`RawMessageUpdateEvent.guild_id` (:issue:`6489`)
-- :class:`AuditLogEntry` is now hashable (:issue:`6495`)
+- Add support for voice regions in voice channels via :attr:`VoiceChannel.rtc_region` (:dpyissue:`6606`)
+- Add support for :meth:`PartialEmoji.url_as` (:dpyissue:`6341`)
+- Add :attr:`MessageReference.jump_url` (:dpyissue:`6318`)
+- Add :attr:`File.spoiler` (:dpyissue:`6317`)
+- Add support for passing ``roles`` to :meth:`Guild.estimate_pruned_members` (:dpyissue:`6538`)
+- Allow callable class factories to be used in :meth:`abc.Connectable.play` (:dpyissue:`6478`)
+- Add a way to get mutual guilds from the client's cache via :attr:`User.mutual_guilds` (:dpyissue:`2539`, :dpyissue:`6444`)
+- :meth:`PartialMessage.edit` now returns a full :class:`Message` upon success (:dpyissue:`6309`)
+- Add :attr:`RawMessageUpdateEvent.guild_id` (:dpyissue:`6489`)
+- :class:`AuditLogEntry` is now hashable (:dpyissue:`6495`)
 - :class:`Attachment` is now hashable
-- Add :attr:`Attachment.content_type` attribute (:issue:`6618`)
+- Add :attr:`Attachment.content_type` attribute (:dpyissue:`6618`)
 - Add support for casting :class:`Attachment` to :class:`str` to get the URL.
-- Add ``seed`` parameter for :class:`Colour.random` (:issue:`6562`)
+- Add ``seed`` parameter for :class:`Colour.random` (:dpyissue:`6562`)
     - This only seeds it for one call. If seeding for multiple calls is desirable, use :func:`random.seed`.
 
-- Add a :func:`utils.remove_markdown` helper function (:issue:`6573`)
-- Add support for passing scopes to :func:`utils.oauth_url` (:issue:`6568`)
-- |commands| Add support for ``rgb`` CSS function as a parameter to :class:`ColourConverter <ext.commands.ColourConverter>` (:issue:`6374`)
-- |commands| Add support for converting :class:`StoreChannel` via :class:`StoreChannelConverter <ext.commands.StoreChannelConverter>` (:issue:`6603`)
+- Add a :func:`utils.remove_markdown` helper function (:dpyissue:`6573`)
+- Add support for passing scopes to :func:`utils.oauth_url` (:dpyissue:`6568`)
+- |commands| Add support for ``rgb`` CSS function as a parameter to :class:`ColourConverter <ext.commands.ColourConverter>` (:dpyissue:`6374`)
+- |commands| Add support for converting :class:`StoreChannel` via :class:`StoreChannelConverter <ext.commands.StoreChannelConverter>` (:dpyissue:`6603`)
 - |commands| Add support for stripping whitespace after the prefix is encountered using the ``strip_after_prefix`` :class:`~ext.commands.Bot` constructor parameter.
-- |commands| Add :attr:`Context.invoked_parents <ext.commands.Context.invoked_parents>` to get the aliases a command's parent was invoked with (:issue:`1874`, :issue:`6462`)
-- |commands| Add a converter for :class:`PartialMessage` under :class:`ext.commands.PartialMessageConverter` (:issue:`6308`)
-- |commands| Add a converter for :class:`Guild` under :class:`ext.commands.GuildConverter` (:issue:`6016`, :issue:`6365`)
+- |commands| Add :attr:`Context.invoked_parents <ext.commands.Context.invoked_parents>` to get the aliases a command's parent was invoked with (:dpyissue:`1874`, :dpyissue:`6462`)
+- |commands| Add a converter for :class:`PartialMessage` under :class:`ext.commands.PartialMessageConverter` (:dpyissue:`6308`)
+- |commands| Add a converter for :class:`Guild` under :class:`ext.commands.GuildConverter` (:dpyissue:`6016`, :dpyissue:`6365`)
 - |commands| Add :meth:`Command.has_error_handler <ext.commands.Command.has_error_handler>`
     - This is also adds :meth:`Cog.has_error_handler <ext.commands.Cog.has_error_handler>`
-- |commands| Allow callable types to act as a bucket key for cooldowns (:issue:`6563`)
-- |commands| Add ``linesep`` keyword argument to :class:`Paginator <ext.commands.Paginator>` (:issue:`5975`)
-- |commands| Allow ``None`` to be passed to :attr:`HelpCommand.verify_checks <ext.commands.HelpCommand.verify_checks>` to only verify in a guild context (:issue:`2008`, :issue:`6446`)
-- |commands| Allow relative paths when loading extensions via a ``package`` keyword argument (:issue:`2465`, :issue:`6445`)
+- |commands| Allow callable types to act as a bucket key for cooldowns (:dpyissue:`6563`)
+- |commands| Add ``linesep`` keyword argument to :class:`Paginator <ext.commands.Paginator>` (:dpyissue:`5975`)
+- |commands| Allow ``None`` to be passed to :attr:`HelpCommand.verify_checks <ext.commands.HelpCommand.verify_checks>` to only verify in a guild context (:dpyissue:`2008`, :dpyissue:`6446`)
+- |commands| Allow relative paths when loading extensions via a ``package`` keyword argument (:dpyissue:`2465`, :dpyissue:`6445`)
 
 Bug Fixes
 ~~~~~~~~~~
 
-- Fix mentions not working if ``mention_author`` is passed in :meth:`abc.Messageable.send` without :attr:`Client.allowed_mentions` set (:issue:`6192`, :issue:`6458`)
-- Fix user created instances of :class:`CustomActivity` triggering an error (:issue:`4049`)
+- Fix mentions not working if ``mention_author`` is passed in :meth:`abc.Messageable.send` without :attr:`Client.allowed_mentions` set (:dpyissue:`6192`, :dpyissue:`6458`)
+- Fix user created instances of :class:`CustomActivity` triggering an error (:dpyissue:`4049`)
     - Note that currently, bot users still cannot set a custom activity due to a Discord limitation.
-- Fix :exc:`ZeroDivisionError` being raised from :attr:`VoiceClient.average_latency` (:issue:`6430`, :issue:`6436`)
-- Fix :attr:`User.public_flags` not updating upon edit (:issue:`6315`)
-- Fix :attr:`Message.call` sometimes causing attribute errors (:issue:`6390`)
-- Fix issue resending a file during request retries on newer versions of ``aiohttp`` (:issue:`6531`)
+- Fix :exc:`ZeroDivisionError` being raised from :attr:`VoiceClient.average_latency` (:dpyissue:`6430`, :dpyissue:`6436`)
+- Fix :attr:`User.public_flags` not updating upon edit (:dpyissue:`6315`)
+- Fix :attr:`Message.call` sometimes causing attribute errors (:dpyissue:`6390`)
+- Fix issue resending a file during request retries on newer versions of ``aiohttp`` (:dpyissue:`6531`)
 - Raise an error when ``user_ids`` is empty in :meth:`Guild.query_members`
 - Fix ``__str__`` magic method raising when a :class:`Guild` is unavailable.
-- Fix potential :exc:`AttributeError` when accessing :attr:`VoiceChannel.members` (:issue:`6602`)
-- :class:`Embed` constructor parameters now implicitly convert to :class:`str` (:issue:`6574`)
-- Ensure ``discord`` package is only run if executed as a script (:issue:`6483`)
+- Fix potential :exc:`AttributeError` when accessing :attr:`VoiceChannel.members` (:dpyissue:`6602`)
+- :class:`Embed` constructor parameters now implicitly convert to :class:`str` (:dpyissue:`6574`)
+- Ensure ``discord`` package is only run if executed as a script (:dpyissue:`6483`)
 - |commands| Fix irrelevant commands potentially being unloaded during cog unload due to failure.
-- |commands| Fix attribute errors when setting a cog to :class:`~.ext.commands.HelpCommand` (:issue:`5154`)
-- |commands| Fix :attr:`Context.invoked_with <ext.commands.Context.invoked_with>` being improperly reassigned during a :meth:`~ext.commands.Context.reinvoke` (:issue:`6451`, :issue:`6462`)
-- |commands| Remove duplicates from :meth:`HelpCommand.get_bot_mapping <ext.commands.HelpCommand.get_bot_mapping>` (:issue:`6316`)
-- |commands| Properly handle positional-only parameters in bot command signatures (:issue:`6431`)
-- |commands| Group signatures now properly show up in :attr:`Command.signature <ext.commands.Command.signature>` (:issue:`6529`, :issue:`6530`)
+- |commands| Fix attribute errors when setting a cog to :class:`~.ext.commands.HelpCommand` (:dpyissue:`5154`)
+- |commands| Fix :attr:`Context.invoked_with <ext.commands.Context.invoked_with>` being improperly reassigned during a :meth:`~ext.commands.Context.reinvoke` (:dpyissue:`6451`, :dpyissue:`6462`)
+- |commands| Remove duplicates from :meth:`HelpCommand.get_bot_mapping <ext.commands.HelpCommand.get_bot_mapping>` (:dpyissue:`6316`)
+- |commands| Properly handle positional-only parameters in bot command signatures (:dpyissue:`6431`)
+- |commands| Group signatures now properly show up in :attr:`Command.signature <ext.commands.Command.signature>` (:dpyissue:`6529`, :dpyissue:`6530`)
 
 Miscellaneous
 ~~~~~~~~~~~~~~
 
 - User endpoints and all userbot related functionality has been deprecated and will be removed in the next major version of the library.
-- :class:`Permission` class methods were updated to match the UI of the Discord client (:issue:`6476`)
-- ``_`` and ``-`` characters are now stripped when making a new cog using the ``discord`` package (:issue:`6313`)
+- :class:`Permission` class methods were updated to match the UI of the Discord client (:dpyissue:`6476`)
+- ``_`` and ``-`` characters are now stripped when making a new cog using the ``discord`` package (:dpyissue:`6313`)
 
 .. _vp1p6p0:
 
@@ -149,10 +149,10 @@ New Features
 
 - An entirely redesigned documentation. This was the cumulation of multiple months of effort.
     - There's now a dark theme, feel free to navigate to the cog on the screen to change your setting, though this should be automatic.
-- Add support for :meth:`AppInfo.icon_url_as` and :meth:`AppInfo.cover_image_url_as` (:issue:`5888`)
-- Add :meth:`Colour.random` to get a random colour (:issue:`6067`)
-- Add support for stickers via :class:`Sticker` (:issue:`5946`)
-- Add support for replying via :meth:`Message.reply` (:issue:`6061`)
+- Add support for :meth:`AppInfo.icon_url_as` and :meth:`AppInfo.cover_image_url_as` (:dpyissue:`5888`)
+- Add :meth:`Colour.random` to get a random colour (:dpyissue:`6067`)
+- Add support for stickers via :class:`Sticker` (:dpyissue:`5946`)
+- Add support for replying via :meth:`Message.reply` (:dpyissue:`6061`)
     - This also comes with the :attr:`AllowedMentions.replied_user` setting.
     - :meth:`abc.Messageable.send` can now accept a :class:`MessageReference`.
     - :class:`MessageReference` can now be constructed by users.
@@ -167,47 +167,47 @@ New Features
     - :meth:`Role.is_integration` to check if a role is role created by an integration.
 - Add :meth:`Client.is_ws_ratelimited` to check if the websocket is rate limited.
     - :meth:`ShardInfo.is_ws_ratelimited` is the equivalent for checking a specific shard.
-- Add support for chunking an :class:`AsyncIterator` through :meth:`AsyncIterator.chunk` (:issue:`6100`, :issue:`6082`)
-- Add :attr:`PartialEmoji.created_at` (:issue:`6128`)
-- Add support for editing and deleting webhook sent messages (:issue:`6058`)
+- Add support for chunking an :class:`AsyncIterator` through :meth:`AsyncIterator.chunk` (:dpyissue:`6100`, :dpyissue:`6082`)
+- Add :attr:`PartialEmoji.created_at` (:dpyissue:`6128`)
+- Add support for editing and deleting webhook sent messages (:dpyissue:`6058`)
     - This adds :class:`WebhookMessage` as well to power this behaviour.
-- Add :class:`PartialMessage` to allow working with a message via channel objects and just a message_id (:issue:`5905`)
+- Add :class:`PartialMessage` to allow working with a message via channel objects and just a message_id (:dpyissue:`5905`)
     - This is useful if you don't want to incur an extra API call to fetch the message.
-- Add :meth:`Emoji.url_as` (:issue:`6162`)
+- Add :meth:`Emoji.url_as` (:dpyissue:`6162`)
 - Add support for :attr:`Member.pending` for the membership gating feature.
-- Allow ``colour`` parameter to take ``int`` in :meth:`Guild.create_role` (:issue:`6195`)
-- Add support for ``presences`` in :meth:`Guild.query_members` (:issue:`2354`)
-- |commands| Add support for ``description`` keyword argument in :class:`commands.Cog <ext.commands.Cog>` (:issue:`6028`)
+- Allow ``colour`` parameter to take ``int`` in :meth:`Guild.create_role` (:dpyissue:`6195`)
+- Add support for ``presences`` in :meth:`Guild.query_members` (:dpyissue:`2354`)
+- |commands| Add support for ``description`` keyword argument in :class:`commands.Cog <ext.commands.Cog>` (:dpyissue:`6028`)
 - |tasks| Add support for calling the wrapped coroutine as a function via ``__call__``.
 
 
 Bug Fixes
 ~~~~~~~~~~~
 
-- Raise :exc:`DiscordServerError` when reaching 503s repeatedly (:issue:`6044`)
-- Fix :exc:`AttributeError` when :meth:`Client.fetch_template` is called (:issue:`5986`)
-- Fix errors when playing audio and moving to another channel (:issue:`5953`)
-- Fix :exc:`AttributeError` when voice channels disconnect too fast (:issue:`6039`)
+- Raise :exc:`DiscordServerError` when reaching 503s repeatedly (:dpyissue:`6044`)
+- Fix :exc:`AttributeError` when :meth:`Client.fetch_template` is called (:dpyissue:`5986`)
+- Fix errors when playing audio and moving to another channel (:dpyissue:`5953`)
+- Fix :exc:`AttributeError` when voice channels disconnect too fast (:dpyissue:`6039`)
 - Fix stale :class:`User` references when the members intent is off.
 - Fix :func:`on_user_update` not dispatching in certain cases when a member is not cached but the user somehow is.
 - Fix :attr:`Message.author` being overwritten in certain cases during message update.
     - This would previously make it so :attr:`Message.author` is a :class:`User`.
-- Fix :exc:`UnboundLocalError` for editing ``public_updates_channel`` in :meth:`Guild.edit` (:issue:`6093`)
-- Fix uninitialised :attr:`CustomActivity.created_at` (:issue:`6095`)
-- |commands| Errors during cog unload no longer stops module cleanup (:issue:`6113`)
-- |commands| Properly cleanup lingering commands when a conflicting alias is found when adding commands (:issue:`6217`)
+- Fix :exc:`UnboundLocalError` for editing ``public_updates_channel`` in :meth:`Guild.edit` (:dpyissue:`6093`)
+- Fix uninitialised :attr:`CustomActivity.created_at` (:dpyissue:`6095`)
+- |commands| Errors during cog unload no longer stops module cleanup (:dpyissue:`6113`)
+- |commands| Properly cleanup lingering commands when a conflicting alias is found when adding commands (:dpyissue:`6217`)
 
 Miscellaneous
 ~~~~~~~~~~~~~~~
 
-- ``ffmpeg`` spawned processes no longer open a window in Windows (:issue:`6038`)
-- Update dependencies to allow the library to work on Python 3.9+ without requiring build tools. (:issue:`5984`, :issue:`5970`)
-- Fix docstring issue leading to a SyntaxError in 3.9 (:issue:`6153`)
-- Update Windows opus binaries from 1.2.1 to 1.3.1 (:issue:`6161`)
-- Allow :meth:`Guild.create_role` to accept :class:`int` as the ``colour`` parameter (:issue:`6195`)
-- |commands| :class:`MessageConverter <ext.commands.MessageConverter>` regex got updated to support ``www.`` prefixes (:issue:`6002`)
+- ``ffmpeg`` spawned processes no longer open a window in Windows (:dpyissue:`6038`)
+- Update dependencies to allow the library to work on Python 3.9+ without requiring build tools. (:dpyissue:`5984`, :dpyissue:`5970`)
+- Fix docstring issue leading to a SyntaxError in 3.9 (:dpyissue:`6153`)
+- Update Windows opus binaries from 1.2.1 to 1.3.1 (:dpyissue:`6161`)
+- Allow :meth:`Guild.create_role` to accept :class:`int` as the ``colour`` parameter (:dpyissue:`6195`)
+- |commands| :class:`MessageConverter <ext.commands.MessageConverter>` regex got updated to support ``www.`` prefixes (:dpyissue:`6002`)
 - |commands| :class:`UserConverter <ext.commands.UserConverter>` now fetches the API if an ID is passed and the user is not cached.
-- |commands| :func:`max_concurrency <ext.commands.max_concurrency>` is now called before cooldowns (:issue:`6172`)
+- |commands| :func:`max_concurrency <ext.commands.max_concurrency>` is now called before cooldowns (:dpyissue:`6172`)
 
 .. _vp1p5p1:
 
@@ -217,19 +217,19 @@ v1.5.1
 Bug Fixes
 ~~~~~~~~~~~
 
-- Fix :func:`utils.escape_markdown` not escaping quotes properly (:issue:`5897`)
-- Fix :class:`Message` not being hashable (:issue:`5901`, :issue:`5866`)
-- Fix moving channels to the end of the channel list (:issue:`5923`)
-- Fix seemingly strange behaviour in ``__eq__`` for :class:`PermissionOverwrite` (:issue:`5929`)
-- Fix aliases showing up in ``__iter__`` for :class:`Intents` (:issue:`5945`)
-- Fix the bot disconnecting from voice when moving them to another channel (:issue:`5904`)
+- Fix :func:`utils.escape_markdown` not escaping quotes properly (:dpyissue:`5897`)
+- Fix :class:`Message` not being hashable (:dpyissue:`5901`, :dpyissue:`5866`)
+- Fix moving channels to the end of the channel list (:dpyissue:`5923`)
+- Fix seemingly strange behaviour in ``__eq__`` for :class:`PermissionOverwrite` (:dpyissue:`5929`)
+- Fix aliases showing up in ``__iter__`` for :class:`Intents` (:dpyissue:`5945`)
+- Fix the bot disconnecting from voice when moving them to another channel (:dpyissue:`5904`)
 - Fix attribute errors when chunking times out sometimes during delayed on_ready dispatching.
-- Ensure that the bot's own member is not evicted from the cache (:issue:`5949`)
+- Ensure that the bot's own member is not evicted from the cache (:dpyissue:`5949`)
 
 Miscellaneous
 ~~~~~~~~~~~~~~
 
-- Members are now loaded during ``GUILD_MEMBER_UPDATE`` events if :attr:`MemberCacheFlags.joined` is set. (:issue:`5930`)
+- Members are now loaded during ``GUILD_MEMBER_UPDATE`` events if :attr:`MemberCacheFlags.joined` is set. (:dpyissue:`5930`)
 - |commands| :class:`MemberConverter <ext.commands.MemberConverter>` now properly lazily fetches members if not available from cache.
     - This is the same as having ``discord.Member`` as the type-hint.
 - :meth:`Guild.chunk` now allows concurrent calls without spamming the gateway with requests.
@@ -251,48 +251,48 @@ New Features
 ~~~~~~~~~~~~~~
 
 - Support for gateway intents, passed via ``intents`` in :class:`Client` using :class:`Intents`.
-- Add :attr:`VoiceRegion.south_korea` (:issue:`5233`)
-- Add support for ``__eq__`` for :class:`Message` (:issue:`5789`)
-- Add :meth:`Colour.dark_theme` factory method (:issue:`1584`)
-- Add :meth:`AllowedMentions.none` and :meth:`AllowedMentions.all` (:issue:`5785`)
-- Add more concrete exceptions for 500 class errors under :class:`DiscordServerError` (:issue:`5797`)
+- Add :attr:`VoiceRegion.south_korea` (:dpyissue:`5233`)
+- Add support for ``__eq__`` for :class:`Message` (:dpyissue:`5789`)
+- Add :meth:`Colour.dark_theme` factory method (:dpyissue:`1584`)
+- Add :meth:`AllowedMentions.none` and :meth:`AllowedMentions.all` (:dpyissue:`5785`)
+- Add more concrete exceptions for 500 class errors under :class:`DiscordServerError` (:dpyissue:`5797`)
 - Implement :class:`VoiceProtocol` to better intersect the voice flow.
 - Add :meth:`Guild.chunk` to fully chunk a guild.
 - Add :class:`MemberCacheFlags` to better control member cache. See :ref:`intents_member_cache` for more info.
-- Add support for :attr:`ActivityType.competing` (:issue:`5823`)
+- Add support for :attr:`ActivityType.competing` (:dpyissue:`5823`)
     - This seems currently unused API wise.
 
-- Add support for message references, :attr:`Message.reference` (:issue:`5754`, :issue:`5832`)
-- Add alias for :class:`ColourConverter` under ``ColorConverter`` (:issue:`5773`)
-- Add alias for :attr:`PublicUserFlags.verified_bot_developer` under :attr:`PublicUserFlags.early_verified_bot_developer` (:issue:`5849`)
-- |commands| Add support for ``require_var_positional`` for :class:`Command` (:issue:`5793`)
+- Add support for message references, :attr:`Message.reference` (:dpyissue:`5754`, :dpyissue:`5832`)
+- Add alias for :class:`ColourConverter` under ``ColorConverter`` (:dpyissue:`5773`)
+- Add alias for :attr:`PublicUserFlags.verified_bot_developer` under :attr:`PublicUserFlags.early_verified_bot_developer` (:dpyissue:`5849`)
+- |commands| Add support for ``require_var_positional`` for :class:`Command` (:dpyissue:`5793`)
 
 Bug Fixes
 ~~~~~~~~~~
 
 - Fix issue with :meth:`Guild.by_category` not showing certain channels.
-- Fix :attr:`abc.GuildChannel.permissions_synced` always being ``False`` (:issue:`5772`)
-- Fix handling of cloudflare bans on webhook related requests (:issue:`5221`)
-- Fix cases where a keep-alive thread would ack despite already dying (:issue:`5800`)
-- Fix cases where a :class:`Member` reference would be stale when cache is disabled in message events (:issue:`5819`)
-- Fix ``allowed_mentions`` not being sent when sending a single file (:issue:`5835`)
-- Fix ``overwrites`` being ignored in :meth:`abc.GuildChannel.edit` if ``{}`` is passed (:issue:`5756`, :issue:`5757`)
-- |commands| Fix exceptions being raised improperly in command invoke hooks (:issue:`5799`)
-- |commands| Fix commands not being properly ejected during errors in a cog injection (:issue:`5804`)
+- Fix :attr:`abc.GuildChannel.permissions_synced` always being ``False`` (:dpyissue:`5772`)
+- Fix handling of cloudflare bans on webhook related requests (:dpyissue:`5221`)
+- Fix cases where a keep-alive thread would ack despite already dying (:dpyissue:`5800`)
+- Fix cases where a :class:`Member` reference would be stale when cache is disabled in message events (:dpyissue:`5819`)
+- Fix ``allowed_mentions`` not being sent when sending a single file (:dpyissue:`5835`)
+- Fix ``overwrites`` being ignored in :meth:`abc.GuildChannel.edit` if ``{}`` is passed (:dpyissue:`5756`, :dpyissue:`5757`)
+- |commands| Fix exceptions being raised improperly in command invoke hooks (:dpyissue:`5799`)
+- |commands| Fix commands not being properly ejected during errors in a cog injection (:dpyissue:`5804`)
 - |commands| Fix cooldown timing ignoring edited timestamps.
-- |tasks| Fix tasks extending the next iteration on handled exceptions (:issue:`5762`, :issue:`5763`)
+- |tasks| Fix tasks extending the next iteration on handled exceptions (:dpyissue:`5762`, :dpyissue:`5763`)
 
 Miscellaneous
 ~~~~~~~~~~~~~~~
 
-- Webhook requests are now logged (:issue:`5798`)
+- Webhook requests are now logged (:dpyissue:`5798`)
 - Remove caching layer from :attr:`AutoShardedClient.shards`. This was causing issues if queried before launching shards.
 - Gateway rate limits are now handled.
 - Warnings logged due to missed caches are now changed to DEBUG log level.
 - Some strings are now explicitly interned to reduce memory usage.
-- Usage of namedtuples has been reduced to avoid potential breaking changes in the future (:issue:`5834`)
-- |commands| All :class:`BadArgument` exceptions from the built-in converters now raise concrete exceptions to better tell them apart (:issue:`5748`)
-- |tasks| Lazily fetch the event loop to prevent surprises when changing event loop policy (:issue:`5808`)
+- Usage of namedtuples has been reduced to avoid potential breaking changes in the future (:dpyissue:`5834`)
+- |commands| All :class:`BadArgument` exceptions from the built-in converters now raise concrete exceptions to better tell them apart (:dpyissue:`5748`)
+- |tasks| Lazily fetch the event loop to prevent surprises when changing event loop policy (:dpyissue:`5808`)
 
 .. _vp1p4p2:
 
@@ -305,22 +305,22 @@ Bug Fixes
 ~~~~~~~~~~~
 
 - Fix issue with :meth:`Guild.by_category` not showing certain channels.
-- Fix :attr:`abc.GuildChannel.permissions_synced` always being ``False`` (:issue:`5772`)
-- Fix handling of cloudflare bans on webhook related requests (:issue:`5221`)
-- Fix cases where a keep-alive thread would ack despite already dying (:issue:`5800`)
-- Fix cases where a :class:`Member` reference would be stale when cache is disabled in message events (:issue:`5819`)
-- Fix ``allowed_mentions`` not being sent when sending a single file (:issue:`5835`)
-- Fix ``overwrites`` being ignored in :meth:`abc.GuildChannel.edit` if ``{}`` is passed (:issue:`5756`, :issue:`5757`)
-- |commands| Fix exceptions being raised improperly in command invoke hooks (:issue:`5799`)
-- |commands| Fix commands not being properly ejected during errors in a cog injection (:issue:`5804`)
+- Fix :attr:`abc.GuildChannel.permissions_synced` always being ``False`` (:dpyissue:`5772`)
+- Fix handling of cloudflare bans on webhook related requests (:dpyissue:`5221`)
+- Fix cases where a keep-alive thread would ack despite already dying (:dpyissue:`5800`)
+- Fix cases where a :class:`Member` reference would be stale when cache is disabled in message events (:dpyissue:`5819`)
+- Fix ``allowed_mentions`` not being sent when sending a single file (:dpyissue:`5835`)
+- Fix ``overwrites`` being ignored in :meth:`abc.GuildChannel.edit` if ``{}`` is passed (:dpyissue:`5756`, :dpyissue:`5757`)
+- |commands| Fix exceptions being raised improperly in command invoke hooks (:dpyissue:`5799`)
+- |commands| Fix commands not being properly ejected during errors in a cog injection (:dpyissue:`5804`)
 - |commands| Fix cooldown timing ignoring edited timestamps.
-- |tasks| Fix tasks extending the next iteration on handled exceptions (:issue:`5762`, :issue:`5763`)
+- |tasks| Fix tasks extending the next iteration on handled exceptions (:dpyissue:`5762`, :dpyissue:`5763`)
 
 Miscellaneous
 ~~~~~~~~~~~~~~~
 
 - Remove caching layer from :attr:`AutoShardedClient.shards`. This was causing issues if queried before launching shards.
-- |tasks| Lazily fetch the event loop to prevent surprises when changing event loop policy (:issue:`5808`)
+- |tasks| Lazily fetch the event loop to prevent surprises when changing event loop policy (:dpyissue:`5808`)
 
 .. _vp1p4p1:
 
@@ -330,9 +330,9 @@ v1.4.1
 Bug Fixes
 ~~~~~~~~~~~
 
-- Properly terminate the connection when :meth:`Client.close` is called (:issue:`5207`)
-- Fix error being raised when clearing embed author or image when it was already cleared (:issue:`5210`, :issue:`5212`)
-- Fix ``__path__`` to allow editable extensions (:issue:`5213`)
+- Properly terminate the connection when :meth:`Client.close` is called (:dpyissue:`5207`)
+- Fix error being raised when clearing embed author or image when it was already cleared (:dpyissue:`5210`, :dpyissue:`5212`)
+- Fix ``__path__`` to allow editable extensions (:dpyissue:`5213`)
 
 .. _vp1p4p0:
 
@@ -348,7 +348,7 @@ New Features
     - This can be set globally through :attr:`Client.allowed_mentions`
     - This can also be set on a per message basis via :meth:`abc.Messageable.send`
 
-- :class:`AutoShardedClient` has been completely redesigned from the ground up to better suit multi-process clusters (:issue:`2654`)
+- :class:`AutoShardedClient` has been completely redesigned from the ground up to better suit multi-process clusters (:dpyissue:`2654`)
     - Add :class:`ShardInfo` which allows fetching specific information about a shard.
     - The :class:`ShardInfo` allows for reconnecting and disconnecting of a specific shard as well.
     - Add :meth:`AutoShardedClient.get_shard` and :attr:`AutoShardedClient.shards` to get information about shards.
@@ -356,13 +356,13 @@ New Features
     - Add a hook :meth:`Client.before_identify_hook` to have better control over what happens before an ``IDENTIFY`` is done.
     - Add more shard related events such as :func:`on_shard_connect`, :func:`on_shard_disconnect` and :func:`on_shard_resumed`.
 
-- Add support for guild templates (:issue:`2652`)
+- Add support for guild templates (:dpyissue:`2652`)
     - This adds :class:`Template` to read a template's information.
     - :meth:`Client.fetch_template` can be used to fetch a template's information from the API.
     - :meth:`Client.create_guild` can now take an optional template to base the creation from.
     - Note that fetching a guild's template is currently restricted for bot accounts.
 
-- Add support for guild integrations (:issue:`2051`, :issue:`1083`)
+- Add support for guild integrations (:dpyissue:`2051`, :dpyissue:`1083`)
     - :class:`Integration` is used to read integration information.
     - :class:`IntegrationAccount` is used to read integration account information.
     - :meth:`Guild.integrations` will fetch all integrations in a guild.
@@ -372,66 +372,66 @@ New Features
     - :meth:`Integration.sync` will sync an integration.
     - There is currently no support in the audit log for this.
 
-- Add an alias for :attr:`VerificationLevel.extreme` under :attr:`VerificationLevel.very_high` (:issue:`2650`)
-- Add various grey to gray aliases for :class:`Colour` (:issue:`5130`)
-- Added :attr:`VoiceClient.latency` and :attr:`VoiceClient.average_latency` (:issue:`2535`)
-- Add ``use_cached`` and ``spoiler`` parameters to :meth:`Attachment.to_file` (:issue:`2577`, :issue:`4095`)
-- Add ``position`` parameter support to :meth:`Guild.create_category` (:issue:`2623`)
-- Allow passing ``int`` for the colour in :meth:`Role.edit` (:issue:`4057`)
-- Add :meth:`Embed.remove_author` to clear author information from an embed (:issue:`4068`)
-- Add the ability to clear images and thumbnails in embeds using :attr:`Embed.Empty` (:issue:`4053`)
-- Add :attr:`Guild.max_video_channel_users` (:issue:`4120`)
-- Add :attr:`Guild.public_updates_channel` (:issue:`4120`)
-- Add ``guild_ready_timeout`` parameter to :class:`Client` and subclasses to control timeouts when the ``GUILD_CREATE`` stream takes too long (:issue:`4112`)
-- Add support for public user flags via :attr:`User.public_flags` and :class:`PublicUserFlags` (:issue:`3999`)
-- Allow changing of channel types via :meth:`TextChannel.edit` to and from a news channel (:issue:`4121`)
-- Add :meth:`Guild.edit_role_positions` to bulk edit role positions in a single API call (:issue:`2501`, :issue:`2143`)
-- Add :meth:`Guild.change_voice_state` to change your voice state in a guild (:issue:`5088`)
-- Add :meth:`PartialInviteGuild.is_icon_animated` for checking if the invite guild has animated icon (:issue:`4180`, :issue:`4181`)
-- Add :meth:`PartialInviteGuild.icon_url_as` now supports ``static_format`` for consistency (:issue:`4180`, :issue:`4181`)
+- Add an alias for :attr:`VerificationLevel.extreme` under :attr:`VerificationLevel.very_high` (:dpyissue:`2650`)
+- Add various grey to gray aliases for :class:`Colour` (:dpyissue:`5130`)
+- Added :attr:`VoiceClient.latency` and :attr:`VoiceClient.average_latency` (:dpyissue:`2535`)
+- Add ``use_cached`` and ``spoiler`` parameters to :meth:`Attachment.to_file` (:dpyissue:`2577`, :dpyissue:`4095`)
+- Add ``position`` parameter support to :meth:`Guild.create_category` (:dpyissue:`2623`)
+- Allow passing ``int`` for the colour in :meth:`Role.edit` (:dpyissue:`4057`)
+- Add :meth:`Embed.remove_author` to clear author information from an embed (:dpyissue:`4068`)
+- Add the ability to clear images and thumbnails in embeds using :attr:`Embed.Empty` (:dpyissue:`4053`)
+- Add :attr:`Guild.max_video_channel_users` (:dpyissue:`4120`)
+- Add :attr:`Guild.public_updates_channel` (:dpyissue:`4120`)
+- Add ``guild_ready_timeout`` parameter to :class:`Client` and subclasses to control timeouts when the ``GUILD_CREATE`` stream takes too long (:dpyissue:`4112`)
+- Add support for public user flags via :attr:`User.public_flags` and :class:`PublicUserFlags` (:dpyissue:`3999`)
+- Allow changing of channel types via :meth:`TextChannel.edit` to and from a news channel (:dpyissue:`4121`)
+- Add :meth:`Guild.edit_role_positions` to bulk edit role positions in a single API call (:dpyissue:`2501`, :dpyissue:`2143`)
+- Add :meth:`Guild.change_voice_state` to change your voice state in a guild (:dpyissue:`5088`)
+- Add :meth:`PartialInviteGuild.is_icon_animated` for checking if the invite guild has animated icon (:dpyissue:`4180`, :dpyissue:`4181`)
+- Add :meth:`PartialInviteGuild.icon_url_as` now supports ``static_format`` for consistency (:dpyissue:`4180`, :dpyissue:`4181`)
 - Add support for ``user_ids`` in :meth:`Guild.query_members`
-- Add support for pruning members by roles in :meth:`Guild.prune_members` (:issue:`4043`)
-- |commands| Implement :func:`~ext.commands.before_invoke` and :func:`~ext.commands.after_invoke` decorators (:issue:`1986`, :issue:`2502`)
-- |commands| Add a way to retrieve ``retry_after`` from a cooldown in a command via :meth:`Command.get_cooldown_retry_after <.ext.commands.Command.get_cooldown_retry_after>` (:issue:`5195`)
-- |commands| Add a way to dynamically add and remove checks from a :class:`HelpCommand <.ext.commands.HelpCommand>` (:issue:`5197`)
-- |tasks| Add :meth:`Loop.is_running <.ext.tasks.Loop.is_running>` method to the task objects (:issue:`2540`)
-- |tasks| Allow usage of custom error handlers similar to the command extensions to tasks using :meth:`Loop.error <.ext.tasks.Loop.error>` decorator (:issue:`2621`)
+- Add support for pruning members by roles in :meth:`Guild.prune_members` (:dpyissue:`4043`)
+- |commands| Implement :func:`~ext.commands.before_invoke` and :func:`~ext.commands.after_invoke` decorators (:dpyissue:`1986`, :dpyissue:`2502`)
+- |commands| Add a way to retrieve ``retry_after`` from a cooldown in a command via :meth:`Command.get_cooldown_retry_after <.ext.commands.Command.get_cooldown_retry_after>` (:dpyissue:`5195`)
+- |commands| Add a way to dynamically add and remove checks from a :class:`HelpCommand <.ext.commands.HelpCommand>` (:dpyissue:`5197`)
+- |tasks| Add :meth:`Loop.is_running <.ext.tasks.Loop.is_running>` method to the task objects (:dpyissue:`2540`)
+- |tasks| Allow usage of custom error handlers similar to the command extensions to tasks using :meth:`Loop.error <.ext.tasks.Loop.error>` decorator (:dpyissue:`2621`)
 
 
 Bug Fixes
 ~~~~~~~~~~~~
 
-- Fix issue with :attr:`PartialEmoji.url` reads leading to a failure (:issue:`4015`, :issue:`4016`)
-- Allow :meth:`abc.Messageable.history` to take a limit of ``1`` even if ``around`` is passed (:issue:`4019`)
-- Fix :attr:`Guild.member_count` not updating in certain cases when a member has left the guild (:issue:`4021`)
-- Fix the type of :attr:`Object.id` not being validated. For backwards compatibility ``str`` is still allowed but is converted to ``int`` (:issue:`4002`)
-- Fix :meth:`Guild.edit` not allowing editing of notification settings (:issue:`4074`, :issue:`4047`)
-- Fix crash when the guild widget contains channels that aren't in the payload (:issue:`4114`, :issue:`4115`)
-- Close ffmpeg stdin handling from spawned processes with :class:`FFmpegOpusAudio` and :class:`FFmpegPCMAudio` (:issue:`4036`)
-- Fix :func:`utils.escape_markdown` not escaping masked links (:issue:`4206`, :issue:`4207`)
-- Fix reconnect loop due to failed handshake on region change (:issue:`4210`, :issue:`3996`)
-- Fix :meth:`Guild.by_category` not returning empty categories (:issue:`4186`)
-- Fix certain JPEG images not being identified as JPEG (:issue:`5143`)
-- Fix a crash when an incomplete guild object is used when fetching reaction information (:issue:`5181`)
+- Fix issue with :attr:`PartialEmoji.url` reads leading to a failure (:dpyissue:`4015`, :dpyissue:`4016`)
+- Allow :meth:`abc.Messageable.history` to take a limit of ``1`` even if ``around`` is passed (:dpyissue:`4019`)
+- Fix :attr:`Guild.member_count` not updating in certain cases when a member has left the guild (:dpyissue:`4021`)
+- Fix the type of :attr:`Object.id` not being validated. For backwards compatibility ``str`` is still allowed but is converted to ``int`` (:dpyissue:`4002`)
+- Fix :meth:`Guild.edit` not allowing editing of notification settings (:dpyissue:`4074`, :dpyissue:`4047`)
+- Fix crash when the guild widget contains channels that aren't in the payload (:dpyissue:`4114`, :dpyissue:`4115`)
+- Close ffmpeg stdin handling from spawned processes with :class:`FFmpegOpusAudio` and :class:`FFmpegPCMAudio` (:dpyissue:`4036`)
+- Fix :func:`utils.escape_markdown` not escaping masked links (:dpyissue:`4206`, :dpyissue:`4207`)
+- Fix reconnect loop due to failed handshake on region change (:dpyissue:`4210`, :dpyissue:`3996`)
+- Fix :meth:`Guild.by_category` not returning empty categories (:dpyissue:`4186`)
+- Fix certain JPEG images not being identified as JPEG (:dpyissue:`5143`)
+- Fix a crash when an incomplete guild object is used when fetching reaction information (:dpyissue:`5181`)
 - Fix a timeout issue when fetching members using :meth:`Guild.query_members`
-- Fix an issue with domain resolution in voice (:issue:`5188`, :issue:`5191`)
-- Fix an issue where :attr:`PartialEmoji.id` could be a string (:issue:`4153`, :issue:`4152`)
+- Fix an issue with domain resolution in voice (:dpyissue:`5188`, :dpyissue:`5191`)
+- Fix an issue where :attr:`PartialEmoji.id` could be a string (:dpyissue:`4153`, :dpyissue:`4152`)
 - Fix regression where :attr:`Member.activities` would not clear.
-- |commands| A :exc:`TypeError` is now raised when :obj:`typing.Optional` is used within :data:`commands.Greedy <.ext.commands.Greedy>` (:issue:`2253`, :issue:`5068`)
-- |commands| :meth:`Bot.walk_commands <.ext.commands.Bot.walk_commands>` no longer yields duplicate commands due to aliases (:issue:`2591`)
-- |commands| Fix regex characters not being escaped in :attr:`HelpCommand.clean_prefix <.ext.commands.HelpCommand.clean_prefix>` (:issue:`4058`, :issue:`4071`)
-- |commands| Fix :meth:`Bot.get_command <.ext.commands.Bot.get_command>` from raising errors when a name only has whitespace (:issue:`5124`)
-- |commands| Fix issue with :attr:`Context.subcommand_passed <.ext.commands.Context.subcommand_passed>` not functioning as expected (:issue:`5198`)
-- |tasks| Task objects are no longer stored globally so two class instances can now start two separate tasks (:issue:`2294`)
-- |tasks| Allow cancelling the loop within :meth:`before_loop <.ext.tasks.Loop.before_loop>` (:issue:`4082`)
+- |commands| A :exc:`TypeError` is now raised when :obj:`typing.Optional` is used within :data:`commands.Greedy <.ext.commands.Greedy>` (:dpyissue:`2253`, :dpyissue:`5068`)
+- |commands| :meth:`Bot.walk_commands <.ext.commands.Bot.walk_commands>` no longer yields duplicate commands due to aliases (:dpyissue:`2591`)
+- |commands| Fix regex characters not being escaped in :attr:`HelpCommand.clean_prefix <.ext.commands.HelpCommand.clean_prefix>` (:dpyissue:`4058`, :dpyissue:`4071`)
+- |commands| Fix :meth:`Bot.get_command <.ext.commands.Bot.get_command>` from raising errors when a name only has whitespace (:dpyissue:`5124`)
+- |commands| Fix issue with :attr:`Context.subcommand_passed <.ext.commands.Context.subcommand_passed>` not functioning as expected (:dpyissue:`5198`)
+- |tasks| Task objects are no longer stored globally so two class instances can now start two separate tasks (:dpyissue:`2294`)
+- |tasks| Allow cancelling the loop within :meth:`before_loop <.ext.tasks.Loop.before_loop>` (:dpyissue:`4082`)
 
 
 Miscellaneous
 ~~~~~~~~~~~~~~~
 
-- The :attr:`Member.roles` cache introduced in v1.3 was reverted due to issues caused (:issue:`4087`, :issue:`4157`)
-- :class:`Webhook` objects are now comparable and hashable (:issue:`4182`)
-- Some more API requests got a ``reason`` parameter for audit logs (:issue:`5086`)
+- The :attr:`Member.roles` cache introduced in v1.3 was reverted due to issues caused (:dpyissue:`4087`, :dpyissue:`4157`)
+- :class:`Webhook` objects are now comparable and hashable (:dpyissue:`4182`)
+- Some more API requests got a ``reason`` parameter for audit logs (:dpyissue:`5086`)
     - :meth:`TextChannel.follow`
     - :meth:`Message.pin` and :meth:`Message.unpin`
     - :meth:`Webhook.delete` and :meth:`Webhook.edit`
@@ -439,10 +439,10 @@ Miscellaneous
 - For performance reasons ``websockets`` has been dropped in favour of ``aiohttp.ws``.
 - The blocking logging message now shows the stack trace of where the main thread was blocking
 - The domain name was changed from ``discordapp.com`` to ``discord.com`` to prepare for the required domain migration
-- Reduce memory usage when reconnecting due to stale references being held by the message cache (:issue:`5133`)
+- Reduce memory usage when reconnecting due to stale references being held by the message cache (:dpyissue:`5133`)
 - Optimize :meth:`abc.GuildChannel.permissions_for` by not creating as many temporary objects (20-32% savings).
-- |commands| Raise :exc:`~ext.commands.CommandRegistrationError` instead of :exc:`ClientException` when a duplicate error is registered (:issue:`4217`)
-- |tasks| No longer handle :exc:`HTTPException` by default in the task reconnect loop (:issue:`5193`)
+- |commands| Raise :exc:`~ext.commands.CommandRegistrationError` instead of :exc:`ClientException` when a duplicate error is registered (:dpyissue:`4217`)
+- |tasks| No longer handle :exc:`HTTPException` by default in the task reconnect loop (:dpyissue:`5193`)
 
 .. _vp1p3p4:
 
@@ -452,7 +452,7 @@ v1.3.4
 Bug Fixes
 ~~~~~~~~~~~
 
-- Fix an issue with channel overwrites causing multiple issues including crashes (:issue:`5109`)
+- Fix an issue with channel overwrites causing multiple issues including crashes (:dpyissue:`5109`)
 
 .. _vp1p3p3:
 
@@ -465,7 +465,7 @@ Bug Fixes
 - Change default WS close to 4000 instead of 1000.
     - The previous close code caused sessions to be invalidated at a higher frequency than desired.
 
-- Fix ``None`` appearing in ``Member.activities``. (:issue:`2619`)
+- Fix ``None`` appearing in ``Member.activities``. (:dpyissue:`2619`)
 
 .. _vp1p3p2:
 
@@ -479,10 +479,10 @@ Bug Fixes
 
 - Higher the wait time during the ``GUILD_CREATE`` stream before ``on_ready`` is fired for :class:`AutoShardedClient`.
 - :func:`on_voice_state_update` now uses the inner ``member`` payload which should make it more reliable.
-- Fix various Cloudflare handling errors (:issue:`2572`, :issue:`2544`)
+- Fix various Cloudflare handling errors (:dpyissue:`2572`, :dpyissue:`2544`)
 - Fix crashes if :attr:`Message.guild` is :class:`Object` instead of :class:`Guild`.
 - Fix :meth:`Webhook.send` returning an empty string instead of ``None`` when ``wait=False``.
-- Fix invalid format specifier in webhook state (:issue:`2570`)
+- Fix invalid format specifier in webhook state (:dpyissue:`2570`)
 - |commands| Passing invalid permissions to permission related checks now raises ``TypeError``.
 
 .. _vp1p3p1:
@@ -496,7 +496,7 @@ Bug Fixes
 ~~~~~~~~~~~
 
 - Fix fetching invites in guilds that the user is not in.
-- Fix the channel returned from :meth:`Client.fetch_channel` raising when sending messages. (:issue:`2531`)
+- Fix the channel returned from :meth:`Client.fetch_channel` raising when sending messages. (:dpyissue:`2531`)
 
 Miscellaneous
 ~~~~~~~~~~~~~~
@@ -514,48 +514,48 @@ This version comes with a lot of bug fixes and new features. It's been in develo
 New Features
 ~~~~~~~~~~~~~~
 
-- Add :meth:`Guild.fetch_members` to fetch members from the HTTP API. (:issue:`2204`)
-- Add :meth:`Guild.fetch_roles` to fetch roles from the HTTP API. (:issue:`2208`)
-- Add support for teams via :class:`Team` when fetching with :meth:`Client.application_info`. (:issue:`2239`)
+- Add :meth:`Guild.fetch_members` to fetch members from the HTTP API. (:dpyissue:`2204`)
+- Add :meth:`Guild.fetch_roles` to fetch roles from the HTTP API. (:dpyissue:`2208`)
+- Add support for teams via :class:`Team` when fetching with :meth:`Client.application_info`. (:dpyissue:`2239`)
 - Add support for suppressing embeds via :meth:`Message.edit`
 - Add support for guild subscriptions. See the :class:`Client` documentation for more details.
 - Add :attr:`VoiceChannel.voice_states` to get voice states without relying on member cache.
 - Add :meth:`Guild.query_members` to request members from the gateway.
-- Add :class:`FFmpegOpusAudio` and other voice improvements. (:issue:`2258`)
-- Add :attr:`RawMessageUpdateEvent.channel_id` for retrieving channel IDs during raw message updates. (:issue:`2301`)
+- Add :class:`FFmpegOpusAudio` and other voice improvements. (:dpyissue:`2258`)
+- Add :attr:`RawMessageUpdateEvent.channel_id` for retrieving channel IDs during raw message updates. (:dpyissue:`2301`)
 - Add :attr:`RawReactionActionEvent.event_type` to disambiguate between reaction addition and removal in reaction events.
-- Add :attr:`abc.GuildChannel.permissions_synced` to query whether permissions are synced with the category. (:issue:`2300`, :issue:`2324`)
-- Add :attr:`MessageType.channel_follow_add` message type for announcement channels being followed. (:issue:`2314`)
+- Add :attr:`abc.GuildChannel.permissions_synced` to query whether permissions are synced with the category. (:dpyissue:`2300`, :dpyissue:`2324`)
+- Add :attr:`MessageType.channel_follow_add` message type for announcement channels being followed. (:dpyissue:`2314`)
 - Add :meth:`Message.is_system` to allow for quickly filtering through system messages.
-- Add :attr:`VoiceState.self_stream` to indicate whether someone is streaming via Go Live. (:issue:`2343`)
-- Add :meth:`Emoji.is_usable` to check if the client user can use an emoji. (:issue:`2349`)
-- Add :attr:`VoiceRegion.europe` and :attr:`VoiceRegion.dubai`. (:issue:`2358`, :issue:`2490`)
-- Add :meth:`TextChannel.follow` to follow a news channel. (:issue:`2367`)
-- Add :attr:`Permissions.view_guild_insights` permission. (:issue:`2415`)
-- Add support for new audit log types. See :ref:`discord-api-audit-logs` for more information. (:issue:`2427`)
+- Add :attr:`VoiceState.self_stream` to indicate whether someone is streaming via Go Live. (:dpyissue:`2343`)
+- Add :meth:`Emoji.is_usable` to check if the client user can use an emoji. (:dpyissue:`2349`)
+- Add :attr:`VoiceRegion.europe` and :attr:`VoiceRegion.dubai`. (:dpyissue:`2358`, :dpyissue:`2490`)
+- Add :meth:`TextChannel.follow` to follow a news channel. (:dpyissue:`2367`)
+- Add :attr:`Permissions.view_guild_insights` permission. (:dpyissue:`2415`)
+- Add support for new audit log types. See :ref:`discord-api-audit-logs` for more information. (:dpyissue:`2427`)
     - Note that integration support is not finalized.
 
-- Add :attr:`Webhook.type` to query the type of webhook (:class:`WebhookType`). (:issue:`2441`)
-- Allow bulk editing of channel overwrites through :meth:`abc.GuildChannel.edit`. (:issue:`2198`)
-- Add :class:`Activity.created_at` to see when an activity was started. (:issue:`2446`)
-- Add support for ``xsalsa20_poly1305_lite`` encryption mode for voice. (:issue:`2463`)
-- Add :attr:`RawReactionActionEvent.member` to get the member who did the reaction. (:issue:`2443`)
-- Add support for new YouTube streaming via :attr:`Streaming.platform` and :attr:`Streaming.game`. (:issue:`2445`)
-- Add :attr:`Guild.discovery_splash_url` to get the discovery splash image asset. (:issue:`2482`)
-- Add :attr:`Guild.rules_channel` to get the rules channel of public guilds. (:issue:`2482`)
+- Add :attr:`Webhook.type` to query the type of webhook (:class:`WebhookType`). (:dpyissue:`2441`)
+- Allow bulk editing of channel overwrites through :meth:`abc.GuildChannel.edit`. (:dpyissue:`2198`)
+- Add :class:`Activity.created_at` to see when an activity was started. (:dpyissue:`2446`)
+- Add support for ``xsalsa20_poly1305_lite`` encryption mode for voice. (:dpyissue:`2463`)
+- Add :attr:`RawReactionActionEvent.member` to get the member who did the reaction. (:dpyissue:`2443`)
+- Add support for new YouTube streaming via :attr:`Streaming.platform` and :attr:`Streaming.game`. (:dpyissue:`2445`)
+- Add :attr:`Guild.discovery_splash_url` to get the discovery splash image asset. (:dpyissue:`2482`)
+- Add :attr:`Guild.rules_channel` to get the rules channel of public guilds. (:dpyissue:`2482`)
     - It should be noted that this feature is restricted to those who are either in Server Discovery or planning to be there.
 
-- Add support for message flags via :attr:`Message.flags` and :class:`MessageFlags`. (:issue:`2433`)
+- Add support for message flags via :attr:`Message.flags` and :class:`MessageFlags`. (:dpyissue:`2433`)
 - Add :attr:`User.system` and :attr:`Profile.system` to know whether a user is an official Discord Trust and Safety account.
 - Add :attr:`Profile.team_user` to check whether a user is a member of a team.
 - Add :meth:`Attachment.to_file` to easily convert attachments to :class:`File` for sending.
-- Add certain aliases to :class:`Permissions` to match the UI better. (:issue:`2496`)
+- Add certain aliases to :class:`Permissions` to match the UI better. (:dpyissue:`2496`)
     - :attr:`Permissions.manage_permissions`
     - :attr:`Permissions.view_channel`
     - :attr:`Permissions.use_external_emojis`
 
 - Add support for passing keyword arguments when creating :class:`Permissions`.
-- Add support for custom activities via :class:`CustomActivity`. (:issue:`2400`)
+- Add support for custom activities via :class:`CustomActivity`. (:dpyissue:`2400`)
     - Note that as of now, bots cannot send custom activities yet.
 
 - Add support for :func:`on_invite_create` and :func:`on_invite_delete` events.
@@ -563,49 +563,49 @@ New Features
     - :meth:`Message.clear_reaction` and :meth:`Reaction.clear` methods.
     - :func:`on_raw_reaction_clear_emoji` and :func:`on_reaction_clear_emoji` events.
 
-- Add :func:`utils.sleep_until` helper to sleep until a specific datetime. (:issue:`2517`, :issue:`2519`)
-- |commands| Add support for teams and :attr:`Bot.owner_ids <.ext.commands.Bot.owner_ids>` to have multiple bot owners. (:issue:`2239`)
-- |commands| Add new :attr:`BucketType.role <.ext.commands.BucketType.role>` bucket type. (:issue:`2201`)
-- |commands| Expose :attr:`Command.cog <.ext.commands.Command.cog>` property publicly. (:issue:`2360`)
-- |commands| Add non-decorator interface for adding checks to commands via :meth:`Command.add_check <.ext.commands.Command.add_check>` and :meth:`Command.remove_check <.ext.commands.Command.remove_check>`. (:issue:`2411`)
-- |commands| Add :func:`has_guild_permissions <.ext.commands.has_guild_permissions>` check. (:issue:`2460`)
-- |commands| Add :func:`bot_has_guild_permissions <.ext.commands.bot_has_guild_permissions>` check. (:issue:`2460`)
+- Add :func:`utils.sleep_until` helper to sleep until a specific datetime. (:dpyissue:`2517`, :dpyissue:`2519`)
+- |commands| Add support for teams and :attr:`Bot.owner_ids <.ext.commands.Bot.owner_ids>` to have multiple bot owners. (:dpyissue:`2239`)
+- |commands| Add new :attr:`BucketType.role <.ext.commands.BucketType.role>` bucket type. (:dpyissue:`2201`)
+- |commands| Expose :attr:`Command.cog <.ext.commands.Command.cog>` property publicly. (:dpyissue:`2360`)
+- |commands| Add non-decorator interface for adding checks to commands via :meth:`Command.add_check <.ext.commands.Command.add_check>` and :meth:`Command.remove_check <.ext.commands.Command.remove_check>`. (:dpyissue:`2411`)
+- |commands| Add :func:`has_guild_permissions <.ext.commands.has_guild_permissions>` check. (:dpyissue:`2460`)
+- |commands| Add :func:`bot_has_guild_permissions <.ext.commands.bot_has_guild_permissions>` check. (:dpyissue:`2460`)
 - |commands| Add ``predicate`` attribute to checks decorated with :func:`~.ext.commands.check`.
 - |commands| Add :func:`~.ext.commands.check_any` check to logical OR multiple checks.
 - |commands| Add :func:`~.ext.commands.max_concurrency` to allow only a certain amount of users to use a command concurrently before waiting or erroring.
 - |commands| Add support for calling a :class:`~.ext.commands.Command` as a regular function.
-- |tasks| :meth:`Loop.add_exception_type <.ext.tasks.Loop.add_exception_type>` now allows multiple exceptions to be set. (:issue:`2333`)
-- |tasks| Add :attr:`Loop.next_iteration <.ext.tasks.Loop.next_iteration>` property. (:issue:`2305`)
+- |tasks| :meth:`Loop.add_exception_type <.ext.tasks.Loop.add_exception_type>` now allows multiple exceptions to be set. (:dpyissue:`2333`)
+- |tasks| Add :attr:`Loop.next_iteration <.ext.tasks.Loop.next_iteration>` property. (:dpyissue:`2305`)
 
 Bug Fixes
 ~~~~~~~~~~
 
 - Fix issue with permission resolution sometimes failing for guilds with no owner.
-- Tokens are now stripped upon use. (:issue:`2135`)
-- Passing in a ``name`` is no longer required for :meth:`Emoji.edit`. (:issue:`2368`)
-- Fix issue with webhooks not re-raising after retries have run out. (:issue:`2272`, :issue:`2380`)
-- Fix mismatch in URL handling in :func:`utils.escape_markdown`. (:issue:`2420`)
-- Fix issue with ports being read in little endian when they should be big endian in voice connections. (:issue:`2470`)
+- Tokens are now stripped upon use. (:dpyissue:`2135`)
+- Passing in a ``name`` is no longer required for :meth:`Emoji.edit`. (:dpyissue:`2368`)
+- Fix issue with webhooks not re-raising after retries have run out. (:dpyissue:`2272`, :dpyissue:`2380`)
+- Fix mismatch in URL handling in :func:`utils.escape_markdown`. (:dpyissue:`2420`)
+- Fix issue with ports being read in little endian when they should be big endian in voice connections. (:dpyissue:`2470`)
 - Fix :meth:`Member.mentioned_in` not taking into consideration the message's guild.
 - Fix bug with moving channels when there are gaps in positions due to channel deletion and creation.
-- Fix :func:`on_shard_ready` not triggering when ``fetch_offline_members`` is disabled. (:issue:`2504`)
+- Fix :func:`on_shard_ready` not triggering when ``fetch_offline_members`` is disabled. (:dpyissue:`2504`)
 - Fix issue with large sharded bots taking too long to actually dispatch :func:`on_ready`.
 - Fix issue with fetching group DM based invites in :meth:`Client.fetch_invite`.
 - Fix out of order files being sent in webhooks when there are 10 files.
-- |commands| Extensions that fail internally due to ImportError will no longer raise :exc:`~.ext.commands.ExtensionNotFound`. (:issue:`2244`, :issue:`2275`, :issue:`2291`)
-- |commands| Updating the :attr:`Paginator.suffix <.ext.commands.Paginator.suffix>` will not cause out of date calculations. (:issue:`2251`)
-- |commands| Allow converters from custom extension packages. (:issue:`2369`, :issue:`2374`)
-- |commands| Fix issue with paginator prefix being ``None`` causing empty pages. (:issue:`2471`)
+- |commands| Extensions that fail internally due to ImportError will no longer raise :exc:`~.ext.commands.ExtensionNotFound`. (:dpyissue:`2244`, :dpyissue:`2275`, :dpyissue:`2291`)
+- |commands| Updating the :attr:`Paginator.suffix <.ext.commands.Paginator.suffix>` will not cause out of date calculations. (:dpyissue:`2251`)
+- |commands| Allow converters from custom extension packages. (:dpyissue:`2369`, :dpyissue:`2374`)
+- |commands| Fix issue with paginator prefix being ``None`` causing empty pages. (:dpyissue:`2471`)
 - |commands| :class:`~.commands.Greedy` now ignores parsing errors rather than propagating them.
 - |commands| :meth:`Command.can_run <.ext.commands.Command.can_run>` now checks whether a command is disabled.
-- |commands| :attr:`HelpCommand.clean_prefix <.ext.commands.HelpCommand.clean_prefix>` now takes into consideration nickname mentions. (:issue:`2489`)
+- |commands| :attr:`HelpCommand.clean_prefix <.ext.commands.HelpCommand.clean_prefix>` now takes into consideration nickname mentions. (:dpyissue:`2489`)
 - |commands| :meth:`Context.send_help <.ext.commands.Context.send_help>` now properly propagates to the :meth:`HelpCommand.on_help_command_error <.ext.commands.HelpCommand.on_help_command_error>` handler.
 
 Miscellaneous
 ~~~~~~~~~~~~~~~
 
 - The library now fully supports Python 3.8 without warnings.
-- Bump the dependency of ``websockets`` to 8.0 for those who can use it. (:issue:`2453`)
+- Bump the dependency of ``websockets`` to 8.0 for those who can use it. (:dpyissue:`2453`)
 - Due to Discord providing :class:`Member` data in mentions, users will now be upgraded to :class:`Member` more often if mentioned.
 - :func:`utils.escape_markdown` now properly escapes new quote markdown.
 - The message cache can now be disabled by passing ``None`` to ``max_messages`` in :class:`Client`.
@@ -615,13 +615,13 @@ Miscellaneous
 - The rate limiting code now uses millisecond precision to have more granular rate limit handling.
     - Along with that, the rate limiting code now uses Discord's response to wait. If you need to use the system clock again for whatever reason, consider passing ``assume_synced_clock`` in :class:`Client`.
 
-- The performance of :attr:`Guild.default_role` has been improved from O(N) to O(1). (:issue:`2375`)
+- The performance of :attr:`Guild.default_role` has been improved from O(N) to O(1). (:dpyissue:`2375`)
 - The performance of :attr:`Member.roles` has improved due to usage of caching to avoid surprising performance traps.
 - The GC is manually triggered during things that cause large deallocations (such as guild removal) to prevent memory fragmentation.
 - There have been many changes to the documentation for fixes both for usability, correctness, and to fix some linter errors. Thanks to everyone who contributed to those.
 - The loading of the opus module has been delayed which would make the result of :func:`opus.is_loaded` somewhat surprising.
-- |commands| Usernames prefixed with @ inside DMs will properly convert using the :class:`User` converter. (:issue:`2498`)
-- |tasks| The task sleeping time will now take into consideration the amount of time the task body has taken before sleeping. (:issue:`2516`)
+- |commands| Usernames prefixed with @ inside DMs will properly convert using the :class:`User` converter. (:dpyissue:`2498`)
+- |tasks| The task sleeping time will now take into consideration the amount of time the task body has taken before sleeping. (:dpyissue:`2516`)
 
 .. _vp1p2p5:
 
@@ -643,10 +643,10 @@ Bug Fixes
 
 - Fix a regression when :attr:`Message.channel` would be ``None``.
 - Fix a regression where :attr:`Message.edited_at` would not update during edits.
-- Fix a crash that would trigger during message updates (:issue:`2265`, :issue:`2287`).
-- Fix a bug when :meth:`VoiceChannel.connect` would not return (:issue:`2274`, :issue:`2372`, :issue:`2373`, :issue:`2377`).
-- Fix a crash relating to token-less webhooks (:issue:`2364`).
-- Fix issue where :attr:`Guild.premium_subscription_count` would be ``None`` due to a Discord bug. (:issue:`2331`, :issue:`2376`).
+- Fix a crash that would trigger during message updates (:dpyissue:`2265`, :dpyissue:`2287`).
+- Fix a bug when :meth:`VoiceChannel.connect` would not return (:dpyissue:`2274`, :dpyissue:`2372`, :dpyissue:`2373`, :dpyissue:`2377`).
+- Fix a crash relating to token-less webhooks (:dpyissue:`2364`).
+- Fix issue where :attr:`Guild.premium_subscription_count` would be ``None`` due to a Discord bug. (:dpyissue:`2331`, :dpyissue:`2376`).
 
 .. _vp1p2p3:
 
@@ -656,10 +656,10 @@ v1.2.3
 Bug Fixes
 ~~~~~~~~~~~
 
-- Fix an AttributeError when accessing :attr:`Member.premium_since` in :func:`on_member_update`. (:issue:`2213`)
-- Handle :exc:`asyncio.CancelledError` in :meth:`abc.Messageable.typing` context manager. (:issue:`2218`)
-- Raise the max encoder bitrate to 512kbps to account for nitro boosting. (:issue:`2232`)
-- Properly propagate exceptions in :meth:`Client.run`. (:issue:`2237`)
+- Fix an AttributeError when accessing :attr:`Member.premium_since` in :func:`on_member_update`. (:dpyissue:`2213`)
+- Handle :exc:`asyncio.CancelledError` in :meth:`abc.Messageable.typing` context manager. (:dpyissue:`2218`)
+- Raise the max encoder bitrate to 512kbps to account for nitro boosting. (:dpyissue:`2232`)
+- Properly propagate exceptions in :meth:`Client.run`. (:dpyissue:`2237`)
 - |commands| Ensure cooldowns are properly copied when used in cog level ``command_attrs``.
 
 .. _vp1p2p2:
@@ -704,14 +704,14 @@ New Features
 - Add support for animated icons in :meth:`Guild.icon_url_as` and :attr:`Guild.icon_url`.
 - Add :meth:`Guild.is_icon_animated`.
 - Add support for the various new :class:`MessageType` involving nitro boosting.
-- Add :attr:`VoiceRegion.india`. (:issue:`2145`)
-- Add :meth:`Embed.insert_field_at`. (:issue:`2178`)
-- Add a ``type`` attribute for all channels to their appropriate :class:`ChannelType`. (:issue:`2185`)
-- Add :meth:`Client.fetch_channel` to fetch a channel by ID via HTTP. (:issue:`2169`)
-- Add :meth:`Guild.fetch_channels` to fetch all channels via HTTP. (:issue:`2169`)
+- Add :attr:`VoiceRegion.india`. (:dpyissue:`2145`)
+- Add :meth:`Embed.insert_field_at`. (:dpyissue:`2178`)
+- Add a ``type`` attribute for all channels to their appropriate :class:`ChannelType`. (:dpyissue:`2185`)
+- Add :meth:`Client.fetch_channel` to fetch a channel by ID via HTTP. (:dpyissue:`2169`)
+- Add :meth:`Guild.fetch_channels` to fetch all channels via HTTP. (:dpyissue:`2169`)
 - |tasks| Add :meth:`Loop.stop <.ext.tasks.Loop.stop>` to gracefully stop a task rather than cancelling.
 - |tasks| Add :meth:`Loop.failed <.ext.tasks.Loop.failed>` to query if a task had failed somehow.
-- |tasks| Add :meth:`Loop.change_interval <.ext.tasks.Loop.change_interval>` to change the sleep interval at runtime (:issue:`2158`, :issue:`2162`)
+- |tasks| Add :meth:`Loop.change_interval <.ext.tasks.Loop.change_interval>` to change the sleep interval at runtime (:dpyissue:`2158`, :dpyissue:`2162`)
 
 Bug Fixes
 ~~~~~~~~~~~
@@ -719,7 +719,7 @@ Bug Fixes
 - Fix internal error when using :meth:`Guild.prune_members`.
 - |commands| Fix :attr:`.Command.invoked_subcommand` being invalid in many cases.
 - |tasks| Reset iteration count when the loop terminates and is restarted.
-- |tasks| The decorator interface now works as expected when stacking (:issue:`2154`)
+- |tasks| The decorator interface now works as expected when stacking (:dpyissue:`2154`)
 
 Miscellaneous
 ~~~~~~~~~~~~~~~
@@ -732,7 +732,7 @@ Miscellaneous
 - Improve performance of attribute access on :class:`Member` about by 2x.
 - Improve performance of :func:`utils.get` by around 4-6x depending on usage.
 - Improve performance of event parsing lookup by around 2.5x.
-- Keyword arguments in :meth:`Client.start` and :meth:`Client.run` are now validated (:issue:`953`, :issue:`2170`)
+- Keyword arguments in :meth:`Client.start` and :meth:`Client.run` are now validated (:dpyissue:`953`, :dpyissue:`2170`)
 - The Discord error code is now shown in the exception message for :exc:`HTTPException`.
 - Internal tasks launched by the library will now have their own custom ``__repr__``.
 - All public facing types should now have a proper and more detailed ``__repr__``.
@@ -746,7 +746,7 @@ v1.1.1
 Bug Fixes
 ~~~~~~~~~~~~
 
-- Webhooks do not overwrite data on retrying their HTTP requests (:issue:`2140`)
+- Webhooks do not overwrite data on retrying their HTTP requests (:dpyissue:`2140`)
 
 Miscellaneous
 ~~~~~~~~~~~~~~
@@ -763,15 +763,15 @@ New Features
 
 - **There is a new extension dedicated to making background tasks easier.**
     - You can check the documentation here: :ref:`ext_tasks_api`.
-- Add :attr:`Permissions.stream` permission. (:issue:`2077`)
+- Add :attr:`Permissions.stream` permission. (:dpyissue:`2077`)
 - Add equality comparison and hash support to :class:`Asset`
-- Add ``compute_prune_members`` parameter to :meth:`Guild.prune_members` (:issue:`2085`)
-- Add :attr:`Client.cached_messages` attribute to fetch the message cache (:issue:`2086`)
-- Add :meth:`abc.GuildChannel.clone` to clone a guild channel. (:issue:`2093`)
-- Add ``delay`` keyword-only argument to :meth:`Message.delete` (:issue:`2094`)
-- Add support for ``<:name:id>`` when adding reactions (:issue:`2095`)
-- Add :meth:`Asset.read` to fetch the bytes content of an asset (:issue:`2107`)
-- Add :meth:`Attachment.read` to fetch the bytes content of an attachment (:issue:`2118`)
+- Add ``compute_prune_members`` parameter to :meth:`Guild.prune_members` (:dpyissue:`2085`)
+- Add :attr:`Client.cached_messages` attribute to fetch the message cache (:dpyissue:`2086`)
+- Add :meth:`abc.GuildChannel.clone` to clone a guild channel. (:dpyissue:`2093`)
+- Add ``delay`` keyword-only argument to :meth:`Message.delete` (:dpyissue:`2094`)
+- Add support for ``<:name:id>`` when adding reactions (:dpyissue:`2095`)
+- Add :meth:`Asset.read` to fetch the bytes content of an asset (:dpyissue:`2107`)
+- Add :meth:`Attachment.read` to fetch the bytes content of an attachment (:dpyissue:`2118`)
 - Add support for voice kicking by passing ``None`` to :meth:`Member.move_to`.
 
 ``discord.ext.commands``
@@ -781,8 +781,8 @@ New Features
 - Support callable converters in :data:`~.commands.Greedy`
 - Add new :class:`~.commands.MessageConverter`.
     - This allows you to use :class:`Message` as a type hint in functions.
-- Allow passing ``cls`` in the :func:`~.commands.group` decorator (:issue:`2061`)
-- Add :attr:`.Command.parents` to fetch the parents of a command (:issue:`2104`)
+- Allow passing ``cls`` in the :func:`~.commands.group` decorator (:dpyissue:`2061`)
+- Add :attr:`.Command.parents` to fetch the parents of a command (:dpyissue:`2104`)
 
 
 Bug Fixes
@@ -793,7 +793,7 @@ Bug Fixes
 - Remove incorrect legacy NSFW checks in e.g. :meth:`TextChannel.is_nsfw`.
 - Fix :exc:`UnboundLocalError` when :class:`RequestsWebhookAdapter` raises an error.
 - Fix bug where updating your own user did not update your member instances.
-- Tighten constraints of ``__eq__`` in :class:`Spotify` objects (:issue:`2113`, :issue:`2117`)
+- Tighten constraints of ``__eq__`` in :class:`Spotify` objects (:dpyissue:`2113`, :dpyissue:`2117`)
 
 ``discord.ext.commands``
 ++++++++++++++++++++++++++
@@ -801,10 +801,10 @@ Bug Fixes
 - Fix lambda converters in a non-module context (e.g. ``eval``).
 - Use message creation time for reference time when computing cooldowns.
     - This prevents cooldowns from triggering during e.g. a RESUME session.
-- Fix the default :func:`on_command_error` to work with new-style cogs (:issue:`2094`)
+- Fix the default :func:`on_command_error` to work with new-style cogs (:dpyissue:`2094`)
 - DM channels are now recognised as NSFW in :func:`~.commands.is_nsfw` check.
-- Fix race condition with help commands (:issue:`2123`)
-- Fix cog descriptions not showing in :class:`~.commands.MinimalHelpCommand` (:issue:`2139`)
+- Fix race condition with help commands (:dpyissue:`2123`)
+- Fix cog descriptions not showing in :class:`~.commands.MinimalHelpCommand` (:dpyissue:`2139`)
 
 Miscellaneous
 ~~~~~~~~~~~~~~~
@@ -817,7 +817,7 @@ Miscellaneous
 ``discord.ext.commands``
 ++++++++++++++++++++++++++
 
-- Custom exception classes are now used for all default checks in the library (:issue:`2101`)
+- Custom exception classes are now used for all default checks in the library (:dpyissue:`2101`)
 
 
 .. _vp1p0p1:
@@ -830,7 +830,7 @@ Bug Fixes
 
 - Fix issue with speaking state being cast to ``int`` when it was invalid.
 - Fix some issues with loop cleanup that some users experienced on Linux machines.
-- Fix voice handshake race condition (:issue:`2056`, :issue:`2063`)
+- Fix voice handshake race condition (:dpyissue:`2056`, :dpyissue:`2063`)
 
 .. _vp1p0p0:
 
@@ -868,7 +868,7 @@ Bug Fixes
 - Servers are now properly chunked for user bots.
 - The CDN URL is now used instead of the API URL for assets.
 - Rate limit implementation now tries to use header information if possible.
-- Event loop is now properly propagated (:issue:`420`)
+- Event loop is now properly propagated (:dpyissue:`420`)
 - Allow falsey values in :meth:`Client.send_message` and :meth:`Client.send_file`.
 
 .. _vp0p16p0:
@@ -1023,7 +1023,7 @@ New Features
 Bug Fixes
 ~~~~~~~~~~
 
-- Paginator pages do not exceed their max_size anymore (:issue:`340`)
+- Paginator pages do not exceed their max_size anymore (:dpyissue:`340`)
 - Do Not Disturb users no longer show up offline due to the new :class:`Status` changes.
 
 .. _v0p12p0:
@@ -1076,7 +1076,7 @@ Bug Fixes
 ~~~~~~~~~~
 
 - Fix bug that caused the library to not work with the latest ``websockets`` library.
-- Fix bug that leaked keep alive threads (:issue:`309`)
+- Fix bug that leaked keep alive threads (:dpyissue:`309`)
 - Fix bug that disallowed :class:`ServerRegion` from being used in :meth:`Client.edit_server`.
 - Fix bug in :meth:`Channel.permissions_for` that caused permission resolution to happen out of order.
 - Fix bug in :attr:`Member.top_role` that did not account for same-position roles.

--- a/nextcord/ext/commands/help.py
+++ b/nextcord/ext/commands/help.py
@@ -268,7 +268,7 @@ class HelpCommand:
 
         Internally instances of this class are deep copied every time
         the command itself is invoked to prevent a race condition
-        mentioned in :issue:`2123`.
+        mentioned in :dpyissue:`2123`.
 
         This means that relying on the state of this class to be
         the same between command invocations would not work as expected.

--- a/nextcord/member.py
+++ b/nextcord/member.py
@@ -239,7 +239,7 @@ class Member(abc.Messageable, _UserTag):
 
             Due to a Discord API limitation, a user's Spotify activity may not appear
             if they are listening to a song with a title longer
-            than 128 characters. See :issue:`1738` for more information.
+            than 128 characters. See :dpyissue:`1738` for more information.
 
     guild: :class:`Guild`
         The guild that the member belongs to.
@@ -543,7 +543,7 @@ class Member(abc.Messageable, _UserTag):
 
             Due to a Discord API limitation, this may be ``None`` if
             the user is listening to a song on Spotify with a title longer
-            than 128 characters. See :issue:`1738` for more information.
+            than 128 characters. See :dpyissue:`1738` for more information.
 
         .. note::
 

--- a/nextcord/object.py
+++ b/nextcord/object.py
@@ -51,7 +51,7 @@ class Object(Hashable):
     objects (if any) actually inherit from this class.
 
     There are also some cases where some websocket events are received
-    in :issue:`strange order <21>` and when such events happened you would
+    in :dpyissue:`strange order <21>` and when such events happened you would
     receive this class rather than the actual data class. These cases are
     extremely rare.
 


### PR DESCRIPTION
## Summary

Fixes broken links across documentation that linked to incorrect or non-existent nextcord issues, to direct to their correct destination.

Discord.py issues are now referenced using `:dpyissue:`, new issues and PRs in nextcord can still be referenced using `:issue:`

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
