### PR TITLE
Add check_all function to application_checks

### DIFF
--- a/nextcord/ext/application_checks/core.py
+++ b/nextcord/ext/application_checks/core.py
@@ -303,8 +303,8 @@ def check_all(*checks: "ApplicationCheck") -> Callable[[T], T]:
         for func in unwrapped:
             try:
                 value = await func(interaction)
-            except:
-                raise
+            except ApplicationCheckFailure:
+                raise ApplicationCheckAllFailure from ApplicationCheckFailure
             if value:
                 return True
 

--- a/nextcord/ext/application_checks/core.py
+++ b/nextcord/ext/application_checks/core.py
@@ -296,22 +296,17 @@ def check_all(*checks: "ApplicationCheck") -> Callable[[T], T]:
             raise TypeError(
                 f"{wrapped!r} must be wrapped by application_checks.check decorator"
             ) from None
-        else:
-            unwrapped.append(pred)
+
+        unwrapped.append(pred)
 
     async def predicate(interaction: Interaction) -> bool:
         for func in unwrapped:
             try:
                 value = await func(interaction)
-            except ApplicationCheckFailure as e:
-                raise ApplicationCheckAllFailure(
-                    f"The checks for every check in check_all failed"
-                ) from None
-            else:
-                if value:
-                    return True
-        # if we're here, all checks failed
-        raise ApplicationCheckAllFailure(unwrapped, errors)
+            except:
+                raise
+            if value:
+                return True
 
     return check(predicate)
 

--- a/nextcord/ext/application_checks/errors.py
+++ b/nextcord/ext/application_checks/errors.py
@@ -38,6 +38,7 @@ from nextcord.threads import Thread
 
 __all__ = (
     "ApplicationCheckAnyFailure",
+    "ApplicationCheckAllFailure",
     "ApplicationNoPrivateMessage",
     "ApplicationMissingRole",
     "ApplicationMissingAnyRole",
@@ -49,9 +50,8 @@ __all__ = (
     "ApplicationNotOwner",
     "ApplicationNSFWChannelRequired",
     "ApplicationCheckForBotOnly",
-)
-
-
+)       
+        
 class ApplicationCheckAnyFailure(ApplicationCheckFailure):
     """Exception raised when all predicates in :func:`check_any` fail.
 
@@ -73,7 +73,17 @@ class ApplicationCheckAnyFailure(ApplicationCheckFailure):
         self.checks: List[ApplicationCheckFailure] = checks
         self.errors: List[Callable[[Interaction], bool]] = errors
         super().__init__("You do not have permission to run this command.")
+        
+class ApplicationCheckAllFailure(ApplicationCheckFailure):
+    """Exception raised when at least 1 predicate in :func:`check_all` fails.
 
+    This inherits from :exc:`~.ApplicationCheckFailure`.
+    """
+
+    def __init__(
+        self,
+    ) -> None:
+        super().__init__("You do not have permission to run this command.")
 
 class ApplicationNoPrivateMessage(ApplicationCheckFailure):
     """Exception raised when an operation does not work in private message


### PR DESCRIPTION
## Summary

This PR adds "check_all" function to nextcord.ext.application_checks
to make code slightly "nicer"?
How it works, is you can use check_all like:
```py
def guild_owner_only():
  def predicate(interaction: Interaction):
     return interaction.user == interaction.guild.owner
  return application_checks.check(predicate)

@client.slash_command()
@application_checks.check_all(
  guild_owner_only(),
  application_checks.is_owner()
)
async def owner_only(interaction: Interaction):
  await interaction.send("I know you, mister!")
```
You make a check (or not, just 2 or more checks together) so you can put it in check_all!
or you can do something like this as I said:
```py
@client.slash_command()
@application_checks.check_all(
  application_checks.bot_has_permissions(manage_messages=True),
  application_checks.has_permissions(manage_messages=True)
)
async def with_perms_only(interaction: Interaction):
  await interaction.send("We're both worthy of managing messages!")
```
## Checklist

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
