### PR TITLE
Fixes gateway voice hook fallback

### DIFF
--- a/nextcord/gateway.py
+++ b/nextcord/gateway.py
@@ -784,7 +784,7 @@ class DiscordVoiceWebSocket:
         self.secret_key = None
         self._hook = hook or getattr(self, "_hook", None) or getattr(self, "_default_hook")
 
-    def _default_hook(self, *args):
+    async def _default_hook(self, *args):
         ...
 
     async def send_as_json(self, data):


### PR DESCRIPTION
## Summary

This pull request resolves #660 by making the fallback method `async`. This resolves the issues as the non-async default method returned `None`, which is not `await`able even if the method does nothing. 

## Checklist

- [x] If code changes were made then they have been tested.
  - [ ] I have updated the documentation to reflect the changes.
  - [x] I have run `task pyright` and fixed the relevant issues.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
