### PR TITLE
docs: Remove incorrect attributes from docs

### DIFF
--- a/nextcord/interactions.py
+++ b/nextcord/interactions.py
@@ -145,10 +145,6 @@ class Interaction:
         The attached data of the interaction. This is used to store any data you may need inside the interaction for convenience. This data will stay on the interaction, even after a :meth:`Interaction.application_command_before_invoke`.
     application_command: Optional[:class:`ApplicationCommand`]
         The application command that handled the interaction.
-    client: :class:`Client`
-        The client that handled the interaction. Can be a subclass of :class:`Client`.
-    bot: :class:`Client`:
-        An alias for ``client``.
     """
 
     __slots__: Tuple[str, ...] = (
@@ -166,7 +162,6 @@ class Interaction:
         'version',
         'application_command',
         'attached',
-        '_client',
         '_permissions',
         '_state',
         '_session',


### PR DESCRIPTION
## Summary

* Fix docs for `client` and `bot` in `nextcord.Interaction`

## Changes

client is documented as a property so should not be in attributes

bot never existed as an attribute so should not be in the documentation

_client does not exist as an attribute so should not be in slots

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
