### PR TITLE
docs: Document migration change to intents

### DIFF
--- a/docs/intents.rst
+++ b/docs/intents.rst
@@ -167,7 +167,7 @@ Some common issues relating to the mandatory intent change.
 Where'd my members go?
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
-Due to an :ref:`API change <intents_member_cache>` Discord is now forcing developers who want member caching to explicitly opt-in to it. This is a Discord mandated change and there is no way to bypass it. To get members back, you have to explicitly enable the :ref:`members privileged intent <privileged_intents>` and change the :attr:`Intents.members` attribute to true.
+Due to an :ref:`API change <intents_member_cache>` Discord is now forcing developers who want member caching to explicitly opt in to it. This is a Discord mandated change and there is no way to bypass it. To get members back, you have to explicitly enable the :ref:`members privileged intent <privileged_intents>` and change the :attr:`Intents.members` attribute to true.
 
 For example:
 
@@ -177,6 +177,29 @@ For example:
     import nextcord
     intents = nextcord.Intents.default()
     intents.members = True
+
+    # Somewhere else:
+    # client = nextcord.Client(intents=intents)
+    # or
+    # from nextcord.ext import commands
+    # bot = commands.Bot(command_prefix='!', intents=intents)
+
+What happened to my message commands?
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Due to an :ref:`API change <need_message_content_intent>`, to read message content in most messages,
+you have to explicitly opt in to it. This is a Discord mandated change and there is no way to bypass it.
+To get message content back, you have to explicitly enable the :ref:`message content privileged intent <privileged_intents>`
+and change the :attr:`Intents.message_content` attribute to true.
+
+For example:
+
+.. code-block:: python3
+   :emphasize-lines: 3,6,8,9
+
+    import nextcord
+    intents = nextcord.Intents.default()
+    intents.message_content = True
 
     # Somewhere else:
     # client = nextcord.Client(intents=intents)

--- a/docs/migrating_2.rst
+++ b/docs/migrating_2.rst
@@ -30,6 +30,7 @@ Overview
 - Many method arguments now reject ``None``.
 - Many arguments are now specified as positional-only or keyword-only; e.g. :func:`oauth_url` now takes keyword-only arguments, and methods starting with ``get_`` or ``fetch_`` take positional-only arguments.
 - :attr:`AppInfo.summary` and :attr:`PartialAppInfo.summary` now return an empty string and will be removed in API v11.
+- You must explicitly enable the :attr:`~Intents.message_content` intent to receive message :attr:`~Message.content`, :attr:`~Message.embeds`, :attr:`~Message.attachments`, and :attr:`~Message.components` in most messages.
 
 Changes
 -----------------------
@@ -259,6 +260,19 @@ on_socket_raw_receive behavior
 Guild.get_member taking positional only argument
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 :meth:`Guild.get_member` method's first argument is now positional only.
+
+Intents.message_content must be enabled to receive message content
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+In order to receive message content in most messages, you must have :attr:`Intents.message_content` enabled.
+
+You can do this by using :meth:`Intents.all` or by setting :attr:`~Intents.message_content` to ``True``:
+
+.. code-block:: python3
+
+    intents = nextcord.Intents.default()
+    intents.message_content = True
+
+For more information go to the :ref:`message content intent documentation <need_message_content_intent>`.
 
 Removals
 -----------------------

--- a/nextcord/appinfo.py
+++ b/nextcord/appinfo.py
@@ -78,7 +78,7 @@ class AppInfo:
 
         .. warning::
 
-            This attribute now returns an empty string and will be removed in API v11.       
+            This attribute now returns an empty string and will be removed in API v11.
 
         .. versionadded:: 1.3
 
@@ -219,8 +219,8 @@ class PartialAppInfo:
         this field will be the summary field for the store page of its primary SKU.
 
         .. warning::
-            
-            This attribute now returns an empty string and will be removed in API v11. 
+
+            This attribute now returns an empty string and will be removed in API v11.
     verify_key: :class:`str`
         The hex encoded key for verification in interactions and the
         GameSDK's `GetTicket <https://discord.com/developers/docs/game-sdk/applications#getticket>`_.

--- a/nextcord/flags.py
+++ b/nextcord/flags.py
@@ -898,7 +898,7 @@ class Intents(BaseFlags):
 
         .. note::
 
-            As of April 30, 2022, this requires opting in explicitly via the developer portal as well.
+            As of September 1, 2022, this requires opting in explicitly via the developer portal as well.
             Bots in over 100 guilds will need to apply to Discord for verification.
         """
         return 1 << 15


### PR DESCRIPTION
## Summary

Mentions in migrating 2.0 that message content must be enabled if using Intents.default()

Extended deprecation deadline mentioned in docstring (https://github.com/discord/discord-api-docs/discussions/4729)

_Note: This is an API v10 branch PR_

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)