### PR TITLE
feat: return message from InteractionResponse.edit_message

### DIFF
--- a/nextcord/interactions.py
+++ b/nextcord/interactions.py
@@ -387,7 +387,7 @@ class Interaction:
             Editing the message failed.
         Forbidden
             Edited a message that is not yours.
-        TypeError
+        InvalidArgument
             You specified both ``embed`` and ``embeds`` or ``file`` and ``files``
         ValueError
             The length of ``embeds`` was invalid.
@@ -496,7 +496,7 @@ class Interaction:
             but the followup webhook is expired.
         Forbidden
             The authorization token for the webhook is incorrect.
-        TypeError
+        InvalidArgument
             You specified both ``embed`` and ``embeds`` or ``file`` and ``files``.
         ValueError
             The length of ``embeds`` was invalid.
@@ -551,9 +551,10 @@ class Interaction:
         ------
         HTTPException
             Editing the message failed.
+        InvalidArgument
+            You specified both ``embed`` and ``embeds`` or ``file`` and ``files``
         TypeError
-            You specified both ``embed`` and ``embeds`` or ``file`` and ``files``,
-            or an object of type :class:`File` was passed to ``file`` or ``files``.
+            An object of type :class:`File` was passed to ``file`` or ``files``.
         HTTPException
             Editing the message failed.
         InvalidArgument
@@ -772,9 +773,10 @@ class InteractionResponse:
             The interaction has expired. :meth:`InteractionResponse.defer` and
             :attr:`Interaction.followup` should be used if the interaction will take
             a while to respond.
+        InvalidArgument
+            You specified both ``embed`` and ``embeds`` or ``file`` and ``files``
         TypeError
-            You specified both ``embed`` and ``embeds`` or ``file`` and ``files``,
-            or an object of type :class:`File` was passed to ``file`` or ``files``.
+            An object of type :class:`File` was passed to ``file`` or ``files``.
         ValueError
             The length of ``embeds`` was invalid.
         InteractionResponded
@@ -795,7 +797,7 @@ class InteractionResponse:
         }
 
         if embed is not MISSING and embeds is not MISSING:
-            raise TypeError('Cannot mix embed and embeds keyword arguments')
+            raise InvalidArgument('Cannot mix embed and embeds keyword arguments')
 
         if embed is not MISSING:
             embeds = [embed]
@@ -804,7 +806,7 @@ class InteractionResponse:
             payload['embeds'] = [e.to_dict() for e in embeds]
 
         if file is not MISSING and files is not MISSING:
-            raise TypeError('Cannot mix file and files keyword arguments')
+            raise InvalidArgument('Cannot mix file and files keyword arguments')
 
         if file is not MISSING:
             files = [file]
@@ -942,9 +944,10 @@ class InteractionResponse:
         -------
         HTTPException
             Editing the message failed.
+        InvalidArgument
+            You specified both ``embed`` and ``embeds`` or ``file`` and ``files``.
         TypeError
-            You specified both ``embed`` and ``embeds`` or ``file`` and ``files``,
-            or an object of type :class:`File` was passed to ``file`` or ``files``.
+            An object of type :class:`File` was passed to ``file`` or ``files``.
         InteractionResponded
             This interaction has already been responded to before.
 
@@ -970,7 +973,7 @@ class InteractionResponse:
                 payload['content'] = str(content)
 
         if embed is not MISSING and embeds is not MISSING:
-            raise TypeError('cannot mix both embed and embeds keyword arguments')
+            raise InvalidArgument('cannot mix both embed and embeds keyword arguments')
 
         if embed is not MISSING:
             if embed is None:
@@ -982,7 +985,7 @@ class InteractionResponse:
             payload['embeds'] = [e.to_dict() for e in embeds]
 
         if file is not MISSING and files is not MISSING:
-            raise TypeError('Cannot mix file and files keyword arguments')
+            raise InvalidArgument('Cannot mix file and files keyword arguments')
 
         if file is not MISSING:
             files = [file]
@@ -1106,7 +1109,7 @@ class _InteractionMessageMixin:
             Editing the message failed.
         Forbidden
             Edited a message that is not yours.
-        TypeError
+        InvalidArgument
             You specified both ``embed`` and ``embeds`` or ``file`` and ``files``
         ValueError
             The length of ``embeds`` was invalid.

--- a/nextcord/interactions.py
+++ b/nextcord/interactions.py
@@ -552,8 +552,8 @@ class Interaction:
         HTTPException
             Editing the message failed.
         TypeError
-            You specified both ``embed`` and ``embeds`` or ``file`` and ``files``
-            or ``file`` or ``files`` contained objects that are not of type :class:`File`.
+            You specified both ``embed`` and ``embeds`` or ``file`` and ``files``,
+            or an object of type :class:`File` was passed to ``file`` or ``files``.
         HTTPException
             Editing the message failed.
         InvalidArgument
@@ -773,8 +773,8 @@ class InteractionResponse:
             :attr:`Interaction.followup` should be used if the interaction will take
             a while to respond.
         TypeError
-            You specified both ``embed`` and ``embeds`` or ``file`` and ``files``
-            or ``file`` or ``files`` contained objects that are not of type :class:`File`.
+            You specified both ``embed`` and ``embeds`` or ``file`` and ``files``,
+            or an object of type :class:`File` was passed to ``file`` or ``files``.
         ValueError
             The length of ``embeds`` was invalid.
         InteractionResponded
@@ -943,8 +943,8 @@ class InteractionResponse:
         HTTPException
             Editing the message failed.
         TypeError
-            You specified both ``embed`` and ``embeds`` or ``file`` and ``files``
-            or ``file`` or ``files`` contained objects that are not of type :class:`File`.
+            You specified both ``embed`` and ``embeds`` or ``file`` and ``files``,
+            or an object of type :class:`File` was passed to ``file`` or ``files``.
         InteractionResponded
             This interaction has already been responded to before.
 

--- a/nextcord/interactions.py
+++ b/nextcord/interactions.py
@@ -483,7 +483,7 @@ class Interaction:
 
         This is a shorthand function for helping in sending messages in
         response to an interaction. If the interaction has not been responded to,
-        :meth:InteractionResponse.send_message` is used. If the response
+        :meth:`InteractionResponse.send_message` is used. If the response
         :meth:`~InteractionResponse.is_done` then the message is sent
         via :attr:`Interaction.followup` using :class:`Webhook.send` instead.
 
@@ -542,7 +542,7 @@ class Interaction:
 
         This is a shorthand function for helping in editing messages in
         response to a component or modal submit interaction. If the
-        interaction has not been responded to, :meth:InteractionResponse.edit_message`
+        interaction has not been responded to, :meth:`InteractionResponse.edit_message`
         is used. If the response :meth:`~InteractionResponse.is_done` then
         the message is edited via the :attr:`Interaction.message` using
         :meth:`Message.edit` instead.

--- a/nextcord/message.py
+++ b/nextcord/message.py
@@ -1329,7 +1329,7 @@ class Message(Hashable):
         Forbidden
             Tried to suppress a message without permissions or
             edited a message's content or embed that isn't yours.
-        TypeError
+        InvalidArgument
             You specified both ``embed`` and ``embeds`` or ``file`` and ``files``.
 
         Returns
@@ -1346,9 +1346,9 @@ class Message(Hashable):
                 payload['content'] = None
 
         if embed is not MISSING and embeds is not MISSING:
-            raise TypeError('cannot pass both embed and embeds parameter to edit()')
+            raise InvalidArgument('cannot pass both embed and embeds parameter to edit()')
         if file is not MISSING and files is not MISSING:
-            raise TypeError('cannot pass both file and files parameter to edit()')
+            raise InvalidArgument('cannot pass both file and files parameter to edit()')
 
         if embed is not MISSING:
             if embed is None:

--- a/nextcord/message.py
+++ b/nextcord/message.py
@@ -1329,9 +1329,13 @@ class Message(Hashable):
         Forbidden
             Tried to suppress a message without permissions or
             edited a message's content or embed that isn't yours.
-        ~nextcord.InvalidArgument
-            You specified both ``embed`` and ``embeds``
-            or ``file`` and ``files``.
+        TypeError
+            You specified both ``embed`` and ``embeds`` or ``file`` and ``files``.
+
+        Returns
+        --------
+        :class:`Message`
+            The edited message.
         """
 
         payload: Dict[str, Any] = {}
@@ -1342,9 +1346,9 @@ class Message(Hashable):
                 payload['content'] = None
 
         if embed is not MISSING and embeds is not MISSING:
-            raise InvalidArgument('cannot pass both embed and embeds parameter to edit()')
+            raise TypeError('cannot pass both embed and embeds parameter to edit()')
         if file is not MISSING and files is not MISSING:
-            raise InvalidArgument('cannot pass both file and files parameter to edit()')
+            raise TypeError('cannot pass both file and files parameter to edit()')
 
         if embed is not MISSING:
             if embed is None:

--- a/nextcord/webhook/async_.py
+++ b/nextcord/webhook/async_.py
@@ -466,9 +466,9 @@ def handle_message_parameters(
     previous_allowed_mentions: Optional[AllowedMentions] = None,
 ) -> ExecuteWebhookParameters:
     if files is not MISSING and file is not MISSING:
-        raise TypeError('Cannot mix file and files keyword arguments.')
+        raise InvalidArgument('Cannot mix file and files keyword arguments.')
     if embeds is not MISSING and embed is not MISSING:
-        raise TypeError('Cannot mix embed and embeds keyword arguments.')
+        raise InvalidArgument('Cannot mix embed and embeds keyword arguments.')
 
     payload: Dict[str, Any] = {}
 
@@ -732,7 +732,7 @@ class WebhookMessage(Message):
             Editing the message failed.
         Forbidden
             Edited a message that is not yours.
-        TypeError
+        InvalidArgument
             You specified both ``embed`` and ``embeds`` or ``file`` and ``files``
         ValueError
             The length of ``embeds`` was invalid
@@ -1385,7 +1385,7 @@ class Webhook(BaseWebhook):
             This webhook was not found or has expired.
         Forbidden
             The authorization token for the webhook is incorrect.
-        TypeError
+        InvalidArgument
             You specified both ``embed`` and ``embeds`` or ``file`` and ``files``.
         ValueError
             The length of ``embeds`` was invalid.
@@ -1569,7 +1569,7 @@ class Webhook(BaseWebhook):
             Editing the message failed.
         Forbidden
             Edited a message that is not yours.
-        TypeError
+        InvalidArgument
             You specified both ``embed`` and ``embeds`` or ``file`` and ``files``
         ValueError
             The length of ``embeds`` was invalid

--- a/nextcord/webhook/async_.py
+++ b/nextcord/webhook/async_.py
@@ -1382,7 +1382,7 @@ class Webhook(BaseWebhook):
         HTTPException
             Sending the message failed.
         NotFound
-            This webhook was not found.
+            This webhook was not found or has expired.
         Forbidden
             The authorization token for the webhook is incorrect.
         TypeError

--- a/nextcord/webhook/sync.py
+++ b/nextcord/webhook/sync.py
@@ -414,7 +414,7 @@ class SyncWebhookMessage(Message):
             Editing the message failed.
         Forbidden
             Edited a message that is not yours.
-        TypeError
+        InvalidArgument
             You specified both ``embed`` and ``embeds`` or ``file`` and ``files``
         ValueError
             The length of ``embeds`` was invalid
@@ -874,7 +874,7 @@ class SyncWebhook(BaseWebhook):
             This webhook was not found.
         Forbidden
             The authorization token for the webhook is incorrect.
-        TypeError
+        InvalidArgument
             You specified both ``embed`` and ``embeds`` or ``file`` and ``files``
         ValueError
             The length of ``embeds`` was invalid
@@ -1010,7 +1010,7 @@ class SyncWebhook(BaseWebhook):
             Editing the message failed.
         Forbidden
             Edited a message that is not yours.
-        TypeError
+        InvalidArgument
             You specified both ``embed`` and ``embeds`` or ``file`` and ``files``
         ValueError
             The length of ``embeds`` was invalid


### PR DESCRIPTION
## Summary

* Returns the newly edited message from the state when `InteractionResponse.edit_message` is used.
* `send` and `edit` methods related to Webhooks or Interactions now raise `InvalidArgument` instead of `TypeError` when `embed` and `embed` or `file` and `files` are specified. This is for consistency with `Messageable.send` and `Message.edit`.
* Docstrings related to interactions were updated with additional clarification.

## Testing

Example code for testing:

```py
class Counter(nextcord.ui.View):
    def __init__(self):
        super().__init__(timeout=None)

    @nextcord.ui.button(label="+1")
    async def count(self, button: nextcord.ui.Button, interaction: Interaction):
        msg = await interaction.response.edit_message(content=int(interaction.message.content) + 1)
        print(msg.content)  # Prints "2" (the new count)
        print(interaction.message.content)  # Prints "1" (the old count)


@client.slash_command(guild_ids=[TESTING_GUILD_ID])
async def counter(interaction: Interaction):
    await interaction.send("1", view=Counter())
```

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
