### PR TITLE
feat(embeds): set image and thumbnail arent kwarg forced

### DIFF
--- a/nextcord/embeds.py
+++ b/nextcord/embeds.py
@@ -398,7 +398,7 @@ class Embed:
         """
         return EmbedProxy(getattr(self, '_image', {}))  # type: ignore
 
-    def set_image(self: E, *, url: MaybeEmpty[Any]) -> E:
+    def set_image(self: E, url: MaybeEmpty[Any]) -> E:
         """Sets the image for the embed content.
 
         This function returns the class instance to allow for fluent-style
@@ -440,7 +440,7 @@ class Embed:
         """
         return EmbedProxy(getattr(self, '_thumbnail', {}))  # type: ignore
 
-    def set_thumbnail(self: E, *, url: MaybeEmpty[Any]) -> E:
+    def set_thumbnail(self: E, url: MaybeEmpty[Any]) -> E:
         """Sets the thumbnail for the embed content.
 
         This function returns the class instance to allow for fluent-style


### PR DESCRIPTION
URL input as arge instead of kwarg because it'll be more convenient to use the function for many users.

## Summary

<!-- What is this pull request for? Does it fix any issues? -->
Everytime I need to add image or thumbnail in Embed I had to use 
```py
        em = Embed(description="Test")
        em.set_image(url="https://www.pic.com/image.png")
        em.set_thumbnail(url="https://www.pic.com/thumbnail.png")
```
URL as kwarg in set_image function. Now you'll just gonna use like this
```py
        em = Embed(description="Test")
        em.set_image("https://www.pic.com/image.png")
        em.set_thumbnail("https://www.pic.com/thumbnail.png")
```

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
