### PR TITLE
fix(app-checks): fix typing for bot_has[_any]_role to allow str

### DIFF
--- a/nextcord/ext/application_checks/core.py
+++ b/nextcord/ext/application_checks/core.py
@@ -348,7 +348,7 @@ def has_any_role(*items: Union[int, str]) -> AC:
     return check(predicate)
 
 
-def bot_has_role(item: int) -> AC:
+def bot_has_role(item: Union[int, str]) -> AC:
     """Similar to :func:`.has_role` except checks if the bot itself has the
     role.
 
@@ -389,7 +389,7 @@ def bot_has_role(item: int) -> AC:
     return check(predicate)
 
 
-def bot_has_any_role(*items: int) -> AC:
+def bot_has_any_role(*items: Union[str, int]) -> AC:
     """Similar to :func:`.has_any_role` except checks if the bot itself has
     any of the roles listed.
 
@@ -400,7 +400,7 @@ def bot_has_any_role(*items: int) -> AC:
 
     Parameters
     -----------
-    items: List[Union[:class:`str`, :class:`int`]]
+    *items: Union[:class:`str`, :class:`int`]
         An argument list of names or IDs to check that the bot has roles wise.
 
     Example


### PR DESCRIPTION
## Summary

<!-- What is this pull request for? Does it fix any issues? -->
Typings for ext.application_checks.core.bot_has[_any]_role does not include `str`, this fixes that.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
  - [x] I have updated the documentation to reflect the changes.
  - [x] I have run `task pyright` and fixed the relevant issues.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
