### PR TITLE
feat: Add close event (#349)

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -307,6 +307,10 @@ to handle it, which defaults to print a traceback and ignoring the exception.
     :param kwargs: The keyword arguments for the event that raised the
         exception.
 
+.. function:: on_close()
+
+    Called when the client is exiting the event loop and shutting down.
+
 .. function:: on_socket_event_type(event_type)
 
     Called whenever a websocket event is received from the WebSocket.

--- a/nextcord/client.py
+++ b/nextcord/client.py
@@ -657,6 +657,8 @@ class Client:
 
         self._closed = True
 
+        self.dispatch("close")
+
         for voice in self.voice_clients:
             try:
                 await voice.disconnect(force=True)


### PR DESCRIPTION
## Summary

This adds the "close" event, which can then be listened for by library users to help shutdown parts of their bot, like database connections.

This ended up being a single line addition to the Client.close() function to just dispatch the `close` event but it looks like that's all that should be needed? Would greatly appreciate some feedback or confirmation.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)