### PR TITLE
Note that `Attachment.save` can take a `str`-type for `fp`

### DIFF
--- a/nextcord/message.py
+++ b/nextcord/message.py
@@ -179,7 +179,7 @@ class Attachment(Hashable):
 
     async def save(
         self,
-        fp: Union[io.BufferedIOBase, PathLike],
+        fp: Union[io.BufferedIOBase, PathLike, str],
         *,
         seek_begin: bool = True,
         use_cached: bool = False,
@@ -190,7 +190,7 @@ class Attachment(Hashable):
 
         Parameters
         -----------
-        fp: Union[:class:`io.BufferedIOBase`, :class:`os.PathLike`]
+        fp: Union[:class:`io.BufferedIOBase`, :class:`os.PathLike`, :class:`str`]
             The file-like object to save this attachment to or the filename
             to use. If a filename is passed then a file is created with that
             filename and used instead.


### PR DESCRIPTION
## Summary

The `open()` built-in, which `Attachment.save()` calls, can take a str value for its `fp` argument. However 'str' is not covered by the `save()` method's existing type hints. Counter-intuitively, str does not satisfy [`os.PathLike`](https://docs.python.org/3/library/os.html#os.PathLike), as it does not define an `__fspath__` method.

Thus, we extend the type hint by adding "str" to the `Union`. See this example of the same case in python/typeshed: https://github.com/python/typeshed/blob/994b69ef8f18e76689daca3947879c3d7f76173e/stdlib/_typeshed/__init__.pyi#L77


## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
