### PR TITLE
Community/apiv10

### DIFF
--- a/docs/intents.rst
+++ b/docs/intents.rst
@@ -11,7 +11,7 @@ In version 1.5 comes the introduction of :class:`Intents`. This is a radical cha
 
 These intents are passed to the constructor of :class:`Client` or its subclasses (:class:`AutoShardedClient`, :class:`~.AutoShardedBot`, :class:`~.Bot`) with the ``intents`` argument.
 
-If intents are not passed, then the library defaults to every intent being enabled except the privileged intents, currently :attr:`Intents.members` and :attr:`Intents.presences`.
+If intents are not passed, then the library defaults to every intent being enabled except the privileged intents, currently :attr:`Intents.members`, :attr:`Intents.presences`, and :attr:`Intents.message_content`.
 
 What intents are needed?
 --------------------------
@@ -107,6 +107,18 @@ Member Intent
 - Whether you want to request the guild member list through :meth:`Guild.chunk` or :meth:`Guild.fetch_members`.
 - Whether you want high accuracy member cache under :attr:`Guild.members`.
 
+.. _need_message_content_intent:
+
+Message Content
++++++++++++++++++
+
+- Whether you want to read :attr:`Message.content`, :attr:`Message.embeds`, :attr:`Message.attachments`, or :attr:`Message.components` in most messages.
+
+.. note::
+
+    Without this intent, the attributes above will appear empty (either an empty string or empty array depending on the data type) in most messages.
+    The bot will always be able to get these attributes from messages the bot sends, messages the bot receives in DMs, and messages in which the bot is mentioned.
+
 .. _intents_member_cache:
 
 Member Cache
@@ -155,7 +167,7 @@ Some common issues relating to the mandatory intent change.
 Where'd my members go?
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
-Due to an :ref:`API change <intents_member_cache>` Discord is now forcing developers who want member caching to explicitly opt-in to it. This is a Discord mandated change and there is no way to bypass it. To get members back, you have to explicitly enable the :ref:`members privileged intent <privileged_intents>` and change the :attr:`Intents.members` attribute to true.
+Due to an :ref:`API change <intents_member_cache>` Discord is now forcing developers who want member caching to explicitly opt in to it. This is a Discord mandated change and there is no way to bypass it. To get members back, you have to explicitly enable the :ref:`members privileged intent <privileged_intents>` and change the :attr:`Intents.members` attribute to true.
 
 For example:
 
@@ -165,6 +177,29 @@ For example:
     import nextcord
     intents = nextcord.Intents.default()
     intents.members = True
+
+    # Somewhere else:
+    # client = nextcord.Client(intents=intents)
+    # or
+    # from nextcord.ext import commands
+    # bot = commands.Bot(command_prefix='!', intents=intents)
+
+What happened to my message commands?
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Due to an :ref:`API change <need_message_content_intent>`, to read message content in most messages,
+you have to explicitly opt in to it. This is a Discord mandated change and there is no way to bypass it.
+To get message content back, you have to explicitly enable the :ref:`message content privileged intent <privileged_intents>`
+and change the :attr:`Intents.message_content` attribute to true.
+
+For example:
+
+.. code-block:: python3
+   :emphasize-lines: 3,6,8,9
+
+    import nextcord
+    intents = nextcord.Intents.default()
+    intents.message_content = True
 
     # Somewhere else:
     # client = nextcord.Client(intents=intents)

--- a/docs/migrating_2.rst
+++ b/docs/migrating_2.rst
@@ -278,6 +278,13 @@ You can do this by using :meth:`Intents.all` or by setting :attr:`~Intents.messa
 
 For more information go to the :ref:`message content intent documentation <need_message_content_intent>`.
 
+If you are unable to get the message content intent and would like some time to migrate to application commands:
+This will only be effective until Discord's current deadline of the 31st of August 2022.
+
+.. code-block:: python3
+
+    nextcord.http._modify_api_version(9)
+
 Guild.bans now returns an AsyncIterator
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/docs/migrating_2.rst
+++ b/docs/migrating_2.rst
@@ -278,12 +278,15 @@ You can do this by using :meth:`Intents.all` or by setting :attr:`~Intents.messa
 
 For more information go to the :ref:`message content intent documentation <need_message_content_intent>`.
 
-If you are unable to get the message content intent and would like some time to migrate to application commands:
-This will only be effective until Discord's current deadline of the 31st of August 2022.
+If you are unable to get the message content intent and would like some time to migrate to application commands you can downgrade the API back to version 9 as shown below.
 
 .. code-block:: python3
 
     nextcord.http._modify_api_version(9)
+
+.. note::
+
+    This will only be effective until Discord's current deadline of the 31st of August 2022.
 
 Guild.bans now returns an AsyncIterator
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/migrating_2.rst
+++ b/docs/migrating_2.rst
@@ -29,6 +29,7 @@ Overview
 - ``missing_perms`` attributes and arguments are renamed to ``missing_permissions``.
 - Many method arguments now reject ``None``.
 - Many arguments are now specified as positional-only or keyword-only; e.g. :func:`oauth_url` now takes keyword-only arguments, and methods starting with ``get_`` or ``fetch_`` take positional-only arguments.
+- You must explicitly enable the :attr:`~Intents.message_content` intent to receive message :attr:`~Message.content`, :attr:`~Message.embeds`, :attr:`~Message.attachments`, and :attr:`~Message.components` in most messages.
 - :meth:`Guild.bans` is no longer a coroutine and returns an :class:`~nextcord.AsyncIterator` instead of a :class:`list`.
 - ``StoreChannel`` is removed as it is deprecated by Discord, see `here <https://support-dev.discord.com/hc/en-us/articles/4414590563479>`_ for more info.
 - ``ChannelType.store`` is removed.
@@ -263,6 +264,19 @@ on_socket_raw_receive behavior
 Guild.get_member taking positional only argument
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 :meth:`Guild.get_member` method's first argument is now positional only.
+
+Intents.message_content must be enabled to receive message content
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+In order to receive message content in most messages, you must have :attr:`Intents.message_content` enabled.
+
+You can do this by using :meth:`Intents.all` or by setting :attr:`~Intents.message_content` to ``True``:
+
+.. code-block:: python3
+
+    intents = nextcord.Intents.default()
+    intents.message_content = True
+
+For more information go to the :ref:`message content intent documentation <need_message_content_intent>`.
 
 Guild.bans now returns an AsyncIterator
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/nextcord/flags.py
+++ b/nextcord/flags.py
@@ -512,11 +512,12 @@ class Intents(BaseFlags):
     @classmethod
     def default(cls: Type[Intents]) -> Intents:
         """A factory method that creates a :class:`Intents` with everything enabled
-        except :attr:`presences` and :attr:`members`.
+        except :attr:`presences`, :attr:`members`, and :attr:`message_content`.
         """
         self = cls.all()
         self.presences = False
         self.members = False
+        self.message_content = False
         return self
 
     @flag_value
@@ -896,6 +897,33 @@ class Intents(BaseFlags):
         return 1 << 14
 
     @flag_value
+    def message_content(self):
+        """:class:`bool`: Whether most message content can be accessed.
+
+        Without this intent, the following attributes may appear empty - either an
+        empty string or empty array depending on the data type:
+
+        - :attr:`Message.content`
+        - :attr:`Message.embeds`
+        - :attr:`Message.attachments`
+        - :attr:`Message.components`
+
+        A bot will always be able to get these attributes from:
+
+        - Messages the bot sends
+        - Messages the bot receives in DMs
+        - Messages in which the bot is mentioned
+
+        For more information go to the :ref:`message content intent documentation <need_message_content_intent>`.
+
+        .. note::
+
+            As of September 1, 2022, this requires opting in explicitly via the developer portal as well.
+            Bots in over 100 guilds will need to apply to Discord for verification.
+        """
+        return 1 << 15
+
+    @flag_value
     def scheduled_events(self):
         """:class:`bool`: Whether scheduled events related events are enabled.
 
@@ -1109,3 +1137,17 @@ class ApplicationFlags(BaseFlags):
     def embedded(self):
         """:class:`bool`: Returns ``True`` if the application is embedded within the Discord client."""
         return 1 << 17
+
+    @flag_value
+    def gateway_message_content(self):
+        """:class:`bool`: Returns ``True`` if the application is allowed to receive message content
+        over the gateway.
+        """
+        return 1 << 18
+
+    @flag_value
+    def gateway_message_content_limited(self):
+        """:class:`bool`: Returns ``True`` if the application is allowed to receive limited
+        message content over the gateway.
+        """
+        return 1 << 19

--- a/nextcord/gateway.py
+++ b/nextcord/gateway.py
@@ -238,7 +238,7 @@ class DiscordClientWebSocketResponse(aiohttp.ClientWebSocketResponse):
 
 
 class DiscordWebSocket:
-    """Implements a WebSocket for Discord's gateway v6.
+    """Implements a WebSocket for Discord's gateway.
 
     Attributes
     -----------
@@ -429,7 +429,6 @@ class DiscordWebSocket:
                 },
                 "compress": True,
                 "large_threshold": 250,
-                "v": 3,
             },
         }
 

--- a/nextcord/guild.py
+++ b/nextcord/guild.py
@@ -2365,7 +2365,7 @@ class Guild(Hashable):
             "tags": emoji,
         }
 
-        data = await self._state.http.create_guild_sticker(self.id, payload, file, reason)
+        data = await self._state.http.create_guild_sticker(self.id, payload, file, reason=reason)
         return self._state.store_sticker(self, data)
 
     async def delete_sticker(self, sticker: Snowflake, *, reason: Optional[str] = None) -> None:

--- a/nextcord/http.py
+++ b/nextcord/http.py
@@ -113,7 +113,7 @@ async def json_or_text(response: aiohttp.ClientResponse) -> Union[Dict[str, Any]
 
 
 class Route:
-    BASE: ClassVar[str] = "https://discord.com/api/v9"
+    BASE: ClassVar[str] = "https://discord.com/api/v10"
 
     def __init__(self, method: str, path: str, **parameters: Any) -> None:
         self.path: str = path
@@ -777,11 +777,7 @@ class HTTPClient:
         r = Route(
             "DELETE", "/guilds/{guild_id}/members/{user_id}", guild_id=guild_id, user_id=user_id
         )
-        if reason:
-            # thanks aiohttp
-            r.url = f"{r.url}?reason={_uriquote(reason)}"
-
-        return self.request(r)
+        return self.request(r, reason=reason)
 
     def ban(
         self,
@@ -2197,9 +2193,9 @@ class HTTPClient:
         except HTTPException as exc:
             raise GatewayNotFound() from exc
         if zlib:
-            value = "{0}?encoding={1}&v=9&compress=zlib-stream"
+            value = "{0}?encoding={1}&v=10&compress=zlib-stream"
         else:
-            value = "{0}?encoding={1}&v=9"
+            value = "{0}?encoding={1}&v=10"
         return value.format(data["url"], encoding)
 
     async def get_bot_gateway(
@@ -2211,9 +2207,9 @@ class HTTPClient:
             raise GatewayNotFound() from exc
 
         if zlib:
-            value = "{0}?encoding={1}&v=9&compress=zlib-stream"
+            value = "{0}?encoding={1}&v=10&compress=zlib-stream"
         else:
-            value = "{0}?encoding={1}&v=9"
+            value = "{0}?encoding={1}&v=10"
         return data["shards"], value.format(data["url"], encoding)
 
     def get_user(self, user_id: Snowflake) -> Response[user.User]:

--- a/nextcord/http.py
+++ b/nextcord/http.py
@@ -116,6 +116,7 @@ async def json_or_text(response: aiohttp.ClientResponse) -> Union[Dict[str, Any]
 _API_VERSION: Literal[9, 10] = 10
 
 
+# TODO: remove once message content is enforced on all versions (31 aug)
 def _modify_api_version(version: Literal[9, 10]):
     if version not in (9, 10):
         raise ValueError("Version must be an integer of `9` or `10`")

--- a/nextcord/message.py
+++ b/nextcord/message.py
@@ -747,7 +747,7 @@ class Message(Hashable):
             # if the channel doesn't have a guild attribute, we handle that
             self.guild = channel.guild  # type: ignore
         except AttributeError:
-            if channel.type is not ChannelType.private and channel.type is not ChannelType.group:
+            if getattr(channel, "type", None) not in (ChannelType.group, ChannelType.private):
                 self.guild = state._get_guild(utils._get_as_snowflake(data, "guild_id"))
             else:
                 self.guild = None

--- a/nextcord/sticker.py
+++ b/nextcord/sticker.py
@@ -516,7 +516,7 @@ class GuildSticker(Sticker):
         HTTPException
             An error occurred deleting the sticker.
         """
-        await self._state.http.delete_guild_sticker(self.guild_id, self.id, reason)
+        await self._state.http.delete_guild_sticker(self.guild_id, self.id, reason=reason)
 
 
 def _sticker_factory(


### PR DESCRIPTION
## Summary

<!-- What is this pull request for? Does it fix any issues? -->
Switches nextcord to use discord api v10 and fixes the [relevant changes](https://discord.com/developers/docs/change-log#api-v10)
in order of changelog
- not used
- not used
- added intent
- changed for kick
- resolved
- was removed in #560
- unused
- unused

closes #467

<u>to test</u>

- [x] message content without intents
- [x] message content with intents
- [x] intents.message_content
- [x] ApplicationFlags.gateway_message_content
- [x] kick
- [x] backport to v9

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
  - [x] I have updated the documentation to reflect the changes.
  - [x] I have run `task pyright` and fixed the relevant issues.
- [x] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [x] This PR is a breaking change (e.g. methods or parameters removed/renamed) technically? message.content will not resolve
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
