### PR TITLE
refactor: add specific return types for component payloads

### DIFF
--- a/nextcord/ui/button.py
+++ b/nextcord/ui/button.py
@@ -42,6 +42,7 @@ __all__ = (
 if TYPE_CHECKING:
     from .view import View
     from ..emoji import Emoji
+    from ..types.components import ButtonComponent as ButtonComponentPayload
 
 B = TypeVar('B', bound='Button')
 V = TypeVar('V', bound='View', covariant=True)
@@ -211,7 +212,7 @@ class Button(Item[V]):
     def type(self) -> ComponentType:
         return self._underlying.type
 
-    def to_component_dict(self):
+    def to_component_dict(self) -> ButtonComponentPayload:
         return self._underlying.to_dict()
 
     def is_dispatchable(self) -> bool:

--- a/nextcord/ui/item.py
+++ b/nextcord/ui/item.py
@@ -24,7 +24,7 @@ DEALINGS IN THE SOFTWARE.
 
 from __future__ import annotations
 
-from typing import Any, Callable, Coroutine, Dict, Generic, Optional, TYPE_CHECKING, Tuple, Type, TypeVar
+from typing import Any, Callable, Coroutine, Generic, Optional, TYPE_CHECKING, Tuple, Type, TypeVar
 
 from ..interactions import Interaction
 
@@ -36,6 +36,7 @@ if TYPE_CHECKING:
     from ..enums import ComponentType
     from .view import View
     from ..components import Component
+    from ..types.components import Component as ComponentPayload
 
 I = TypeVar('I', bound='Item')
 V = TypeVar('V', bound='View', covariant=True)
@@ -67,7 +68,7 @@ class Item(Generic[V]):
         # only called upon edit and we're mainly interested during initial creation time.
         self._provided_custom_id: bool = False
 
-    def to_component_dict(self) -> Dict[str, Any]:
+    def to_component_dict(self) -> ComponentPayload:
         raise NotImplementedError
 
     def refresh_component(self, component: Component) -> None:

--- a/nextcord/ui/modal.py
+++ b/nextcord/ui/modal.py
@@ -51,7 +51,7 @@ __all__ = (
 if TYPE_CHECKING:
     from ..interactions import Interaction
     from ..state import ConnectionState
-
+    from ..types.components import ActionRow as ActionRowPayload
 
 class Modal:
     """Represents a Discord modal popup.
@@ -126,12 +126,12 @@ class Modal:
             # Wait N seconds to see if timeout data has been refreshed
             await asyncio.sleep(self.__timeout_expiry - now)
 
-    def to_components(self) -> List[Dict[str, Any]]:
+    def to_components(self) -> List[ActionRowPayload]:
         def key(item: Item) -> int:
             return item._rendered_row or 0
 
         children = sorted(self.children, key=key)
-        components: List[Dict[str, Any]] = []
+        components: List[ActionRowPayload] = []
         for _, group in groupby(children, key=key):
             children = [item.to_component_dict() for item in group]
             if not children:

--- a/nextcord/ui/text_input.py
+++ b/nextcord/ui/text_input.py
@@ -38,6 +38,7 @@ __all__ = ('TextInput',)
 if TYPE_CHECKING:
     from .view import View
     from ..types.interactions import ComponentInteractionData
+    from ..types.components import TextInputComponent as TextInputComponentPayload
 
 
 T = TypeVar('T', bound='TextInput')
@@ -244,7 +245,7 @@ class TextInput(Item[V]):
     def type(self) -> ComponentType:
         return self._underlying.type
 
-    def to_component_dict(self):
+    def to_component_dict(self) -> TextInputComponentPayload:
         return self._underlying.to_dict()
 
     def is_dispatchable(self) -> bool:

--- a/nextcord/ui/view.py
+++ b/nextcord/ui/view.py
@@ -23,7 +23,7 @@ DEALINGS IN THE SOFTWARE.
 """
 
 from __future__ import annotations
-from typing import Any, Callable, ClassVar, Dict, Iterator, List, Optional, Sequence, TYPE_CHECKING, Tuple
+from typing import Callable, ClassVar, Dict, Iterator, List, Optional, Sequence, TYPE_CHECKING, Tuple
 from functools import partial
 from itertools import groupby
 
@@ -50,7 +50,7 @@ __all__ = (
 if TYPE_CHECKING:
     from ..interactions import Interaction
     from ..message import Message
-    from ..types.components import Component as ComponentPayload
+    from ..types.components import Component as ComponentPayload, ActionRow as ActionRowPayload
     from ..state import ConnectionState
 
 
@@ -200,12 +200,12 @@ class View:
             # Wait N seconds to see if timeout data has been refreshed
             await asyncio.sleep(self.__timeout_expiry - now)
 
-    def to_components(self) -> List[Dict[str, Any]]:
+    def to_components(self) -> List[ActionRowPayload]:
         def key(item: Item) -> int:
             return item._rendered_row or 0
 
         children = sorted(self.children, key=key)
-        components: List[Dict[str, Any]] = []
+        components: List[ActionRowPayload] = []
         for _, group in groupby(children, key=key):
             children = [item.to_component_dict() for item in group]
             if not children:


### PR DESCRIPTION
## Summary

Adds specific return types to `to_components` and `to_component_dict` methods

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
