### PR TITLE
Changed str to int in the SlashOption docs

### DIFF
--- a/docs/interactions.rst
+++ b/docs/interactions.rst
@@ -70,7 +70,7 @@ Nextcord's implementation of slash commands has fields and is very simple. in th
     @bot.slash_command()
     async def choose_a_number(
         interaction: Interaction,
-        number: str = SlashOption(name="settings", description="Configure Your Settings", choices={"1": 1, "2": 2,"3": 3})
+        number: int = SlashOption(name="settings", description="Configure Your Settings", choices={"1": 1, "2": 2,"3": 3})
     ):
         await interaction.response.send_message(f"You chose {number}")
 


### PR DESCRIPTION
This code will not run with str, however will with int.

## Summary

<!-- What is this pull request for? Does it fix any issues? -->
Allows the sample code in the documentation to run in its current form. 
## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x ] This PR is **not** a code change (e.g. documentation, README, ...)
