### PR TITLE
fix: delete_after type annotations

### DIFF
--- a/nextcord/webhook/async_.py
+++ b/nextcord/webhook/async_.py
@@ -677,7 +677,7 @@ class WebhookMessage(Message):
         attachments: List[Attachment] = MISSING,
         view: Optional[View] = MISSING,
         allowed_mentions: Optional[AllowedMentions] = None,
-        delete_after: Optional[bool] = None,
+        delete_after: Optional[float] = None,
     ) -> WebhookMessage:
         """|coro|
 
@@ -1265,7 +1265,7 @@ class Webhook(BaseWebhook):
         view: View = MISSING,
         thread: Snowflake = MISSING,
         wait: Literal[True],
-        delete_after: Optional[bool] = None,
+        delete_after: Optional[float] = None,
     ) -> WebhookMessage:
         ...
 
@@ -1286,7 +1286,7 @@ class Webhook(BaseWebhook):
         view: View = MISSING,
         thread: Snowflake = MISSING,
         wait: Literal[False] = ...,
-        delete_after: Optional[bool] = None,
+        delete_after: Optional[float] = None,
     ) -> None:
         ...
 
@@ -1306,7 +1306,7 @@ class Webhook(BaseWebhook):
         view: View = MISSING,
         thread: Snowflake = MISSING,
         wait: bool = False,
-        delete_after: Optional[bool] = None,
+        delete_after: Optional[float] = None,
     ) -> Optional[WebhookMessage]:
         """|coro|
 


### PR DESCRIPTION
## Summary

Resolves #641 

`delete_after` takes a number of seconds as a `float`. The type annotations in webhooks incorrectly said `bool`.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
