### PR TITLE
fix: Support leaving out interaction in numpy docstring

### DIFF
--- a/nextcord/utils.py
+++ b/nextcord/utils.py
@@ -1038,9 +1038,9 @@ def format_dt(dt: datetime.datetime, /, style: Optional[TimestampStyle] = None) 
 
 _FUNCTION_DESCRIPTION_REGEX = re.compile(r"\A(?:.|\n)+?(?=\Z|\r?\n\r?\n)", re.MULTILINE)
 
-_ARG_NAME_SUBREGEX = r"(\\?\*)*(?P<name>[^\s:]+)"
+_ARG_NAME_SUBREGEX = r"(?:\\?\*)*(?P<name>[^\s:\-]+)"
 
-_ARG_DESCRIPTION_SUBREGEX = r"(?P<description>(.|\n)+?(\Z|\r?\n(?=[\S\r\n])))"
+_ARG_DESCRIPTION_SUBREGEX = r"(?P<description>(?:.|\n)+?(?:\Z|\r?\n(?=[\S\r\n])))"
 
 _ARG_TYPE_SUBREGEX = r"(?P<type>.+)"
 
@@ -1055,7 +1055,7 @@ _SPHINX_DOCSTRING_ARG_REGEX = re.compile(
 )
 
 _NUMPY_DOCSTRING_ARG_REGEX = re.compile(
-    rf"^{_ARG_NAME_SUBREGEX}(?:[ \t]*:)?(?:[ \t]+{_ARG_TYPE_SUBREGEX})?[ \t]*\r?\n[ \t]*{_ARG_DESCRIPTION_SUBREGEX}",
+    rf"^{_ARG_NAME_SUBREGEX}(?:[ \t]*:)?(?:[ \t]+{_ARG_TYPE_SUBREGEX})?[ \t]*\r?\n[ \t]+{_ARG_DESCRIPTION_SUBREGEX}",
     re.MULTILINE
 )
 


### PR DESCRIPTION
## Summary

Supports more types of docstring styles for automatic slash argument descriptions.

* Ensures that descriptions in numpy docstrings have at least one space preceding them
* Adds more non-capturing group markers to places where the groups are unused

This fixes an issue where arguments following a line containing `----------` would not get matched.

## Examples

Before this change, if using Numpy-style docstrings, you would need a new line or documentation for `interaction` to appear before the first slash argument's documentation, for example:

```py
@client.slash_command(guild_ids=[TESTING_GUILD_ID])
async def numpy_rst_echo(interaction: Interaction, my_arg: str, my_second_arg: str):
    """NUMPY RST Repeats your messages that you send as arguments

    Parameters
    ----------
    interaction: :class:`nextcord.Interaction`
        Interaction object
    my_arg: :class:`str`
        The first message to repeat. This
        argument is required.
    my_second_arg: :class:`str`
        The second message to repeat.
        This argument is required.
    """
    ...
```

This change allows you to leave out the interaction documentation, for example:

```py
@client.slash_command(guild_ids=[TESTING_GUILD_ID])
async def numpy_rst_echo_2(interaction: Interaction, my_arg: str, my_second_arg: str):
    """NUMPY RST Repeats your messages that you send as arguments

    Parameters
    ----------
    my_arg: :class:`str`
        The first message to repeat. This
        argument is required.
    my_second_arg: :class:`str`
        The second message to repeat.
        This argument is required.
    """
    ...
```

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
