### PR TITLE
fix(app-checks): change type aliases to allow for normal funcs

### DIFF
--- a/nextcord/ext/application_checks/core.py
+++ b/nextcord/ext/application_checks/core.py
@@ -99,7 +99,14 @@ class CheckWrapper(CallbackWrapper):
 
 
 AC = Callable[
-    [Union[Callable[[Interaction], bool], BaseApplicationCommand, SlashApplicationSubcommand]],
+    [
+        Union[
+            CoroFunc,
+            Callable[[Interaction], bool],
+            BaseApplicationCommand,
+            SlashApplicationSubcommand,
+        ]
+    ],
     CheckWrapper,
 ]
 

--- a/nextcord/ext/application_checks/core.py
+++ b/nextcord/ext/application_checks/core.py
@@ -98,17 +98,18 @@ class CheckWrapper(CallbackWrapper):
         app_cmd.checks.append(self.predicate)
 
 
-AC = Callable[
-    [
-        Union[
-            CoroFunc,
-            Callable[[Interaction], bool],
-            BaseApplicationCommand,
-            SlashApplicationSubcommand,
-        ]
-    ],
-    CheckWrapper,
-]
+if TYPE_CHECKING:
+    AC = Callable[
+        [
+            Union[
+                CoroFunc,
+                Callable[[Interaction], bool],
+                BaseApplicationCommand,
+                SlashApplicationSubcommand,
+            ]
+        ],
+        CheckWrapper,
+    ]
 
 
 def check(predicate: "ApplicationCheck") -> AC:

--- a/nextcord/types/checks.py
+++ b/nextcord/types/checks.py
@@ -34,7 +34,9 @@ T = TypeVar("T")
 Coro = Coroutine[Any, Any, T]
 MaybeCoro = Union[T, Coro[T]]
 CoroFunc = Callable[..., Coro[Any]]
-ApplicationCheck = Callable[[Interaction], MaybeCoro[bool]]
+ApplicationCheck = Union[
+    Callable[[ClientCog, Interaction], bool], Callable[[Interaction], MaybeCoro[bool]]
+]
 ApplicationHook = Union[
     Callable[[ClientCog, Interaction], Coro[Any]], Callable[[Interaction], Coro[Any]]
 ]

--- a/nextcord/types/checks.py
+++ b/nextcord/types/checks.py
@@ -35,7 +35,7 @@ Coro = Coroutine[Any, Any, T]
 MaybeCoro = Union[T, Coro[T]]
 CoroFunc = Callable[..., Coro[Any]]
 ApplicationCheck = Union[
-    Callable[[ClientCog, Interaction], bool], Callable[[Interaction], MaybeCoro[bool]]
+    Callable[[ClientCog, Interaction], MaybeCoro[bool]], Callable[[Interaction], MaybeCoro[bool]]
 ]
 ApplicationHook = Union[
     Callable[[ClientCog, Interaction], Coro[Any]], Callable[[Interaction], Coro[Any]]


### PR DESCRIPTION
## Summary

<!-- What is this pull request for? Does it fix any issues? -->
Fixes the application checks to allow for normal `async def` functions before they are decorated as a command.
Also allows for cog versions of the above.

(adding `CoroFunc` to the callable union)

the other partially related change is so app checks can be used on cogs w/o type errors

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
  - [x] I have updated the documentation to reflect the changes.
  - [x] I have run `task pyright` and fixed the relevant issues.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
