### PR TITLE
docs: Clarifications in File attribute and parameter docs

### DIFF
--- a/nextcord/file.py
+++ b/nextcord/file.py
@@ -42,9 +42,10 @@ class File:
         File objects are single use and are not meant to be reused in
         multiple :meth:`abc.Messageable.send`\s.
 
-    Attributes
+    Parameters
     -----------
-    fp: Union[:class:`os.PathLike`, :class:`io.BufferedIOBase`]
+
+    fp: Union[str, bytes, os.PathLike, io.BufferedIOBase]
         A file-like object opened in binary mode and read mode
         or a filename representing a file in the hard drive to
         open.
@@ -55,11 +56,25 @@ class File:
             modes 'rb' should be used.
 
             To pass binary data, consider usage of ``io.BytesIO``.
-
     filename: Optional[:class:`str`]
         The filename to display when uploading to Discord.
         If this is not given then it defaults to ``fp.name`` or if ``fp`` is
         a string then the ``filename`` will default to the string given.
+    description: Optional[:class:`str`]
+        The description for the file. This is used to display alternative text
+        in the Discord client.
+    spoiler: :class:`bool`
+        Whether the attachment is a spoiler.
+
+    Attributes
+    -----------
+    fp: Union[:class:`io.BufferedReader`, :class:`io.BufferedIOBase`]
+        A file-like object opened in binary mode and read mode.
+        This will be a :class:`io.BufferedIOBase` if the an
+        object of type :class:`io.IOBase` was passed, or a
+        :class:`io.BufferedReader` if a filename was passed.
+    filename: Optional[:class:`str`]
+        The filename to display when uploading to Discord.
     description: Optional[:class:`str`]
         The description for the file. This is used to display alternative text
         in the Discord client.
@@ -70,7 +85,7 @@ class File:
     __slots__ = ('fp', 'filename', 'spoiler', '_original_pos', '_owner', '_closer', 'description')
 
     if TYPE_CHECKING:
-        fp: io.BufferedIOBase
+        fp: Union[io.BufferedReader, io.BufferedIOBase]
         filename: Optional[str]
         description: Optional[str]
         spoiler: bool

--- a/nextcord/file.py
+++ b/nextcord/file.py
@@ -70,7 +70,7 @@ class File:
     -----------
     fp: Union[:class:`io.BufferedReader`, :class:`io.BufferedIOBase`]
         A file-like object opened in binary mode and read mode.
-        This will be a :class:`io.BufferedIOBase` if the an
+        This will be a :class:`io.BufferedIOBase` if an
         object of type :class:`io.IOBase` was passed, or a
         :class:`io.BufferedReader` if a filename was passed.
     filename: Optional[:class:`str`]


### PR DESCRIPTION
## Summary

Fixes #543 

Previously the attributes documented were mostly information for the constructor parameters but with some errors such as string and bytes types not mentioned.

This PR documents the parameters and attributes more clearly.

### Parameters

![image](https://user-images.githubusercontent.com/20955511/159402247-b46e4d63-819a-405b-84c5-337ac7877bf3.png)

### Attributes

![image](https://user-images.githubusercontent.com/20955511/159405333-cc62c10f-8cee-4ae4-8e7a-df2c648f067e.png)

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] This PR is **not** a code change (e.g. documentation, README, ...)
