### PR TITLE
fix(app-cmds): dm_permission causing resync and cmds via bot not registering fully

### DIFF
--- a/nextcord/application_command.py
+++ b/nextcord/application_command.py
@@ -1761,11 +1761,11 @@ class BaseApplicationCommand(CallbackMixin, CallbackWrapperMixin):
             ret["guild_id"] = guild_id
         else:  # Global command specific payload options.
             if self.dm_permission is not None:
-                # While Discord defaults to True, they only send back the DM permission if we set it, so this is fairly
-                #  safe it seems? Going from True to None will cause a command update, but that's not too bad at all.
-                #  They might change this behavior though, so we might need to do a:
-                # if self.dm_permission not in (None, True):
                 ret["dm_permission"] = self.dm_permission
+            else:
+                # Discord seems to send back the DM permission as True regardless if we sent it or not, so we send as
+                #  the default (True) to ensure payload parity for comparisons.
+                ret["dm_permission"] = True
 
         return ret
 

--- a/nextcord/client.py
+++ b/nextcord/client.py
@@ -2395,10 +2395,7 @@ class Client:
 
     def _add_decorated_application_commands(self) -> None:
         for command in self._application_commands_to_add:
-            if isinstance(command, (SlashApplicationCommand, SlashApplicationSubcommand)):
-                command.from_callback(command.callback, call_children=False)
-            else:
-                command.from_callback(command.callback)
+            command.from_callback(command.callback)
 
             self.add_application_command(command, use_rollout=True)
 


### PR DESCRIPTION
Fixed dm_permission causing commands to re-register, fixed app cmds added directly via the Client/Bot decos not fully doing from_callback.

Signed-off-by: Alex Schoenhofen <alexanderschoenhofen@gmail.com>

Biggest thing is that App Cmd's with subcommands added via the Client/Bot deco would not fully unpack, causing parameters to not be registered. This fixes that. Could use more testing.

## Summary

<!-- What is this pull request for? Does it fix any issues? -->

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [X] If code changes were made then they have been tested.
  - [ ] I have updated the documentation to reflect the changes.
  - [ ] I have run `task pyright` and fixed the relevant issues.
- [X] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
