### PR TITLE
fix: Add context_menu_command to is_system

### DIFF
--- a/docs/migrating_2.rst
+++ b/docs/migrating_2.rst
@@ -341,11 +341,6 @@ Sticker.tags
 ^^^^^^^^^^^^^^^^^^^^^^^
 Due to the introduction of :class:`GuildSticker`, ``Sticker.tags`` is removed from the parent class :class:`Sticker` and moved to :attr:`StandardSticker.tags`.
 
-MessageType.application_command
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-This was renamed to :attr:`MessageType.chat_input_command` due to Discord adding context menu commands.
-
-
 Meta Change
 -----------------------
 

--- a/nextcord/message.py
+++ b/nextcord/message.py
@@ -1018,6 +1018,7 @@ class Message(Hashable):
             MessageType.default,
             MessageType.reply,
             MessageType.chat_input_command,
+            MessageType.context_menu_command,
             MessageType.thread_starter_message,
         )
 


### PR DESCRIPTION
## Summary

* As `context_menu_command` is a system message (just as much as `chat_input_command` is), it should be checked in `is_system()`
* The change from `application_command` to `chat_input_command` does not belong in migrating to 2.0 as it is not a change between 1.7.3 and 2.0 (`application_command` did not exist before 2.0)

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
