### PR TITLE
fix(scheduled-event-iterator): resolve infinite loop

### DIFF
--- a/nextcord/http.py
+++ b/nextcord/http.py
@@ -2300,8 +2300,8 @@ class HTTPClient:
         *,
         limit: int = MISSING,
         with_member: bool = MISSING,
-        before: Snowflake = MISSING,
-        after: Snowflake = MISSING,
+        before: Optional[Snowflake] = None,
+        after: Optional[Snowflake] = None,
     ) -> Response[List[scheduled_events.ScheduledEventUser]]:
         params: Dict[str, Any] = {}
         if limit is not MISSING:

--- a/nextcord/http.py
+++ b/nextcord/http.py
@@ -2308,9 +2308,9 @@ class HTTPClient:
             params["limit"] = limit
         if with_member is not MISSING:
             params["with_member"] = str(with_member)
-        if before is not MISSING:
+        if before is not None:
             params["before"] = before
-        if after is not MISSING:
+        if after is not None:
             params["after"] = after
         r = Route(
             "GET",

--- a/nextcord/iterators.py
+++ b/nextcord/iterators.py
@@ -942,7 +942,9 @@ class ScheduledEventUserIterator(_AsyncIterator["ScheduledEventUser"]):
         if not self.has_more:
             raise NoMoreItems()
 
-        data = await self.get_event_users(self.guild.id, self.event.id, with_member=self.with_member)
+        data = await self.get_event_users(
+            self.guild.id, self.event.id, with_member=self.with_member
+        )
         self.has_more = False
         if not data:
             # no data, terminate

--- a/nextcord/iterators.py
+++ b/nextcord/iterators.py
@@ -62,8 +62,8 @@ if TYPE_CHECKING:
     from .guild import Guild
     from .member import Member
     from .message import Message
-    from .threads import Thread
     from .scheduled_events import ScheduledEvent, ScheduledEventUser
+    from .threads import Thread
     from .types.audit_log import AuditLog as AuditLogPayload, AuditLogEntry as AuditLogEntryPayload
     from .types.guild import Ban as BanPayload, Guild as GuildPayload
     from .types.message import Message as MessagePayload

--- a/nextcord/iterators.py
+++ b/nextcord/iterators.py
@@ -62,8 +62,8 @@ if TYPE_CHECKING:
     from .guild import Guild
     from .member import Member
     from .message import Message
-    from .scheduled_events import ScheduledEvent, ScheduledEventUser
     from .threads import Thread
+    from .scheduled_events import ScheduledEvent, ScheduledEventUser
     from .types.audit_log import AuditLog as AuditLogPayload, AuditLogEntry as AuditLogEntryPayload
     from .types.guild import Ban as BanPayload, Guild as GuildPayload
     from .types.message import Message as MessagePayload

--- a/nextcord/iterators.py
+++ b/nextcord/iterators.py
@@ -43,7 +43,6 @@ from .audit_logs import AuditLogEntry
 from .bans import BanEntry
 from .errors import NoMoreItems
 from .object import Object
-from .scheduled_events import ScheduledEvent, ScheduledEventUser
 from .utils import maybe_coroutine, snowflake_time, time_snowflake
 
 __all__ = (
@@ -64,13 +63,11 @@ if TYPE_CHECKING:
     from .member import Member
     from .message import Message
     from .threads import Thread
+    from .scheduled_events import ScheduledEvent, ScheduledEventUser
     from .types.audit_log import AuditLog as AuditLogPayload, AuditLogEntry as AuditLogEntryPayload
     from .types.guild import Ban as BanPayload, Guild as GuildPayload
     from .types.message import Message as MessagePayload
-    from .types.scheduled_events import (
-        ScheduledEvent as ScheduledEventPayload,
-        ScheduledEventUser as ScheduledEventUserPayload,
-    )
+    from .types.scheduled_events import ScheduledEventUser as ScheduledEventUserPayload
     from .types.threads import Thread as ThreadPayload
     from .types.user import PartialUser as PartialUserPayload
     from .user import User

--- a/nextcord/scheduled_events.py
+++ b/nextcord/scheduled_events.py
@@ -436,7 +436,7 @@ class ScheduledEvent(Hashable):
         """
         return self._users.get(user_id)
 
-    async def fetch_users(
+    def fetch_users(
         self,
         *,
         limit: int = 100,


### PR DESCRIPTION
## Summary

Somehow this got by, stop `ScheduledEventIterator` and `ScheduledEventUserIterator` from making infinite loops of requests.
```py
@bot.slash_command(guild_ids=TEST)
async def get_events(inter: nextcord.Interaction):
    assert inter.guild is not None

    events = await inter.guild.fetch_scheduled_events().flatten()

    if not events:
        await inter.send("No events found")
    else:
        await inter.send("\n".join(e.name for e in events))


@bot.slash_command(guild_ids=TEST)
async def get_users(inter: nextcord.Interaction, event_id: str):
    assert inter.guild is not None

    event = inter.guild.get_scheduled_event(int(event_id))

    if not event:
        return await inter.send("Event not found")

    users = await event.fetch_users().flatten()

    if not users:
        await inter.send("No users found")
    else:
        await inter.send("\n".join(str(u.user_id) for u in users)
```

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
  - [x] I have updated the documentation to reflect the changes.
  - [x] I have run `task pyright` and fixed the relevant issues.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
