### PR TITLE
feat: Make send return a PartialInteractionMessage

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -3696,6 +3696,10 @@ InteractionMessage
 .. autoclass:: InteractionMessage()
     :members:
 
+    .. automethod:: InteractionMessage.edit
+
+    .. automethod:: InteractionMessage.delete
+
 PartialInteractionMessage
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -3696,9 +3696,9 @@ InteractionMessage
 .. autoclass:: InteractionMessage()
     :members:
 
-    .. automethod:: InteractionMessage.edit
-
     .. automethod:: InteractionMessage.delete
+
+    .. automethod:: InteractionMessage.edit
 
 PartialInteractionMessage
 ~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -3703,6 +3703,7 @@ PartialInteractionMessage
 
 .. autoclass:: PartialInteractionMessage()
     :members:
+    :inherited-members:
 
 Member
 ~~~~~~

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -3695,10 +3695,7 @@ InteractionMessage
 
 .. autoclass:: InteractionMessage()
     :members:
-
-    .. automethod:: InteractionMessage.delete
-
-    .. automethod:: InteractionMessage.edit
+    :inherited-members:
 
 PartialInteractionMessage
 ~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -3696,6 +3696,14 @@ InteractionMessage
 .. autoclass:: InteractionMessage()
     :members:
 
+PartialInteractionMessage
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. attributetable:: PartialInteractionMessage
+
+.. autoclass:: PartialInteractionMessage()
+    :members:
+
 Member
 ~~~~~~
 

--- a/nextcord/interactions.py
+++ b/nextcord/interactions.py
@@ -1174,6 +1174,9 @@ class PartialInteractionMessage(_InteractionMessageBase):
         """Optional[:class:`Guild`]: The guild the interaction was sent from."""
         return self._state._interaction.guild
 
+    def __repr__(self):
+        return f"<{self.__class__.__name__} author={self.author!r} channel={self.channel!r} guild={self.guild!r}>"
+
 
 class InteractionMessage(_InteractionMessageBase, Message):
     """Represents the original interaction response message.
@@ -1182,7 +1185,7 @@ class InteractionMessage(_InteractionMessageBase, Message):
     or :meth:`Interaction.original_message`.
 
     This inherits from :class:`nextcord.Message` with changes to
-    :meth:`edit` and :meth:`delete`.
+    :meth:`edit` and :meth:`delete` to work with the interaction response.
 
     .. versionadded:: 2.0
     """

--- a/nextcord/interactions.py
+++ b/nextcord/interactions.py
@@ -41,7 +41,7 @@ from .channel import PartialMessageable, ChannelType
 
 from .file import File
 from .embeds import Embed
-from .user import User
+from .user import ClientUser, User
 from .mixins import Hashable
 from .member import Member
 from .message import Message, Attachment
@@ -1154,6 +1154,35 @@ class PartialInteractionMessage(_InteractionMessageBase):
             The message.
         """
         return await self._state._interaction.original_message()
+
+    @property
+    def channel(self) -> Optional[InteractionChannel]:
+        """Optional[Union[:class:`abc.GuildChannel`, :class:`PartialMessageable`, :class:`Thread`]]: The channel the interaction was sent from.
+
+        Note that due to a Discord limitation, DM channels are not resolved since there is
+        no data to complete them. These are :class:`PartialMessageable` instead.
+        """
+        return self._state._interaction.channel
+
+    @property
+    def channel_id(self) -> Optional[int]:
+        """Optional[:class:`int`]: The ID of the channel the interaction was sent from."""
+        return self._state._interaction.channel_id
+
+    @property
+    def author(self) -> Optional[ClientUser]:
+        """Optional[:class:`ClientUser`]: The client user that responded to the interaction."""
+        return self._state._interaction.client.user
+
+    @property
+    def guild(self) -> Optional[Guild]:
+        """Optional[:class:`Guild`]: The guild the interaction was sent from."""
+        return self._state._interaction.guild
+
+    @property
+    def guild_id(self) -> Optional[int]:
+        """Optional[:class:`int`]: The ID of the guild the interaction was sent from."""
+        return self._state._interaction.guild_id
 
 
 class InteractionMessage(_InteractionMessageBase, Message):

--- a/nextcord/interactions.py
+++ b/nextcord/interactions.py
@@ -1156,9 +1156,13 @@ class PartialInteractionMessage(_InteractionMessageMixin, Hashable):
         return await self._state._interaction.original_message()
 
     @property
-    def author(self) -> Optional[ClientUser]:
-        """Optional[:class:`ClientUser`]: The client user that responded to the interaction."""
-        return self._state._interaction.client.user
+    def author(self) -> Optional[Union[Member, ClientUser]]:
+        """Optional[Union[:class:`Member`, :class:`ClientUser`]]: The client that responded to the interaction.
+        
+        If the interaction was in a guild, this is a :class:`Member` representing the client.
+        Otherwise, this is a :class:`ClientUser`.
+        """
+        return self.guild.me if self.guild else self._state._interaction.client.user
 
     @property
     def channel(self) -> Optional[InteractionChannel]:

--- a/nextcord/interactions.py
+++ b/nextcord/interactions.py
@@ -1137,21 +1137,21 @@ class PartialInteractionMessage(_InteractionMessageBase):
     async def fetch(self) -> InteractionMessage:
         """|coro|
 
-        Fetches the message.
+        Fetches the original interaction response message associated with the interaction.
+
+        Repeated calls to this will return a cached value.
 
         Raises
         -------
         HTTPException
-            Retrieving the message failed.
-        Forbidden
-            The message is not yours.
-        NotFound
-            The message was deleted.
+            Fetching the original response message failed.
+        ClientException
+            The channel for the message could not be resolved.
 
         Returns
         --------
-        :class:`InteractionMessage`
-            The message.
+        InteractionMessage
+            The original interaction response message.
         """
         return await self._state._interaction.original_message()
 

--- a/nextcord/interactions.py
+++ b/nextcord/interactions.py
@@ -1011,7 +1011,7 @@ class _InteractionMessageState:
         return getattr(self._parent, attr)
 
 
-class _InteractionMessageBase(Hashable):
+class _InteractionMessageMixin:
     __slots__ = ()
     _state: _InteractionMessageState
 
@@ -1116,7 +1116,7 @@ class _InteractionMessageBase(Hashable):
         await self._state._interaction.delete_original_message(delay=delay)
 
 
-class PartialInteractionMessage(_InteractionMessageBase):
+class PartialInteractionMessage(_InteractionMessageMixin, Hashable):
     """Represents the original interaction response message when only the
     application state and interaction token are available.
 
@@ -1178,7 +1178,7 @@ class PartialInteractionMessage(_InteractionMessageBase):
         return f"<{self.__class__.__name__} author={self.author!r} channel={self.channel!r} guild={self.guild!r}>"
 
 
-class InteractionMessage(_InteractionMessageBase, Message):
+class InteractionMessage(_InteractionMessageMixin, Message):
     """Represents the original interaction response message.
 
     To retrieve this object see :meth:`PartialInteractionMessage.fetch`
@@ -1189,3 +1189,4 @@ class InteractionMessage(_InteractionMessageBase, Message):
 
     .. versionadded:: 2.0
     """
+    pass

--- a/nextcord/interactions.py
+++ b/nextcord/interactions.py
@@ -1165,11 +1165,6 @@ class PartialInteractionMessage(_InteractionMessageBase):
         return self._state._interaction.channel
 
     @property
-    def channel_id(self) -> Optional[int]:
-        """Optional[:class:`int`]: The ID of the channel the interaction was sent from."""
-        return self._state._interaction.channel_id
-
-    @property
     def author(self) -> Optional[ClientUser]:
         """Optional[:class:`ClientUser`]: The client user that responded to the interaction."""
         return self._state._interaction.client.user
@@ -1178,11 +1173,6 @@ class PartialInteractionMessage(_InteractionMessageBase):
     def guild(self) -> Optional[Guild]:
         """Optional[:class:`Guild`]: The guild the interaction was sent from."""
         return self._state._interaction.guild
-
-    @property
-    def guild_id(self) -> Optional[int]:
-        """Optional[:class:`int`]: The ID of the guild the interaction was sent from."""
-        return self._state._interaction.guild_id
 
 
 class InteractionMessage(_InteractionMessageBase, Message):

--- a/nextcord/interactions.py
+++ b/nextcord/interactions.py
@@ -1124,7 +1124,7 @@ class PartialInteractionMessage(_InteractionMessageBase):
     the interaction response. This object is returned when responding to
     an interaction with :meth:`InteractionResponse.send_message`.
 
-    This does not support have most attributes and methods of :class:`nextcord.Message`.
+    This does not support most attributes and methods of :class:`nextcord.Message`.
     The :meth:`~PartialInteractionMessage.fetch` method can be used to
     retrieve the full :class:`InteractionMessage` object.
 

--- a/nextcord/interactions.py
+++ b/nextcord/interactions.py
@@ -42,6 +42,7 @@ from .channel import PartialMessageable, ChannelType
 from .file import File
 from .embeds import Embed
 from .user import User
+from .mixins import Hashable
 from .member import Member
 from .message import Message, Attachment
 from .object import Object
@@ -1010,7 +1011,7 @@ class _InteractionMessageState:
         return getattr(self._parent, attr)
 
 
-class _InteractionMessageBase:
+class _InteractionMessageBase(Hashable):
     __slots__ = ()
     _state: _InteractionMessageState
 

--- a/nextcord/interactions.py
+++ b/nextcord/interactions.py
@@ -1125,7 +1125,7 @@ class PartialInteractionMessage(_InteractionMessageBase):
     an interaction with :meth:`InteractionResponse.send_message`.
 
     This does not support have most attributes and methods of :class:`nextcord.Message`.
-    The method :meth:`~PartialInteractionMessage.fetch` can be used to
+    The :meth:`~PartialInteractionMessage.fetch` method can be used to
     retrieve the full :class:`InteractionMessage` object.
 
     .. versionadded:: 2.0
@@ -1159,8 +1159,8 @@ class PartialInteractionMessage(_InteractionMessageBase):
 class InteractionMessage(_InteractionMessageBase, Message):
     """Represents the original interaction response message.
 
-    This allows you to edit or delete the message associated with
-    the interaction response. To retrieve this object see :meth:`Interaction.original_message`.
+    To retrieve this object see :meth:`PartialInteractionMessage.fetch`
+    or :meth:`Interaction.original_message`.
 
     This inherits from :class:`nextcord.Message` with changes to
     :meth:`edit` and :meth:`delete`.

--- a/nextcord/interactions.py
+++ b/nextcord/interactions.py
@@ -1156,6 +1156,11 @@ class PartialInteractionMessage(_InteractionMessageBase):
         return await self._state._interaction.original_message()
 
     @property
+    def author(self) -> Optional[ClientUser]:
+        """Optional[:class:`ClientUser`]: The client user that responded to the interaction."""
+        return self._state._interaction.client.user
+
+    @property
     def channel(self) -> Optional[InteractionChannel]:
         """Optional[Union[:class:`abc.GuildChannel`, :class:`PartialMessageable`, :class:`Thread`]]: The channel the interaction was sent from.
 
@@ -1163,11 +1168,6 @@ class PartialInteractionMessage(_InteractionMessageBase):
         no data to complete them. These are :class:`PartialMessageable` instead.
         """
         return self._state._interaction.channel
-
-    @property
-    def author(self) -> Optional[ClientUser]:
-        """Optional[:class:`ClientUser`]: The client user that responded to the interaction."""
-        return self._state._interaction.client.user
 
     @property
     def guild(self) -> Optional[Guild]:


### PR DESCRIPTION
## Summary

Makes a return value for `InteractionResponse.send_message` supporting `edit`, `delete` and `fetch`

## Testing

Current way of editing, deleting, fetching:

```py
@client.slash_command(guild_ids=[TEST_GUILD_ID])
async def edit_delete_old(interaction: Interaction):
    await interaction.response.send_message("Hello World")
    await interaction.edit_original_message(content=f"Message Edited")
    await interaction.delete_original_message()

@client.slash_command(guild_ids=[TEST_GUILD_ID])
async def fetch_from_interaction(interaction: Interaction):
    await interaction.response.send_message("Hello World")
    msg = await interaction.original_message()
    await msg.add_reaction("\N{THUMBS UP SIGN}")
```

New methods with `PartialInteractionMessage`:

```py
@client.slash_command(guild_ids=[TEST_GUILD_ID])
async def edit_delete_partial(interaction: Interaction):
    pm = await interaction.response.send_message("Hello World")
    await pm.edit(content=f"{pm}")
    await pm.delete()

@client.slash_command(guild_ids=[TEST_GUILD_ID])
async def fetch_from_partial(interaction: Interaction):
    pm = await interaction.response.send_message("Hello World")
    msg = await pm.fetch()
    await msg.add_reaction("\N{THUMBS UP SIGN}")
```

Full example code: https://paste.nextcord.dev/?id=1649215125063750

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
