### PR TITLE
Return Embed from `Embed.remove_field`

### DIFF
--- a/nextcord/embeds.py
+++ b/nextcord/embeds.py
@@ -629,11 +629,14 @@ class Embed:
 
         return self
 
-    def remove_field(self, index: int) -> None:
+    def remove_field(self: E, index: int) -> E:
         """Removes a field at a specified index.
 
         If the index is invalid or out of bounds then the error is
         silently swallowed.
+
+        This function returns the class instance to allow for fluent-style
+        chaining.
 
         .. note::
 
@@ -649,6 +652,8 @@ class Embed:
             del self._fields[index]
         except (AttributeError, IndexError):
             pass
+
+        return self
 
     def set_field_at(self: E, index: int, *, name: Any, value: Any, inline: bool = True) -> E:
         """Modifies a field to the embed object.


### PR DESCRIPTION
## Summary

Related to #624 

For consistency with all the other methods in `Embed`, this should also return the new embed.

I tried mentioning this a few times in the relevant PR for the above mentioned issue but it did not get added.

Example

```py
await ctx.send(embed=embed.add_field(name="Test", value=f"field").remove_field(0))
```

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
