### PR TITLE
Fix issue removing embeds when editing with files and add `embeds` to `PartialMessage.edit`

### DIFF
--- a/nextcord/abc.py
+++ b/nextcord/abc.py
@@ -1259,8 +1259,8 @@ class Messageable:
         Sends a message to the destination with the content given.
 
         The content must be a type that can convert to a string through ``str(content)``.
-        If the content is set to ``None`` (the default), then the ``embed`` parameter must
-        be provided.
+        If the content is set to ``None`` (the default), then the ``embed`` or ``embeds``
+        parameter must be provided.
 
         To upload a single file, the ``file`` parameter should be used with a
         single :class:`~nextcord.File` object. To upload multiple files, the ``files``

--- a/nextcord/http.py
+++ b/nextcord/http.py
@@ -568,6 +568,9 @@ class HTTPClient:
 
     def edit_message(self, channel_id: Snowflake, message_id: Snowflake, **fields: Any) -> Response[message.Message]:
         r = Route('PATCH', '/channels/{channel_id}/messages/{message_id}', channel_id=channel_id, message_id=message_id)
+        if "embed" in fields:
+            embed = fields.pop("embed")
+            fields["embeds"] = [embed] if embed is not None else []
         if "files" in fields:
             return self.send_multipart_helper(r, **fields)
         return self.request(r, json=fields)

--- a/nextcord/http.py
+++ b/nextcord/http.py
@@ -568,9 +568,6 @@ class HTTPClient:
 
     def edit_message(self, channel_id: Snowflake, message_id: Snowflake, **fields: Any) -> Response[message.Message]:
         r = Route('PATCH', '/channels/{channel_id}/messages/{message_id}', channel_id=channel_id, message_id=message_id)
-        if "embed" in fields:
-            embed = fields.pop("embed")
-            fields["embeds"] = [embed] if embed is not None else []
         if "files" in fields:
             return self.send_multipart_helper(r, **fields)
         return self.request(r, json=fields)

--- a/nextcord/http.py
+++ b/nextcord/http.py
@@ -484,21 +484,21 @@ class HTTPClient:
             'attachments': attachments or [],
         }
 
-        if content:
+        if content is not None:
             payload['content'] = content
-        if embed:
+        if embed is not None:
             payload['embeds'] = [embed]
-        if embeds:
+        if embeds is not None:
             payload['embeds'] = embeds
-        if nonce:
+        if nonce is not None:
             payload['nonce'] = nonce
-        if allowed_mentions:
+        if allowed_mentions is not None:
             payload['allowed_mentions'] = allowed_mentions
-        if message_reference:
+        if message_reference is not None:
             payload['message_reference'] = message_reference
-        if components:
+        if components is not None:
             payload['components'] = components
-        if stickers:
+        if stickers is not None:
             payload['sticker_ids'] = stickers
 
         form.append({'name': 'payload_json'})

--- a/nextcord/message.py
+++ b/nextcord/message.py
@@ -1862,10 +1862,10 @@ class PartialMessage(Hashable):
 
         if 'embed' in fields:
             embed = fields.pop('embed')
-            fields['embeds'] = [embed] if embed is not None else []
+            fields['embeds'] = [embed.to_dict()] if embed is not None else []
 
         elif 'embeds' in fields:
-            fields['embeds'] = [e.to_dict() for e in fields['embeds']]
+            fields['embeds'] = [embed.to_dict() for embed in fields['embeds']]
 
         try:
             suppress: bool = fields.pop('suppress')

--- a/nextcord/message.py
+++ b/nextcord/message.py
@@ -1804,6 +1804,11 @@ class PartialMessage(Hashable):
         embed: Optional[:class:`Embed`]
             The new embed to replace the original with.
             Could be ``None`` to remove the embed.
+        embeds: List[:class:`Embed`]
+            The new embeds to replace the original with. Must be a maximum of 10.
+            To remove all embeds ``[]`` should be passed.
+
+            .. versionadded:: 2.0
         suppress: :class:`bool`
             Whether to suppress embeds for the message. This removes
             all the embeds if set to ``True``. If set to ``False``
@@ -1835,6 +1840,8 @@ class PartialMessage(Hashable):
         Forbidden
             Tried to suppress a message without permissions or
             edited a message's content or embed that isn't yours.
+        ~nextcord.InvalidArgument
+            You specified both ``embed`` and ``embeds``
 
         Returns
         ---------
@@ -1850,13 +1857,14 @@ class PartialMessage(Hashable):
             if content is not None:
                 fields['content'] = str(content)
 
-        try:
-            embed = fields['embed']
-        except KeyError:
-            pass
-        else:
-            if embed is not None:
-                fields['embed'] = embed.to_dict()
+        if 'embed' in fields and 'embeds' in fields:
+            raise InvalidArgument('Cannot pass both embed and embeds parameter to edit()')
+
+        if 'embed' in fields and fields['embed'] is not None:
+            fields['embed'] = fields['embed'].to_dict()
+
+        elif 'embeds' in fields:
+            fields['embeds'] = [e.to_dict() for e in fields['embeds']]
 
         try:
             suppress: bool = fields.pop('suppress')

--- a/nextcord/message.py
+++ b/nextcord/message.py
@@ -1860,8 +1860,9 @@ class PartialMessage(Hashable):
         if 'embed' in fields and 'embeds' in fields:
             raise InvalidArgument('Cannot pass both embed and embeds parameter to edit()')
 
-        if 'embed' in fields and fields['embed'] is not None:
-            fields['embed'] = fields['embed'].to_dict()
+        if 'embed' in fields:
+            embed = fields.pop('embed')
+            fields['embeds'] = [embed] if embed is not None else []
 
         elif 'embeds' in fields:
             fields['embeds'] = [e.to_dict() for e in fields['embeds']]


### PR DESCRIPTION
## Summary

Feature:
* Adds support for sending `embeds` in `PartialMessage.edit`

Fixes:
* Replaces use of deprecated `embed` field in `PartialMessage.edit` with `embeds`
* **Fixes issue when trying to remove content, embeds, or other attributes when editing a message with files**

## Bug fix details

This PR fixes a bug where if you pass `embed=None` or `embeds=[]` to an edit method while also sending files, the embeds do not get removed.

This bug also applies to sending `view=None`, a view with no components, an empty list of stickers, or empty string as content.

Example:

```py
@bot.command(name="pme")
async def partial_message_embeds(ctx: commands.Context):
    pm = ctx.channel.get_partial_message(956263847562477619)
    await pm.edit(content="Test 1", embeds=[nextcord.Embed(title="Test"), nextcord.Embed(title="Test 2")])
    await asyncio.sleep(2)
    # this should remove the embeds
    await pm.edit(content="Test 2", embed=None, files=[nextcord.File("nextcord-logo.png")])
    # this should also remove the embeds
    await pm.edit(content="Test 2", embeds=[], files=[nextcord.File("nextcord-logo.png")])
```

This was fixed by checking for `embeds` being `None` rather than checking `if embeds` (which would skip adding the embeds field if the list is empty.

## Testing

Code for testing changes:

https://paste.nextcord.dev/?id=1648148708552851

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
