### PR TITLE
fix: Modal _expires_at and View auto_defer

### DIFF
--- a/nextcord/ui/modal.py
+++ b/nextcord/ui/modal.py
@@ -156,9 +156,16 @@ class Modal:
 
     @property
     def _expires_at(self) -> Optional[float]:
-        if self.timeout:
-            return time.monotonic() + self.timeout
-        return None
+        """The monotonic time this modal times out at.
+
+        Returns
+        -------
+        Optional[float]
+            When this modal times out.
+
+            None if no timeout is set.
+        """
+        return self.__timeout_expiry
 
     def add_item(self, item: Item) -> Modal:
         """Adds an item to the modal.
@@ -259,7 +266,11 @@ class Modal:
                 self.__timeout_expiry = time.monotonic() + self.timeout
 
             await self.callback(interaction)
-            if not interaction.response._responded and self.auto_defer:
+            if (
+                not interaction.response._responded
+                and not interaction.is_expired()
+                and self.auto_defer
+            ):
                 await interaction.response.defer()
         except Exception as e:
             return await self.on_error(e, interaction)


### PR DESCRIPTION
## Summary

Adapts expiry changes from views to modals, and auto_defer from modals to views

## Changes

* Adapts #534 to Modals to not defer if interaction is expired

* Adapts #497 to Modals to fix `Modal._expires_at`

* Adapts `auto_defer` to Views to be consistent with Modals. This allows you to handle component interactions in your command after the callback ends, or handle component interactions in `on_interaction` (see [Help Thread](https://discord.com/channels/881118111967883295/956638253350531092))

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
