### PR TITLE
fix: guild iterator pagination + limits

### DIFF
--- a/nextcord/client.py
+++ b/nextcord/client.py
@@ -1257,7 +1257,7 @@ class Client:
     def fetch_guilds(
         self,
         *,
-        limit: Optional[int] = 100,
+        limit: Optional[int] = 200,
         before: Optional[SnowflakeTime] = None,
         after: Optional[SnowflakeTime] = None,
     ) -> GuildIterator:
@@ -1293,7 +1293,11 @@ class Client:
             The number of guilds to retrieve.
             If ``None``, it retrieves every guild you have access to. Note, however,
             that this would make it a slow operation.
-            Defaults to ``100``.
+            Defaults to ``200``.
+
+            .. versionchanged:: 2.0
+                Changed default to ``200``.
+
         before: Union[:class:`.abc.Snowflake`, :class:`datetime.datetime`]
             Retrieves guilds before this date or object.
             If a datetime is provided, it is recommended to use a UTC aware datetime.

--- a/nextcord/iterators.py
+++ b/nextcord/iterators.py
@@ -684,8 +684,8 @@ class GuildIterator(_AsyncIterator["Guild"]):
 
     def _get_retrieve(self):
         l = self.limit
-        if l is None or l > 100:
-            r = 100
+        if l is None or l > 200:
+            r = 200
         else:
             r = l
         self.retrieve = r
@@ -699,7 +699,7 @@ class GuildIterator(_AsyncIterator["Guild"]):
     async def fill_guilds(self):
         if self._get_retrieve():
             data = await self._retrieve_guilds(self.retrieve)
-            if len(data) < 100:
+            if len(data) < 200:
                 self.limit = 0
 
             if self.reverse:


### PR DESCRIPTION
## Summary

Updates the default limit and page size to 200 ([docs](https://discord.com/developers/docs/resources/user#get-current-user-guilds)), and fixes several issues in `GuildIterator` that could break pagination:
- Only use `before` strategy if `before` parameter was specified
- Don't stop after first page if `limit=None` is set
- Always return results in correct order

Resolves #648

<sup>related: DisnakeDev/disnake#526</sup>

## Checklist

- [x] If code changes were made then they have been tested.
  - [x] I have updated the documentation to reflect the changes.
  - [x] I have run `task pyright` and fixed the relevant issues.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
