### PR TITLE
feat: Support numpy docstring colon with no type

### DIFF
--- a/nextcord/utils.py
+++ b/nextcord/utils.py
@@ -1039,7 +1039,7 @@ _SPHINX_DOCSTRING_ARG_REGEX = re.compile(
 )
 
 _NUMPY_DOCSTRING_ARG_REGEX = re.compile(
-    rf"^{_ARG_NAME_SUBREGEX}(?:[ \t]*:[ \t]+{_ARG_TYPE_SUBREGEX})?[ \t]*\r?\n[ \t]*{_ARG_DESCRIPTION_SUBREGEX}",
+    rf"^{_ARG_NAME_SUBREGEX}(?:[ \t]*:)?(?:[ \t]+{_ARG_TYPE_SUBREGEX})?[ \t]*\r?\n[ \t]*{_ARG_DESCRIPTION_SUBREGEX}",
     re.MULTILINE
 )
 


### PR DESCRIPTION
## Summary

This is an uncommon convention, but can be supported as it does not break existing functionality.

In the below example, the numpy convention already supports `arg1`, `arg2`, and `arg3`.

This PR add support so that `arg4` will also work.

Basically allowing the colon to optionally appear, even when there is no type specified.

```py
@client.slash_command(guild_ids=[TESTING_GUILD_ID])
async def numpy_echo(interaction: Interaction, arg1: int, arg2: int, arg3: str, arg4: str):
    """NUMPY Summary line.

    Extended description of function.

    Parameters
    ----------
    interaction : Interaction
        Interaction object
    arg1 : int
        Description of arg1
    arg2: :class:`int`
        Description of arg number 2
        Second line of description.
    arg3
        Description of arg3
    arg4:
        Description of arg4
    """
    parsed_docstring = json.dumps(parse_docstring(numpy_echo.callback), indent=4)
    await interaction.response.send_message(
        f"You said `{arg1}`, `{arg2}`, `{arg3}`, `{arg4}`\n```{parsed_docstring}```"
    )
```

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
