### PR TITLE
feat: filename and description kwargs in to_file

### DIFF
--- a/nextcord/asset.py
+++ b/nextcord/asset.py
@@ -144,7 +144,7 @@ class AssetMixin:
         ------
         DiscordException
             The asset does not have an associated state.
-        ValueError
+        InvalidArgument
             The asset is a unicode emoji.
         TypeError
             The asset is a sticker with lottie type.

--- a/nextcord/asset.py
+++ b/nextcord/asset.py
@@ -116,7 +116,13 @@ class AssetMixin:
             with open(fp, 'wb') as f:
                 return f.write(data)
 
-    async def to_file(self, *, spoiler: bool = False) -> File:
+    async def to_file(
+        self,
+        *,
+        filename: Optional[str] = MISSING,
+        description: Optional[str] = None,
+        spoiler: bool = False,
+    ) -> File:
         """|coro|
 
         Converts the asset into a :class:`File` suitable for sending via
@@ -126,6 +132,11 @@ class AssetMixin:
 
         Parameters
         -----------
+        filename: Optional[:class:`str`]
+            The filename of the file. If not provided, then the filename from
+            the asset's URL is used.
+        description: Optional[:class:`str`]
+            The description for the file.
         spoiler: :class:`bool`
             Whether the file is a spoiler.
 
@@ -133,12 +144,12 @@ class AssetMixin:
         ------
         DiscordException
             The asset does not have an associated state.
+        ValueError
+            The asset is a unicode emoji.
         TypeError
             The asset is a sticker with lottie type.
         HTTPException
             Downloading the asset failed.
-        Forbidden
-            You do not have permissions to access this asset
         NotFound
             The asset was deleted.
 
@@ -149,9 +160,8 @@ class AssetMixin:
         """
 
         data = await self.read()
-        url = yarl.URL(self.url)
-        _, _, filename = url.path.rpartition('/')
-        return File(io.BytesIO(data), filename=filename, spoiler=spoiler)
+        file_filename = filename if filename is not MISSING else yarl.URL(self.url).name
+        return File(io.BytesIO(data), filename=file_filename, description=description, spoiler=spoiler)
 
 
 class Asset(AssetMixin):

--- a/nextcord/message.py
+++ b/nextcord/message.py
@@ -267,7 +267,14 @@ class Attachment(Hashable):
         data = await self._http.get_from_cdn(url)
         return data
 
-    async def to_file(self, *, use_cached: bool = False, spoiler: bool = False) -> File:
+    async def to_file(
+        self,
+        *,
+        filename: Optional[str] = MISSING,
+        description: Optional[str] = MISSING,
+        use_cached: bool = False,
+        spoiler: bool = False,
+    ) -> File:
         """|coro|
 
         Converts the attachment into a :class:`File` suitable for sending via
@@ -277,6 +284,16 @@ class Attachment(Hashable):
 
         Parameters
         -----------
+        filename: Optional[:class:`str`]
+            The filename to use for the file. If not specified then the filename
+            of the attachment is used instead.
+
+            .. versionadded:: 2.0
+        description: Optional[:class:`str`]
+            The description to use for the file. If not specified then the
+            description of the attachment is used instead.
+
+            .. versionadded:: 2.0
         use_cached: :class:`bool`
             Whether to use :attr:`proxy_url` rather than :attr:`url` when downloading
             the attachment. This will allow attachments to be saved after deletion
@@ -307,7 +324,9 @@ class Attachment(Hashable):
         """
 
         data = await self.read(use_cached=use_cached)
-        return File(io.BytesIO(data), filename=self.filename, description=self.description, spoiler=spoiler)
+        file_filename = filename if filename is not MISSING else self.filename
+        file_description = description if description is not MISSING else self.description
+        return File(io.BytesIO(data), filename=file_filename, description=file_description, spoiler=spoiler)
 
     def to_dict(self) -> AttachmentPayload:
         result: AttachmentPayload = {


### PR DESCRIPTION
## Summary

Adds kwargs to `Asset.to_file` and `Attachment.to_file` for overriding the `filename` or `description` when creating the File.

Fixes to docstrings

## Testing

```py
@bot.command()
async def asset(ctx: commands.Context[commands.Bot], emoji: nextcord.PartialEmoji):
    file = await emoji.to_file(filename="partial_emoji.png", description="Partial Emoji", spoiler=True)
    await ctx.send(file=file)
    await ctx.send(f"{file.filename} {file.description} {file.spoiler}")

@bot.command()
async def attachment(ctx: commands.Context[commands.Bot], message_id: int):
    msg = await ctx.channel.fetch_message(message_id)
    if not msg.attachments:
        await ctx.send("No attachments found")
        return
    file = await msg.attachments[0].to_file(filename="attachment.png", description="Attachment", spoiler=True)
    await ctx.send(file=file)
    await ctx.send(f"{file.filename} {file.description} {file.spoiler}")
```

## Additional info

I made this change in discord.py and it was merged.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
