### PR TITLE
feat!: update bans to use Async Iterator and pagination

### DIFF
--- a/docs/migrating_2.rst
+++ b/docs/migrating_2.rst
@@ -271,7 +271,8 @@ Guild.bans now returns an AsyncIterator
     bans = await guild.bans()
 
     # now
-    bans = await guild.bans().flatten()
+    bans = await guild.bans().flatten()  # get a list of the first 1000 bans
+    bans = await guild.bans(limit=None).flatten()  # get a list of all bans
 
 Removals
 -----------------------

--- a/docs/migrating_2.rst
+++ b/docs/migrating_2.rst
@@ -29,6 +29,7 @@ Overview
 - ``missing_perms`` attributes and arguments are renamed to ``missing_permissions``.
 - Many method arguments now reject ``None``.
 - Many arguments are now specified as positional-only or keyword-only; e.g. :func:`oauth_url` now takes keyword-only arguments, and methods starting with ``get_`` or ``fetch_`` take positional-only arguments.
+- :meth:`Guild.bans` is no longer a coroutine and returns an :class:`~nextcord.AsyncIterator` instead of a :class:`list`.
 
 Changes
 -----------------------
@@ -258,6 +259,19 @@ on_socket_raw_receive behavior
 Guild.get_member taking positional only argument
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 :meth:`Guild.get_member` method's first argument is now positional only.
+
+Guild.bans now returns an AsyncIterator
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+:meth:`Guild.bans` returns an :class:`~nextcord.AsyncIterator` instead of a :class:`list`.
+
+.. code-block:: python3
+
+    # before
+    bans = await guild.bans()
+
+    # now
+    bans = await guild.bans().flatten()
 
 Removals
 -----------------------

--- a/nextcord/__init__.py
+++ b/nextcord/__init__.py
@@ -23,6 +23,7 @@ from typing import NamedTuple, Literal
 
 from .client import *
 from .appinfo import *
+from .bans import *
 from .user import *
 from .emoji import *
 from .partial_emoji import *

--- a/nextcord/bans.py
+++ b/nextcord/bans.py
@@ -1,0 +1,37 @@
+"""
+The MIT License (MIT)
+
+Copyright (c) 2022-present tag-epic
+
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of this software and associated documentation files (the "Software"),
+to deal in the Software without restriction, including without limitation
+the rights to use, copy, modify, merge, publish, distribute, sublicense,
+and/or sell copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, NamedTuple, Optional
+
+__all__ = ("BanEntry",)
+
+if TYPE_CHECKING:
+    from .user import User
+
+
+class BanEntry(NamedTuple):
+    reason: Optional[str]
+    user: "User"

--- a/nextcord/guild.py
+++ b/nextcord/guild.py
@@ -1878,13 +1878,16 @@ class Guild(Hashable):
 
     def bans(self,
         *,
-        limit: Optional[int] = None,
-        before: Optional[SnowflakeTime] = None,
-        after: Optional[SnowflakeTime] = None,
+        limit: Optional[int] = 1000,
+        before: Optional[Snowflake] = None,
+        after: Optional[Snowflake] = None,
     ) -> BanIterator:
         """Returns an :class:`~nextcord.AsyncIterator` that enables receiving the destination's bans.
 
         You must have the :attr:`~Permissions.ban_members` permission to get this information.
+
+        .. versionchanged:: 2.0
+            Due to a breaking change in Discord's API, this now returns an :class:`~nextcord.AsyncIterator` instead of a :class:`list`.
 
         Examples
         ---------
@@ -1906,15 +1909,14 @@ class Guild(Hashable):
         Parameters
         -----------
         limit: Optional[:class:`int`]
-            The number of bans to retrieve (up to maximum 1000). Defaults to 1000.
-        before: Optional[Union[:class:`~nextcord.abc.Snowflake`, :class:`datetime.datetime`]]
-            Retrieve bans before this date or user (by id).
-            If a datetime is provided, it is recommended to use a UTC aware datetime.
-            If the datetime is naive, it is assumed to be local time.
-        after: Optional[Union[:class:`~nextcord.abc.Snowflake`, :class:`datetime.datetime`]]
-            Retrieve bans after this date or user (by id).
-            If a datetime is provided, it is recommended to use a UTC aware datetime.
-            If the datetime is naive, it is assumed to be local time.
+            The number of bans to retrieve.
+            If ``None``, it retrieves every ban in the guild. Note, however,
+            that this would make a slow operation.
+            Defaults to 1000.
+        before: Optional[:class:`~nextcord.abc.Snowflake`]
+            Retrieve bans before this user.
+        after: Optional[:class:`~nextcord.abc.Snowflake`]
+            Retrieve bans after this user.
 
         Raises
         ------

--- a/nextcord/guild.py
+++ b/nextcord/guild.py
@@ -1908,11 +1908,11 @@ class Guild(Hashable):
         limit: Optional[:class:`int`]
             The number of bans to retrieve (up to maximum 1000). Defaults to 1000.
         before: Optional[Union[:class:`~nextcord.abc.Snowflake`, :class:`datetime.datetime`]]
-            Retrieve bans before this date or user id.
+            Retrieve bans before this date or user (by id).
             If a datetime is provided, it is recommended to use a UTC aware datetime.
             If the datetime is naive, it is assumed to be local time.
         after: Optional[Union[:class:`~nextcord.abc.Snowflake`, :class:`datetime.datetime`]]
-            Retrieve bans after this date or user id.
+            Retrieve bans after this date or user (by id).
             If a datetime is provided, it is recommended to use a UTC aware datetime.
             If the datetime is naive, it is assumed to be local time.
 

--- a/nextcord/guild.py
+++ b/nextcord/guild.py
@@ -45,6 +45,7 @@ from typing import (
 
 from . import abc, utils
 from .asset import Asset
+from .bans import BanEntry
 from .channel import *
 from .channel import _guild_channel_factory, _threaded_guild_channel_factory
 from .colour import Colour
@@ -67,7 +68,7 @@ from .file import File
 from .flags import SystemChannelFlags
 from .integrations import Integration, _integration_factory
 from .invite import Invite
-from .iterators import AuditLogIterator, MemberIterator, ScheduledEventIterator
+from .iterators import AuditLogIterator, MemberIterator, BanIterator, ScheduledEventIterator
 from .member import Member, VoiceState
 from .mixins import Hashable
 from .permissions import PermissionOverwrite
@@ -116,11 +117,6 @@ if TYPE_CHECKING:
     VocalGuildChannel = Union[VoiceChannel, StageChannel]
     GuildChannel = Union[VoiceChannel, StageChannel, TextChannel, CategoryChannel, StoreChannel]
     ByCategoryItem = Tuple[Optional[CategoryChannel], List[GuildChannel]]
-
-
-class BanEntry(NamedTuple):
-    reason: Optional[str]
-    user: User
 
 
 class _GuildLimit(NamedTuple):
@@ -1880,29 +1876,71 @@ class Guild(Hashable):
         channel: GuildChannel = factory(guild=self, state=self._state, data=data)  # type: ignore
         return channel
 
-    async def bans(self) -> List[BanEntry]:
-        """|coro|
+    def bans(self,
+        *,
+        limit: Optional[int] = 1000,
+        before: Optional[SnowflakeTime] = None,
+        after: Optional[SnowflakeTime] = None,
+        around: Optional[SnowflakeTime] = None,
+        oldest_first: Optional[bool] = None,
+    ) -> BanIterator:
+        """Returns an :class:`~nextcord.AsyncIterator` that enables receiving the destination's bans.
 
-        Retrieves all the users that are banned from the guild as a :class:`list` of :class:`BanEntry`.
+        You must have the :attr:`~Permissions.ban_members` permission to get this information.
 
-        You must have the :attr:`~Permissions.ban_members` permission
-        to get this information.
+        Examples
+        ---------
+
+        Usage ::
+
+            counter = 0
+            async for ban in guild.bans(limit=200):
+                if not ban.user.bot:
+                    counter += 1
+
+        Flattening into a list: ::
+
+            bans = await guild.bans(limit=123).flatten()
+            # bans is now a list of BanEntry...
+
+        All parameters are optional.
+
+        Parameters
+        -----------
+        limit: :class:`int`
+            The number of bans to retrieve (up to maximum 1000).
+        before: Optional[Union[:class:`~nextcord.abc.Snowflake`, :class:`datetime.datetime`]]
+            Retrieve bans before this date or user id.
+            If a datetime is provided, it is recommended to use a UTC aware datetime.
+            If the datetime is naive, it is assumed to be local time.
+        after: Optional[Union[:class:`~nextcord.abc.Snowflake`, :class:`datetime.datetime`]]
+            Retrieve bans after this date or user id.
+            If a datetime is provided, it is recommended to use a UTC aware datetime.
+            If the datetime is naive, it is assumed to be local time.
+        around: Optional[Union[:class:`~nextcord.abc.Snowflake`, :class:`datetime.datetime`]]
+            Retrieve bans around this date or user id.
+            If a datetime is provided, it is recommended to use a UTC aware datetime.
+            If the datetime is naive, it is assumed to be local time.
+            When using this argument, the maximum limit is 101. Note that if the limit is an
+            even number then this will return at most limit + 1 bans.
+        oldest_first: Optional[:class:`bool`]
+            If set to ``True``, return bans in oldest->newest order. Defaults to ``True`` if
+            ``after`` is specified, otherwise ``False``.
 
         Raises
-        -------
-        Forbidden
-            You do not have proper permissions to get the information.
-        HTTPException
-            An error occurred while fetching the information.
+        ------
+        ~nextcord.Forbidden
+            You do not have permissions to get the bans.
+        ~nextcord.HTTPException
+            An error occurred while fetching the bans.
 
-        Returns
-        --------
-        List[:class:`BanEntry`]
-            A list of :class:`BanEntry` objects.
+        Yields
+        -------
+        :class:`~nextcord.BanEntry`
+            The ban with the ban data parsed.
         """
 
-        data: List[BanPayload] = await self._state.http.get_bans(self.id)
-        return [BanEntry(user=User(state=self._state, data=e['user']), reason=e['reason']) for e in data]
+        return BanIterator(self, limit=limit, before=before, after=after, around=around, oldest_first=oldest_first)
 
     async def prune_members(
         self,

--- a/nextcord/guild.py
+++ b/nextcord/guild.py
@@ -1878,11 +1878,9 @@ class Guild(Hashable):
 
     def bans(self,
         *,
-        limit: Optional[int] = 1000,
+        limit: Optional[int] = None,
         before: Optional[SnowflakeTime] = None,
         after: Optional[SnowflakeTime] = None,
-        around: Optional[SnowflakeTime] = None,
-        oldest_first: Optional[bool] = None,
     ) -> BanIterator:
         """Returns an :class:`~nextcord.AsyncIterator` that enables receiving the destination's bans.
 
@@ -1907,8 +1905,8 @@ class Guild(Hashable):
 
         Parameters
         -----------
-        limit: :class:`int`
-            The number of bans to retrieve (up to maximum 1000).
+        limit: Optional[:class:`int`]
+            The number of bans to retrieve (up to maximum 1000). Defaults to 1000.
         before: Optional[Union[:class:`~nextcord.abc.Snowflake`, :class:`datetime.datetime`]]
             Retrieve bans before this date or user id.
             If a datetime is provided, it is recommended to use a UTC aware datetime.
@@ -1917,15 +1915,6 @@ class Guild(Hashable):
             Retrieve bans after this date or user id.
             If a datetime is provided, it is recommended to use a UTC aware datetime.
             If the datetime is naive, it is assumed to be local time.
-        around: Optional[Union[:class:`~nextcord.abc.Snowflake`, :class:`datetime.datetime`]]
-            Retrieve bans around this date or user id.
-            If a datetime is provided, it is recommended to use a UTC aware datetime.
-            If the datetime is naive, it is assumed to be local time.
-            When using this argument, the maximum limit is 101. Note that if the limit is an
-            even number then this will return at most limit + 1 bans.
-        oldest_first: Optional[:class:`bool`]
-            If set to ``True``, return bans in oldest->newest order. Defaults to ``True`` if
-            ``after`` is specified, otherwise ``False``.
 
         Raises
         ------
@@ -1940,7 +1929,7 @@ class Guild(Hashable):
             The ban with the ban data parsed.
         """
 
-        return BanIterator(self, limit=limit, before=before, after=after, around=around, oldest_first=oldest_first)
+        return BanIterator(self, limit=limit, before=before, after=after)
 
     async def prune_members(
         self,

--- a/nextcord/http.py
+++ b/nextcord/http.py
@@ -1128,21 +1128,18 @@ class HTTPClient:
     def get_bans(
         self,
         guild_id: Snowflake,
-        limit: int,
+        limit: Optional[int] = None,
         before: Optional[Snowflake] = None,
         after: Optional[Snowflake] = None,
-        around: Optional[Snowflake] = None,
     ) -> Response[List[guild.Ban]]:
-        params: Dict[str, Any] = {
-            'limit': limit,
-        }
+        params: Dict[str, Any] = {}
 
+        if limit is not None:
+            params['limit'] = limit
         if before is not None:
             params['before'] = before
         if after is not None:
             params['after'] = after
-        if around is not None:
-            params['around'] = around
 
         return self.request(Route("GET", "/guilds/{guild_id}/bans", guild_id=guild_id), params=params)
 

--- a/nextcord/http.py
+++ b/nextcord/http.py
@@ -1125,8 +1125,26 @@ class HTTPClient:
             payload['icon'] = icon
         return self.request(Route('POST', '/guilds/templates/{code}', code=code), json=payload)
 
-    def get_bans(self, guild_id: Snowflake) -> Response[List[guild.Ban]]:
-        return self.request(Route('GET', '/guilds/{guild_id}/bans', guild_id=guild_id))
+    def get_bans(
+        self,
+        guild_id: Snowflake,
+        limit: int,
+        before: Optional[Snowflake] = None,
+        after: Optional[Snowflake] = None,
+        around: Optional[Snowflake] = None,
+    ) -> Response[List[guild.Ban]]:
+        params: Dict[str, Any] = {
+            'limit': limit,
+        }
+
+        if before is not None:
+            params['before'] = before
+        if after is not None:
+            params['after'] = after
+        if around is not None:
+            params['around'] = around
+
+        return self.request(Route("GET", "/guilds/{guild_id}/bans", guild_id=guild_id), params=params)
 
     def get_ban(self, user_id: Snowflake, guild_id: Snowflake) -> Response[guild.Ban]:
         return self.request(Route('GET', '/guilds/{guild_id}/bans/{user_id}', guild_id=guild_id, user_id=user_id))

--- a/nextcord/iterators.py
+++ b/nextcord/iterators.py
@@ -52,6 +52,7 @@ if TYPE_CHECKING:
     )
     from .types.guild import (
         Guild as GuildPayload,
+        Ban as BanPayload,
     )
     from .types.message import (
         Message as MessagePayload,
@@ -400,62 +401,44 @@ class BanIterator(_AsyncIterator['BanEntry']):
     """Iterator for receiving a guild's bans.
 
     The bans endpoint has two behaviours we care about here:
-    If ``before`` is specified, the bans endpoint returns the `limit`
-    newest bans before ``before``, sorted with newest first. For filling over
-    1000 bans, update the ``before`` parameter to the oldest ban received.
-    Bans will be returned in order by time.
-    If ``after`` is specified, it returns the ``limit`` oldest bans after
-    ``after``, sorted with newest first. For filling over 100 bans, update the
-    ``after`` parameter to the newest ban received. If bans are not
-    reversed, they will be out of order (999-0, 1999-1000, so on)
+    If ``before`` is specified, the bans endpoint returns the ``limit``
+    bans with user ids before ``before``, sorted with smallest first. For filling over
+    1000 bans, update the ``before`` parameter to the largest user id received.
+    If ``after`` is specified, it returns the ``limit`` bans with user ids after
+    ``after``, sorted with smallest first. For filling over 1000 bans, update the
+    ``after`` parameter to the smallest user id received.
 
-    A note that if both ``before`` and ``after`` are specified, ``before`` is ignored by the
+    A note that if both ``before`` and ``after`` are specified, ``after`` is ignored by the
     bans endpoint.
 
     Parameters
     -----------
     guild: :class:`~nextcord.Guild`
         The guild to get bans from.
-    limit: :class:`int`
-        Maximum number of bans to retrieve
+    limit: Optional[:class:`int`]
+        Maximum number of bans to retrieve.
     before: Optional[Union[:class:`abc.Snowflake`, :class:`datetime.datetime`]]
         Date or user id before which all bans must be.
     after: Optional[Union[:class:`abc.Snowflake`, :class:`datetime.datetime`]]
         Date or user id after which all bans must be.
-    around: Optional[Union[:class:`abc.Snowflake`, :class:`datetime.datetime`]]
-        Date or user id around which all bans must be. Limit max 1001. Note that if
-        limit is an even number, this will return at most limit+1 bans.
-    oldest_first: Optional[:class:`bool`]
-        If set to ``True``, return bans in oldest->newest order. Defaults to
-        ``True`` if `after` is specified, otherwise ``False``.
     """
 
     def __init__(
         self,
         guild: Guild,
-        limit: int,
+        limit: Optional[int] = None,
         before: Optional[Union[Snowflake, datetime.datetime]] = None,
         after: Optional[Union[Snowflake, datetime.datetime]] = None,
-        around: Optional[Union[Snowflake, datetime.datetime]] = None,
-        oldest_first: bool = None,
     ):
         if isinstance(before, datetime.datetime):
             before = Object(id=time_snowflake(before, high=False))
         if isinstance(after, datetime.datetime):
             after = Object(id=time_snowflake(after, high=True))
-        if isinstance(around, datetime.datetime):
-            around = Object(id=time_snowflake(around))
-
-        if oldest_first is None:
-            self.reverse = after is not None
-        else:
-            self.reverse = oldest_first
 
         self.guild = guild
         self.limit = limit
         self.before = before
         self.after = after or OLDEST_OBJECT
-        self.around = around
 
         self._filter = None  # ban dict -> bool
 
@@ -463,30 +446,9 @@ class BanIterator(_AsyncIterator['BanEntry']):
         self.get_bans = self.state.http.get_bans
         self.bans = asyncio.Queue()
 
-        if self.around:
-            if self.limit is None:
-                raise ValueError('history does not support around with limit=None')
-            if self.limit > 1001:
-                raise ValueError("history max limit 1001 when specifying around parameter")
-            elif self.limit == 1001:
-                self.limit = 1000  # Thanks discord
-
-            self._retrieve_bans = self._retrieve_bans_around_strategy  # type: ignore
-            if self.before and self.after:
-                self._filter = lambda b: self.after.id < int(b['user']['id']) < self.before.id
-            elif self.before:
-                self._filter = lambda b: int(b['user']['id']) < self.before.id
-            elif self.after:
-                self._filter = lambda b: self.after.id < int(b['user']['id'])
-        else:
-            if self.reverse:
-                self._retrieve_bans = self._retrieve_bans_after_strategy  # type: ignore
-                if self.before:
-                    self._filter = lambda b: int(b['user']['id']) < self.before.id
-            else:
-                self._retrieve_bans = self._retrieve_bans_before_strategy  # type: ignore
-                if self.after and self.after != OLDEST_OBJECT:
-                    self._filter = lambda b: int(b['user']['id']) > self.after.id
+        self._retrieve_bans = self._retrieve_bans_before_strategy  # type: ignore
+        if self.after and self.after != OLDEST_OBJECT:
+            self._filter = lambda b: int(b['user']['id']) > self.after.id
 
     async def next(self) -> BanEntry:
         if self.bans.empty():
@@ -498,62 +460,51 @@ class BanIterator(_AsyncIterator['BanEntry']):
             raise NoMoreItems()
 
     def _get_retrieve(self):
-        l = self.limit
-        if l is None or l > 1000:
-            r = 1000
+        limit = self.limit
+        if limit is not None and limit > 1000:
+            retrieve = 1000
         else:
-            r = l
-        self.retrieve = r
-        return r > 0
+            retrieve = limit
+        self.retrieve = retrieve
+        return retrieve > 0
 
     async def fill_bans(self):
         from .user import User
-        
+
         if self._get_retrieve():
             data = await self._retrieve_bans(self.retrieve)
             if len(data) < 1000:
                 self.limit = 0  # terminate the infinite loop
 
-            if self.reverse:
-                data = reversed(data)
             if self._filter:
                 data = filter(self._filter, data)
 
-            for e in data:
-                await self.bans.put(BanEntry(user=User(state=self.guild._state, data=e['user']), reason=e['reason']))
+            for element in data:
+                await self.bans.put(BanEntry(user=User(state=self.guild._state, data=element['user']), reason=element['reason']))
 
-    async def _retrieve_bans(self, retrieve) -> List[BanEntry]:
-        """Retrieve messages and update next parameters."""
+    async def _retrieve_bans(self, retrieve: Optional[int]) -> List[BanEntry]:
+        """Retrieve bans and update next parameters."""
         raise NotImplementedError
 
-    async def _retrieve_bans_before_strategy(self, retrieve):
-        """Retrieve messages using before parameter."""
+    async def _retrieve_bans_before_strategy(self, retrieve: Optional[int]) -> List[BanEntry]:
+        """Retrieve bans using before parameter."""
         before = self.before.id if self.before else None
-        data: List[MessagePayload] = await self.get_bans(self.guild.id, retrieve, before=before)
+        data: List[BanPayload] = await self.get_bans(self.guild.id, retrieve, before=before)
         if len(data):
             if self.limit is not None:
                 self.limit -= retrieve
             self.before = Object(id=int(data[-1]['user']['id']))
         return data
 
-    async def _retrieve_bans_after_strategy(self, retrieve):
-        """Retrieve messages using after parameter."""
+    async def _retrieve_bans_after_strategy(self, retrieve: Optional[int]) -> List[BanEntry]:
+        """Retrieve bans using after parameter."""
         after = self.after.id if self.after else None
-        data: List[MessagePayload] = await self.get_bans(self.guild.id, retrieve, after=after)
+        data: List[BanPayload] = await self.get_bans(self.guild.id, retrieve, after=after)
         if len(data):
             if self.limit is not None:
                 self.limit -= retrieve
             self.after = Object(id=int(data[0]['user']['id']))
         return data
-
-    async def _retrieve_bans_around_strategy(self, retrieve):
-        """Retrieve messages using around parameter."""
-        if self.around:
-            around = self.around.id if self.around else None
-            data: List[MessagePayload] = await self.get_bans(self.guild.id, retrieve, around=around)
-            self.around = None
-            return data
-        return []
 
 
 class AuditLogIterator(_AsyncIterator['AuditLogEntry']):

--- a/nextcord/iterators.py
+++ b/nextcord/iterators.py
@@ -476,7 +476,7 @@ class BanIterator(_AsyncIterator['BanEntry']):
             for element in data:
                 await self.bans.put(BanEntry(user=User(state=self.guild._state, data=element['user']), reason=element['reason']))
 
-    async def _retrieve_bans(self, retrieve: Optional[int]) -> List[BanEntry]:
+    async def _retrieve_bans(self, retrieve: Optional[int]) -> List[BanPayload]:
         """Retrieve bans using before parameter."""
         if retrieve == 0:
             return []

--- a/nextcord/iterators.py
+++ b/nextcord/iterators.py
@@ -507,6 +507,8 @@ class BanIterator(_AsyncIterator['BanEntry']):
         return r > 0
 
     async def fill_bans(self):
+        from .user import User
+        
         if self._get_retrieve():
             data = await self._retrieve_bans(self.retrieve)
             if len(data) < 1000:


### PR DESCRIPTION
## Summary

https://discord.com/developers/docs/resources/guild#get-guild-bans

## Breaking changes

`Guild.bans` is no longer a coroutine and returns an AsyncIterator of bans instead of a list.

```py
# before
bans = await guild.bans()

# now
bans = await guild.bans().flatten()  # get the default (first 1000) bans
bans = await guild.bans(limit=None).flatten()  # get all bans
```

More examples:

https://paste.nextcord.dev/?id=1648770287939285

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [x] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
