### PR TITLE
feat!: Support for file descriptions

### DIFF
--- a/nextcord/file.py
+++ b/nextcord/file.py
@@ -60,15 +60,19 @@ class File:
         The filename to display when uploading to Discord.
         If this is not given then it defaults to ``fp.name`` or if ``fp`` is
         a string then the ``filename`` will default to the string given.
+    description: Optional[:class:`str`]
+        The description for the file. This is used to display alternative text
+        in the Discord client.
     spoiler: :class:`bool`
         Whether the attachment is a spoiler.
     """
 
-    __slots__ = ('fp', 'filename', 'spoiler', '_original_pos', '_owner', '_closer')
+    __slots__ = ('fp', 'filename', 'spoiler', '_original_pos', '_owner', '_closer', 'description')
 
     if TYPE_CHECKING:
         fp: io.BufferedIOBase
         filename: Optional[str]
+        description: Optional[str]
         spoiler: bool
 
     def __init__(
@@ -76,6 +80,7 @@ class File:
         fp: Union[str, bytes, os.PathLike, io.BufferedIOBase],
         filename: Optional[str] = None,
         *,
+        description: Optional[str] = None,
         spoiler: bool = False,
     ):
         if isinstance(fp, io.IOBase):
@@ -103,6 +108,8 @@ class File:
                 self.filename = getattr(fp, 'name', None)
         else:
             self.filename = filename
+
+        self.description = description
 
         if spoiler and self.filename is not None and not self.filename.startswith('SPOILER_'):
             self.filename = 'SPOILER_' + self.filename

--- a/nextcord/http.py
+++ b/nextcord/http.py
@@ -479,8 +479,10 @@ class HTTPClient:
     ) -> Response[message.Message]:
         form = []
 
-        payload: Dict[str, Any] = {'tts': tts}
-        payload['attachments'] = []
+        payload: Dict[str, Any] = {
+            'tts': tts,
+            'attachments': attachments or [],
+        }
 
         if content:
             payload['content'] = content
@@ -498,8 +500,6 @@ class HTTPClient:
             payload['components'] = components
         if stickers:
             payload['sticker_ids'] = stickers
-        if attachments:
-            payload['attachments'] = attachments
 
         form.append({'name': 'payload_json'})
         for index, file in enumerate(files):

--- a/nextcord/http.py
+++ b/nextcord/http.py
@@ -480,6 +480,8 @@ class HTTPClient:
         form = []
 
         payload: Dict[str, Any] = {'tts': tts}
+        payload['attachments'] = []
+
         if content:
             payload['content'] = content
         if embed:
@@ -496,17 +498,8 @@ class HTTPClient:
             payload['components'] = components
         if stickers:
             payload['sticker_ids'] = stickers
-        if files:
-            payload['attachments'] = []
         if attachments:
-            payload['attachments'] = [
-                {
-                    'filename': files[attachment['id']].filename,
-                    'description': files[attachment['id']].description,
-                    **attachment,
-                }
-                for attachment in attachments
-            ]
+            payload['attachments'] = attachments
 
         form.append({'name': 'payload_json'})
         for index, file in enumerate(files):

--- a/nextcord/http.py
+++ b/nextcord/http.py
@@ -508,7 +508,7 @@ class HTTPClient:
                 for attachment in attachments
             ]
 
-        form.append({'name': 'payload_json', 'value': utils._to_json(payload)})
+        form.append({'name': 'payload_json'})
         for index, file in enumerate(files):
             payload['attachments'].append({
                 'id': index,
@@ -523,6 +523,7 @@ class HTTPClient:
                     'content_type': 'application/octet-stream',
                 }
             )
+        form[0]['value'] = utils._to_json(payload)
 
         return self.request(route, form=form, files=files)
 

--- a/nextcord/http.py
+++ b/nextcord/http.py
@@ -569,13 +569,6 @@ class HTTPClient:
     def edit_message(self, channel_id: Snowflake, message_id: Snowflake, **fields: Any) -> Response[message.Message]:
         r = Route('PATCH', '/channels/{channel_id}/messages/{message_id}', channel_id=channel_id, message_id=message_id)
         if "files" in fields:
-            fields["tts"] = None
-            fields["nonce"] = None
-            fields["message_reference"] = None
-            fields["stickers"] = None
-            attachments = fields.pop("attachments", None)
-            if attachments is not None:
-                fields["attachments"] = attachments
             return self.send_multipart_helper(r, **fields)
         return self.request(r, json=fields)
 

--- a/nextcord/http.py
+++ b/nextcord/http.py
@@ -266,7 +266,7 @@ class HTTPClient:
                         f.reset(seek=tries)
 
                 if form:
-                    form_data = aiohttp.FormData()
+                    form_data = aiohttp.FormData(quote_fields=False)
                     for params in form:
                         form_data.add_field(**params)
                     kwargs['data'] = form_data
@@ -496,11 +496,25 @@ class HTTPClient:
             payload['components'] = components
         if stickers:
             payload['sticker_ids'] = stickers
+        if files:
+            payload['attachments'] = []
         if attachments:
-            payload["attachments"] = [{"filename": files[attachment["id"]].filename, **attachment} for attachment in attachments]
+            payload['attachments'] = [
+                {
+                    'filename': files[attachment['id']].filename,
+                    'description': files[attachment['id']].description,
+                    **attachment,
+                }
+                for attachment in attachments
+            ]
 
         form.append({'name': 'payload_json', 'value': utils._to_json(payload)})
         for index, file in enumerate(files):
+            payload['attachments'].append({
+                'id': index,
+                'filename': file.filename,
+                'description': file.description,
+            })
             form.append(
                 {
                     'name': f'files[{index}]',

--- a/nextcord/interactions.py
+++ b/nextcord/interactions.py
@@ -307,8 +307,9 @@ class Interaction:
             A list of files to send with the content. This cannot be mixed with the
             ``file`` parameter.
         attachments: List[:class:`Attachment`]
-            A list of attachments to keep in the message. If ``[]`` is passed
-            then all attachments are removed.
+            A list of attachments to keep in the message. To keep existing attachments,
+            you must fetch the message with :meth:`original_message` and pass
+            ``message.attachments`` to this parameter.
         allowed_mentions: :class:`AllowedMentions`
             Controls the mentions being processed in this message.
             See :meth:`.abc.Messageable.send` for more information.
@@ -782,8 +783,8 @@ class InteractionResponse:
             A list of files to upload. Maximum of 10. This cannot be mixed with
             the ``file`` parameter.
         attachments: List[:class:`Attachment`]
-            A list of attachments to keep in the message. If ``[]`` is passed
-            then all attachments are removed.
+            A list of attachments to keep in the message. To keep all existing attachments,
+            pass ``interaction.message.attachments``.
         view: Optional[:class:`~nextcord.ui.View`]
             The updated view to update this message with. If ``None`` is passed then
             the view is removed.
@@ -946,8 +947,9 @@ class InteractionMessage(Message):
             A list of files to send with the content. This cannot be mixed with the
             ``file`` parameter.
         attachments: List[:class:`Attachment`]
-            A list of attachments to keep in the message. If ``[]`` is passed
-            then all attachments are removed.
+            A list of attachments to keep in the message. To keep existing attachments,
+            you must fetch the message with :meth:`original_message` and pass
+            ``message.attachments`` to this parameter.
         allowed_mentions: :class:`AllowedMentions`
             Controls the mentions being processed in this message.
             See :meth:`.abc.Messageable.send` for more information.

--- a/nextcord/message.py
+++ b/nextcord/message.py
@@ -1286,7 +1286,7 @@ class Message(Hashable):
             edited a message's content or embed that isn't yours.
         ~nextcord.InvalidArgument
             You specified both ``embed`` and ``embeds``
-            or ``files`` and ``files``.
+            or ``file`` and ``files``.
         """
 
         payload: Dict[str, Any] = {}

--- a/nextcord/message.py
+++ b/nextcord/message.py
@@ -1342,16 +1342,6 @@ class Message(Hashable):
         elif files is not MISSING:
             payload["files"] = files
 
-        if "files" in payload and append_files is not MISSING and not append_files:
-            payload["attachments"] = [
-                {
-                    "id": i,
-                    "filename": file.filename,
-                    "description": file.description,
-                }
-                for i, file in enumerate(payload["files"])
-            ]
-
         data = await self._state.http.edit_message(self.channel.id, self.id, **payload)
         message = Message(state=self._state, channel=self.channel, data=data)
 

--- a/nextcord/message.py
+++ b/nextcord/message.py
@@ -1239,8 +1239,8 @@ class Message(Hashable):
 
             .. versionadded:: 2.0
         attachments: List[:class:`Attachment`]
-            A list of attachments to keep in the message. If ``[]`` is passed
-            then all attachments are removed.
+            A list of attachments to keep in the message. To keep all existing attachments,
+            pass ``message.attachments``.
         suppress: :class:`bool`
             Whether to suppress embeds for the message. This removes
             all the embeds if set to ``True``. If set to ``False``

--- a/nextcord/message.py
+++ b/nextcord/message.py
@@ -1185,6 +1185,7 @@ class Message(Hashable):
         delete_after: Optional[float] = ...,
         allowed_mentions: Optional[AllowedMentions] = ...,
         view: Optional[View] = ...,
+        file: Optional[File] = ...,
     ) -> Message:
         ...
 
@@ -1199,6 +1200,37 @@ class Message(Hashable):
         delete_after: Optional[float] = ...,
         allowed_mentions: Optional[AllowedMentions] = ...,
         view: Optional[View] = ...,
+        file: Optional[File] = ...,
+    ) -> Message:
+        ...
+
+    @overload
+    async def edit(
+        self,
+        *,
+        content: Optional[str] = ...,
+        embed: Optional[Embed] = ...,
+        attachments: List[Attachment] = ...,
+        suppress: bool = ...,
+        delete_after: Optional[float] = ...,
+        allowed_mentions: Optional[AllowedMentions] = ...,
+        view: Optional[View] = ...,
+        files: Optional[List[File]] = ...,
+    ) -> Message:
+        ...
+
+    @overload
+    async def edit(
+        self,
+        *,
+        content: Optional[str] = ...,
+        embeds: List[Embed] = ...,
+        attachments: List[Attachment] = ...,
+        suppress: bool = ...,
+        delete_after: Optional[float] = ...,
+        allowed_mentions: Optional[AllowedMentions] = ...,
+        view: Optional[View] = ...,
+        files: Optional[List[File]] = ...,
     ) -> Message:
         ...
 

--- a/nextcord/message.py
+++ b/nextcord/message.py
@@ -1286,6 +1286,7 @@ class Message(Hashable):
             edited a message's content or embed that isn't yours.
         ~nextcord.InvalidArgument
             You specified both ``embed`` and ``embeds``
+            or ``files`` and ``files``.
         """
 
         payload: Dict[str, Any] = {}
@@ -1299,10 +1300,6 @@ class Message(Hashable):
             raise InvalidArgument('cannot pass both embed and embeds parameter to edit()')
         if file is not MISSING and files is not MISSING:
             raise InvalidArgument('cannot pass both file and files parameter to edit()')
-        if file is not MISSING and attachments is not MISSING:
-            raise InvalidArgument('cannot pass both file and attachments parameter to edit()')
-        if files is not MISSING and attachments is not MISSING:
-            raise InvalidArgument('cannot pass both files and attachments parameter to edit()')
 
         if embed is not MISSING:
             if embed is None:
@@ -1329,6 +1326,9 @@ class Message(Hashable):
 
         if attachments is not MISSING:
             payload['attachments'] = [a.to_dict() for a in attachments]
+
+        if append_files is not MISSING and append_files:
+            payload['attachments'] = [a.to_dict() for a in self.attachments]
 
         if view is not MISSING:
             self._state.prevent_view_updates_for(self.id)

--- a/nextcord/message.py
+++ b/nextcord/message.py
@@ -1214,7 +1214,6 @@ class Message(Hashable):
         view: Optional[View] = MISSING,
         file: Optional[File] = MISSING,
         files: Optional[List[File]] = MISSING,
-        append_files: Optional[bool] = MISSING
     ) -> Message:
         """|coro|
 
@@ -1270,12 +1269,6 @@ class Message(Hashable):
             If provided, a list of new files to add to the message.
 
             .. versionadded:: 2.0
-        append_files: Optional[:class:`bool`]
-            Whether to append files to the message.
-            If set to True (default), files will be appended to the message.
-            If set to False, files will override the current files on the message.
-
-            .. versionadded:: 2.0
 
         Raises
         -------
@@ -1326,9 +1319,6 @@ class Message(Hashable):
 
         if attachments is not MISSING:
             payload['attachments'] = [a.to_dict() for a in attachments]
-
-        if append_files is not MISSING and append_files:
-            payload['attachments'] = [a.to_dict() for a in self.attachments]
 
         if view is not MISSING:
             self._state.prevent_view_updates_for(self.id)

--- a/nextcord/types/message.py
+++ b/nextcord/types/message.py
@@ -52,6 +52,7 @@ class Reaction(TypedDict):
 class _AttachmentOptional(TypedDict, total=False):
     height: Optional[int]
     width: Optional[int]
+    description: str
     content_type: str
     spoiler: bool
 

--- a/nextcord/webhook/async_.py
+++ b/nextcord/webhook/async_.py
@@ -705,8 +705,8 @@ class WebhookMessage(Message):
 
             .. versionadded:: 2.0
         attachments: List[:class:`Attachment`]
-            A list of attachments to keep in the message. If ``[]`` is passed
-            then all attachments are removed.
+            A list of attachments to keep in the message. To keep all existing attachments,
+            pass ``message.attachments``.
 
             .. versionadded:: 2.0
         allowed_mentions: :class:`AllowedMentions`
@@ -1548,8 +1548,7 @@ class Webhook(BaseWebhook):
 
             .. versionadded:: 2.0
         attachments: List[:class:`Attachment`]
-            A list of attachments to keep in the message. If ``[]`` is passed
-            then all attachments are removed.
+            A list of attachments to keep in the message.
 
             .. versionadded:: 2.0
         allowed_mentions: :class:`AllowedMentions`

--- a/nextcord/webhook/async_.py
+++ b/nextcord/webhook/async_.py
@@ -355,33 +355,35 @@ class AsyncWebhookAdapter:
             'type': type,
         }
 
-        multipart = []
-
         if data is not None:
             payload['data'] = data
 
-            if files:
-                if 'attachments' not in payload['data']:
-                    payload['data']['attachments'] = []
-                multipart.append({'name': 'payload_json'})
-                for index, file in enumerate(files):
-                    payload['data']['attachments'].append(
-                        {
-                            'id': index,
-                            'filename': file.filename,
-                            'description': file.description,
-                        }
-                    )
-                    multipart.append(
-                        {
-                            'name': f'files[{index}]',
-                            'value': file.fp,
-                            'filename': file.filename,
-                            'content_type': 'application/octet-stream',
-                        }
-                    )
-                multipart[0]['value'] = utils._to_json(payload)
-                payload = None
+        multipart = []
+
+        if files:
+            if 'data' not in payload:
+                payload['data'] = {}
+            if 'attachments' not in payload['data']:
+                payload['data']['attachments'] = []
+            multipart.append({'name': 'payload_json'})
+            for index, file in enumerate(files):
+                payload['data']['attachments'].append(
+                    {
+                        'id': index,
+                        'filename': file.filename,
+                        'description': file.description,
+                    }
+                )
+                multipart.append(
+                    {
+                        'name': f'files[{index}]',
+                        'value': file.fp,
+                        'filename': file.filename,
+                        'content_type': 'application/octet-stream',
+                    }
+                )
+            multipart[0]['value'] = utils._to_json(payload)
+            payload = None
 
         route = Route(
             'POST',

--- a/nextcord/webhook/async_.py
+++ b/nextcord/webhook/async_.py
@@ -141,7 +141,7 @@ class AsyncWebhookAdapter:
                     file.reset(seek=attempt)
 
                 if multipart:
-                    form_data = aiohttp.FormData()
+                    form_data = aiohttp.FormData(quote_fields=False)
                     for p in multipart:
                         form_data.add_field(**p)
                     to_send = form_data
@@ -368,6 +368,7 @@ class AsyncWebhookAdapter:
                     {
                         'id': index,
                         'filename': file.filename,
+                        'description': file.description,
                     }
                 )
                 multipart.append(

--- a/nextcord/webhook/async_.py
+++ b/nextcord/webhook/async_.py
@@ -355,34 +355,33 @@ class AsyncWebhookAdapter:
             'type': type,
         }
 
-        if files and 'attachments' not in data:
-            data['attachments'] = []
+        multipart = []
 
         if data is not None:
             payload['data'] = data
 
-        multipart = []
-
-        if files:
-            multipart.append({'name': 'payload_json'})
-            for index, file in enumerate(files):
-                payload['data']['attachments'].append(
-                    {
-                        'id': index,
-                        'filename': file.filename,
-                        'description': file.description,
-                    }
-                )
-                multipart.append(
-                    {
-                        'name': f'files[{index}]',
-                        'value': file.fp,
-                        'filename': file.filename,
-                        'content_type': 'application/octet-stream',
-                    }
-                )
-            multipart[0]['value'] = utils._to_json(payload)
-            payload = None
+            if files:
+                if 'attachments' not in payload['data']:
+                    payload['data']['attachments'] = []
+                multipart.append({'name': 'payload_json'})
+                for index, file in enumerate(files):
+                    payload['data']['attachments'].append(
+                        {
+                            'id': index,
+                            'filename': file.filename,
+                            'description': file.description,
+                        }
+                    )
+                    multipart.append(
+                        {
+                            'name': f'files[{index}]',
+                            'value': file.fp,
+                            'filename': file.filename,
+                            'content_type': 'application/octet-stream',
+                        }
+                    )
+                multipart[0]['value'] = utils._to_json(payload)
+                payload = None
 
         route = Route(
             'POST',

--- a/nextcord/webhook/async_.py
+++ b/nextcord/webhook/async_.py
@@ -355,6 +355,9 @@ class AsyncWebhookAdapter:
             'type': type,
         }
 
+        if files and 'attachments' not in data:
+            data['attachments'] = []
+
         if data is not None:
             payload['data'] = data
 
@@ -362,9 +365,8 @@ class AsyncWebhookAdapter:
 
         if files:
             multipart.append({'name': 'payload_json'})
-            payload['attachments'] = []
             for index, file in enumerate(files):
-                payload['attachments'].append(
+                payload['data']['attachments'].append(
                     {
                         'id': index,
                         'filename': file.filename,

--- a/nextcord/webhook/sync.py
+++ b/nextcord/webhook/sync.py
@@ -402,8 +402,8 @@ class SyncWebhookMessage(Message):
             A list of files to send with the content. This cannot be mixed with the
             ``file`` parameter.
         attachments: List[:class:`Attachment`]
-            A list of attachments to keep in the message. If ``[]`` is passed
-            then all attachments are removed.
+            A list of attachments to keep in the message. To keep all existing attachments,
+            pass ``message.attachments``.
         allowed_mentions: :class:`AllowedMentions`
             Controls the mentions being processed in this message.
             See :meth:`.abc.Messageable.send` for more information.
@@ -999,8 +999,7 @@ class SyncWebhook(BaseWebhook):
             A list of files to send with the content. This cannot be mixed with the
             ``file`` parameter.
         attachments: List[:class:`Attachment`]
-            A list of attachments to keep in the message. If ``[]`` is passed
-            then all attachments are removed.
+            A list of attachments to keep in the message.
         allowed_mentions: :class:`AllowedMentions`
             Controls the mentions being processed in this message.
             See :meth:`.abc.Messageable.send` for more information.


### PR DESCRIPTION
## Summary

Fixes #524 

Adds descriptions to file and attachments.

## Changes

* `description` attribute added to `nextcord.File`
* `description` attribute added to `nextcord.Attachment`
* `description` field added to `payload['attachments']` where relevant

### BREAKING CHANGES

In order to send files with descriptions, the `payload['attachments']` needs to be set containing the description for each file. Because of this, you can no longer send files without setting `payload['attachments']`. Therefore, the default behavior of editing a message with files is to **REPLACE** the existing attachments rather than **APPEND**.

NOTE: When [API v10 is used](https://github.com/discord/discord-api-docs/discussions/4510), **this will be the default behavior anyway**. Even if `payload['attachments']` is not set, files will be replaced, rather than appended.

If you want to append files instead, the existing attachments must be passed in to the edit method (eg. `attachments=message.attachments`)

Additionally, the `append_files` parameter was removed from `Message.edit` since it is redundant with `attachments`

## Testing

This has been tested thoroughly with `Message.send`, `Message.edit`, `InteractionResponse.send_message`, `InteractionResponse.edit_message`, `Webhook.send_message`, `WebhookMessage.edit`, `Interaction.send`, and `Interaction.edit_original_message`.

Example code used for testing:

~~https://paste.nextcord.dev/?id=1647147612909766~~

https://paste.nextcord.dev/?id=1647888965297768

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [x] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
