### PR TITLE
fix: getting guild when no channel type

### DIFF
--- a/nextcord/message.py
+++ b/nextcord/message.py
@@ -747,7 +747,10 @@ class Message(Hashable):
             # if the channel doesn't have a guild attribute, we handle that
             self.guild = channel.guild  # type: ignore
         except AttributeError:
-            self.guild = state._get_guild(utils._get_as_snowflake(data, "guild_id"))
+            if getattr(channel, "type", None) in (ChannelType.group, ChannelType.private):
+                self.guild = state._get_guild(utils._get_as_snowflake(data, "guild_id"))
+            else:
+                self.guild = None
 
         if thread_data := data.get("thread"):
             if not self.thread and self.guild:

--- a/nextcord/message.py
+++ b/nextcord/message.py
@@ -747,7 +747,7 @@ class Message(Hashable):
             # if the channel doesn't have a guild attribute, we handle that
             self.guild = channel.guild  # type: ignore
         except AttributeError:
-            if getattr(channel, "type", None) in (ChannelType.group, ChannelType.private):
+            if getattr(channel, "type", None) not in (ChannelType.group, ChannelType.private):
                 self.guild = state._get_guild(utils._get_as_snowflake(data, "guild_id"))
             else:
                 self.guild = None

--- a/nextcord/message.py
+++ b/nextcord/message.py
@@ -747,10 +747,7 @@ class Message(Hashable):
             # if the channel doesn't have a guild attribute, we handle that
             self.guild = channel.guild  # type: ignore
         except AttributeError:
-            if channel.type is not ChannelType.private and channel.type is not ChannelType.group:
-                self.guild = state._get_guild(utils._get_as_snowflake(data, "guild_id"))
-            else:
-                self.guild = None
+            self.guild = state._get_guild(utils._get_as_snowflake(data, "guild_id"))
 
         if thread_data := data.get("thread"):
             if not self.thread and self.guild:


### PR DESCRIPTION
## Summary

Fixes #651

An attribute occurs when the channel used to create a message is partial (i.e. an Object with an id, but without other attributes such as type). This can be caused by the lib, for example, using `PartialMessageable.send()`:

```py
Traceback (most recent call last):
  File "nextcord/ext/commands/core.py", line 165, in wrapped
    ret = await coro(*args, **kwargs)
  File "test.py", line 33, in test
    ret = await partial_channel.send("Hello World")
  File "nextcord/dist/../nextcord/abc.py", line 1465, in send
    ret = state.create_message(channel=channel, data=data)
  File "nextcord/dist/../nextcord/state.py", line 1957, in create_message
    return Message(state=self, channel=channel, data=data)
  File "nextcord/dist/../nextcord/message.py", line 750, in __init__
    if channel.type is not ChannelType.private and channel.type is not ChannelType.group:
AttributeError: 'Object' object has no attribute 'type'
```

To fix this, `getattr(channel, "type", None)` can be used instead of `channel.type`.

### Testing (code from issue #651)

```py
@bot.command(aliases=["t"])
async def test(ctx):
    user = ctx.author
    dm_channel = user.dm_channel if user.dm_channel else await user.create_dm()
    partial_channel = bot.get_partial_messageable(dm_channel.id, type=nextcord.ChannelType.private)
    ret = await partial_channel.send("Hello World")
    await ctx.send(f"Sent message {ret}.\n\nGuild ID: {ret.guild}")
```

![image](https://user-images.githubusercontent.com/20955511/169171896-4a148329-632b-4047-9fa2-402a70fed8b0.png)

### Additional info

Prior to #461, this if-else structure was simply:

```py
self.guild = state._get_guild(utils._get_as_snowflake(data, "guild_id"))
```

While this works and does not cause any issues, it was changed in #461 to bring a small performance improvement.

I have changed it to use `getattr()` rather than reverting to the simpler approach in order to keep the "performance improvement" mentioned in the above mentioned PR.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
  - [ ] I have updated the documentation to reflect the changes.
  - [x] I have run `task pyright` and fixed the relevant issues.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
