### PR TITLE
fix(Message): RawMessage edits throwing key errors

### DIFF
--- a/nextcord/message.py
+++ b/nextcord/message.py
@@ -686,8 +686,9 @@ class Message(Hashable):
         self.id: int = int(data['id'])
         self.webhook_id: Optional[int] = utils._get_as_snowflake(data, 'webhook_id')
         self.reactions: List[Reaction] = [Reaction(message=self, data=d) for d in data.get('reactions', [])]
-        self.attachments: List[Attachment] = \
-            [Attachment(data=a, state=self._state) for a in data.get('attachments', [])]
+        self.attachments: List[Attachment] = [
+            Attachment(data=a, state=self._state) for a in data.get('attachments', [])
+        ]
         self.embeds: List[Embed] = [Embed.from_dict(a) for a in data.get('embeds', [])]
         self.application: Optional[MessageApplicationPayload] = data.get('application')
         self.activity: Optional[MessageActivityPayload] = data.get('activity')

--- a/nextcord/message.py
+++ b/nextcord/message.py
@@ -686,8 +686,9 @@ class Message(Hashable):
         self.id: int = int(data['id'])
         self.webhook_id: Optional[int] = utils._get_as_snowflake(data, 'webhook_id')
         self.reactions: List[Reaction] = [Reaction(message=self, data=d) for d in data.get('reactions', [])]
-        self.attachments: List[Attachment] = [Attachment(data=a, state=self._state) for a in data['attachments']]
-        self.embeds: List[Embed] = [Embed.from_dict(a) for a in data['embeds']]
+        self.attachments: List[Attachment] = \
+            [Attachment(data=a, state=self._state) for a in data.get('attachments', [])]
+        self.embeds: List[Embed] = [Embed.from_dict(a) for a in data.get('embeds', [])]
         self.application: Optional[MessageApplicationPayload] = data.get('application')
         self.activity: Optional[MessageActivityPayload] = data.get('activity')
         self.channel: MessageableChannel = channel


### PR DESCRIPTION
Fixes Error thrown for Raw Message edits due to attachemnts key missing

The possibility of it missing is also mentioned in the docs https://discord.com/developers/docs/topics/gateway#message-update

I am getting this error regulary since a former release so i wanted to fix it:
```python
"/venv/lib/python3.10/site-packages/nextcord/message.py", line 663, in __init__
    self.attachments: List[Attachment] = [Attachment(data=a, state=self._state) for a in data['attachments']]
KeyError: 'attachments'
```

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
