### PR TITLE
docs: warn about AppInfo.summary deprecation

### DIFF
--- a/docs/migrating_2.rst
+++ b/docs/migrating_2.rst
@@ -29,6 +29,7 @@ Overview
 - ``missing_perms`` attributes and arguments are renamed to ``missing_permissions``.
 - Many method arguments now reject ``None``.
 - Many arguments are now specified as positional-only or keyword-only; e.g. :func:`oauth_url` now takes keyword-only arguments, and methods starting with ``get_`` or ``fetch_`` take positional-only arguments.
+- :attr:`AppInfo.summary` and :attr:`PartialAppInfo.summary` now return an empty string and will be removed in API v11.
 
 Changes
 -----------------------

--- a/nextcord/appinfo.py
+++ b/nextcord/appinfo.py
@@ -76,6 +76,10 @@ class AppInfo:
         If this application is a game sold on Discord,
         this field will be the summary field for the store page of its primary SKU.
 
+        .. warning::
+
+            This attribute now returns an empty string and will be removed in API v11.       
+
         .. versionadded:: 1.3
 
     verify_key: :class:`str`
@@ -213,6 +217,10 @@ class PartialAppInfo:
     summary: :class:`str`
         If this application is a game sold on Discord,
         this field will be the summary field for the store page of its primary SKU.
+
+        .. warning::
+            
+            This attribute now returns an empty string and will be removed in API v11. 
     verify_key: :class:`str`
         The hex encoded key for verification in interactions and the
         GameSDK's `GetTicket <https://discord.com/developers/docs/game-sdk/applications#getticket>`_.


### PR DESCRIPTION
Ref: #467 

https://github.com/discord/discord-api-docs/discussions/4510