### PR TITLE
feat: to_file for assets, emojis, and stickers

### DIFF
--- a/nextcord/asset.py
+++ b/nextcord/asset.py
@@ -131,6 +131,10 @@ class AssetMixin:
 
         Raises
         ------
+        DiscordException
+            The asset does not have an associated state.
+        TypeError
+            The asset is a sticker with lottie type.
         HTTPException
             Downloading the asset failed.
         Forbidden
@@ -146,7 +150,7 @@ class AssetMixin:
 
         data = await self.read()
         url = yarl.URL(self.url)
-        filename = url.path.split('/')[-1]
+        _, _, filename = url.path.rpartition('/')
         return File(io.BytesIO(data), filename=filename, spoiler=spoiler)
 
 


### PR DESCRIPTION
## Summary

* Adds `to_file` to all objects that use `AssetMixin` (`Asset`, `Emoji`, `PartialEmoji`, `Sticker`)

## Example code

```py
@bot.command()
async def avatar_file(ctx: commands.Context[commands.Bot]):
    file = await ctx.author.display_avatar.to_file()
    await ctx.send(file=file)

@bot.command()
async def emoji_file(ctx: commands.Context[commands.Bot], emoji: nextcord.Emoji):
    file = await emoji.to_file()
    await ctx.send(file=file)

@bot.command()
async def partial_emoji_file(ctx: commands.Context[commands.Bot], partial_emoji: nextcord.PartialEmoji):
    file = await partial_emoji.to_file()
    await ctx.send(file=file)

@bot.command()
async def sticker_file(ctx: commands.Context[commands.Bot], message_id: int):
    msg = await ctx.channel.fetch_message(message_id)
    file = await msg.stickers[0].to_file()
    await ctx.send(file=file)
```

This feature was lightly discussed [on dpy Discord](https://canary.discord.com/channels/336642139381301249/603069307286454290/958918196021313596). The idea comes from VJ#5945.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
