### PR TITLE
feat: refactor modals to fix select menus

### DIFF
--- a/nextcord/types/components.py
+++ b/nextcord/types/components.py
@@ -28,7 +28,7 @@ from typing import List, Literal, TypedDict, Union
 
 from .emoji import PartialEmoji
 
-ComponentType = Literal[1, 2, 3]
+ComponentType = Literal[1, 2, 3, 4]
 ButtonStyle = Literal[1, 2, 3, 4, 5]
 TextInputStyle = Literal[1, 2]
 

--- a/nextcord/types/interactions.py
+++ b/nextcord/types/interactions.py
@@ -180,6 +180,7 @@ class ApplicationCommandInteractionData(_ApplicationCommandInteractionDataOption
 
 class _ComponentInteractionDataOptional(TypedDict, total=False):
     values: List[str]
+    value: str
 
 
 class ComponentInteractionData(_ComponentInteractionDataOptional):
@@ -187,7 +188,25 @@ class ComponentInteractionData(_ComponentInteractionDataOptional):
     component_type: ComponentType
 
 
-InteractionData = Union[ApplicationCommandInteractionData, ComponentInteractionData]
+class ModalSubmitActionRowInteractionData(TypedDict):
+    type: Literal[1]
+    components: List[ComponentInteractionData]
+
+
+ModalSubmitComponentInteractionData = Union[
+    ModalSubmitActionRowInteractionData,
+    ComponentInteractionData,
+]
+
+
+class ModalSubmitInteractionData(TypedDict):
+    custom_id: str
+    components: List[ModalSubmitComponentInteractionData]
+
+
+InteractionData = Union[
+    ApplicationCommandInteractionData, ComponentInteractionData, ModalSubmitInteractionData
+]
 
 
 class _InteractionOptional(TypedDict, total=False):

--- a/nextcord/ui/item.py
+++ b/nextcord/ui/item.py
@@ -34,6 +34,7 @@ if TYPE_CHECKING:
     from ..components import Component
     from ..enums import ComponentType
     from ..types.components import Component as ComponentPayload
+    from ..types.interactions import ComponentInteractionData
     from .view import View
 
 I = TypeVar("I", bound="Item")
@@ -72,7 +73,7 @@ class Item(Generic[V]):
     def refresh_component(self, component: Component) -> None:
         return None
 
-    def refresh_state(self, interaction: Interaction) -> None:
+    def refresh_state(self, data: ComponentInteractionData) -> None:
         return None
 
     @classmethod

--- a/nextcord/ui/modal.py
+++ b/nextcord/ui/modal.py
@@ -34,7 +34,7 @@ from itertools import groupby
 from typing import TYPE_CHECKING, Any, Callable, Dict, Iterator, List, Optional, Tuple
 
 from ..components import Component
-from ..utils import MISSING, find
+from ..utils import MISSING
 from .item import Item
 from .view import _component_to_item, _ViewWeights, _walk_all_components
 
@@ -273,14 +273,10 @@ class Modal:
     async def _scheduled_task(self, interaction: Interaction):
         data: ModalSubmitInteractionData = interaction.data  # type: ignore
         for child in self.children:
-            find_component: Callable[[ComponentInteractionData, Item[Any]], bool] = (
-                lambda c, child=child: c["custom_id"] == child.custom_id  # type: ignore
-            )
-            component_data: Optional[ComponentInteractionData] = find(
-                find_component, _walk_component_interaction_data(data["components"])
-            )
-            if component_data is not None:
-                child.refresh_state(component_data)
+            for component_data in _walk_component_interaction_data(data["components"]):
+                if component_data["custom_id"] == child.custom_id:  # type: ignore
+                    child.refresh_state(component_data)
+                    break
         try:
             if self.timeout:
                 self.__timeout_expiry = time.monotonic() + self.timeout

--- a/nextcord/ui/modal.py
+++ b/nextcord/ui/modal.py
@@ -49,9 +49,9 @@ if TYPE_CHECKING:
     from ..state import ConnectionState
     from ..types.components import ActionRow as ActionRowPayload
     from ..types.interactions import (
-        ModalSubmitInteractionData,
-        ModalSubmitComponentInteractionData,
         ComponentInteractionData,
+        ModalSubmitComponentInteractionData,
+        ModalSubmitInteractionData,
     )
 
 

--- a/nextcord/ui/select.py
+++ b/nextcord/ui/select.py
@@ -265,8 +265,7 @@ class Select(Item[V]):
     def refresh_component(self, component: SelectMenu) -> None:
         self._underlying = component
 
-    def refresh_state(self, interaction: Interaction) -> None:
-        data: ComponentInteractionData = interaction.data  # type: ignore
+    def refresh_state(self, data: ComponentInteractionData) -> None:
         self._selected_values = data.get("values", [])
 
     @classmethod

--- a/nextcord/ui/select.py
+++ b/nextcord/ui/select.py
@@ -31,7 +31,6 @@ from typing import TYPE_CHECKING, Callable, List, Optional, Tuple, Type, TypeVar
 from ..components import SelectMenu, SelectOption
 from ..emoji import Emoji
 from ..enums import ComponentType
-from ..interactions import Interaction
 from ..partial_emoji import PartialEmoji
 from ..utils import MISSING
 from .item import Item, ItemCallbackType

--- a/nextcord/ui/text_input.py
+++ b/nextcord/ui/text_input.py
@@ -45,14 +45,6 @@ T = TypeVar("T", bound="TextInput")
 V = TypeVar("V", bound="View", covariant=True)
 
 
-def _walk_all_components(components):
-    for item in components:
-        if item["type"] == 1:
-            yield from item["components"]
-        else:
-            yield item
-
-
 class TextInput(Item[V]):
     """Represent a UI text input.
 
@@ -253,9 +245,5 @@ class TextInput(Item[V]):
     def refresh_component(self, text_input: TextInputComponent) -> None:
         self._underlying = text_input
 
-    def refresh_state(self, interaction: Interaction) -> None:
-        data: ComponentInteractionData = interaction.data  # type: ignore
-        for component_data in _walk_all_components(data["components"]):  # type: ignore
-            if component_data["custom_id"] == self.custom_id:
-                self._inputed_value = component_data["value"]
-                return
+    def refresh_state(self, data: ComponentInteractionData) -> None:
+        self._inputed_value = data.get("value", "")

--- a/nextcord/ui/text_input.py
+++ b/nextcord/ui/text_input.py
@@ -29,7 +29,6 @@ from typing import TYPE_CHECKING, Optional, Tuple, Type, TypeVar
 
 from ..components import TextInput as TextInputComponent
 from ..enums import ComponentType, TextInputStyle
-from ..interactions import Interaction
 from ..utils import MISSING
 from .item import Item
 

--- a/nextcord/ui/text_input.py
+++ b/nextcord/ui/text_input.py
@@ -122,7 +122,7 @@ class TextInput(Item[V]):
 
     @property
     def style(self) -> TextInputStyle:
-        """:class:`nextcord.TextInputStyle`: The style of the button."""
+        """:class:`nextcord.TextInputStyle`: The style of the text input."""
         return self._underlying.style
 
     @style.setter
@@ -131,7 +131,7 @@ class TextInput(Item[V]):
 
     @property
     def custom_id(self) -> Optional[str]:
-        """Optional[:class:`str`]: The ID of the button that gets received during an interaction."""
+        """Optional[:class:`str`]: The ID of the text input that gets received during an interaction."""
         return self._underlying.custom_id
 
     @custom_id.setter

--- a/nextcord/ui/view.py
+++ b/nextcord/ui/view.py
@@ -545,7 +545,7 @@ class ViewStore:
             return
 
         view, item = value
-        item.refresh_state(interaction)
+        item.refresh_state(interaction.data)  # type: ignore
         view._dispatch_item(item, interaction)
 
     def is_message_tracked(self, message_id: int):


### PR DESCRIPTION
## Summary

Fixes #668

This refactors Modals to allow any components added to the modal to receive state updates from the interaction callback.

Previously, this was made to work specifically for Text Inputs. In this PR, the logic is moved from text inputs to modals so that all components (i.e. select menus and any new components that are yet to come) will be updated correctly.

This has been tested with TextInput and Select in Modals, and components in Views. (Select menus in Modals are still not available on mobile yet, so they have only been tested on Discord desktop).

### Description of bug

The current behavior is that by adding a select menu, it will appear, but after submitting the form, the `select.values` will appear as an empty list.

This PR, while refactoring modals, fixes this issue and will allow select menus to work properly where Discord supports them.

### Changes

* Changed `Item.refresh_state` to take `ComponentInteractionData` instead of `Interaction` since the `Interaction` object is different for modals and views but the `ComponentInteractionData` objects within them have the same structure
* Moved walking through the modal data out of `TextInput.refresh_state` and instead into the Modal class, since `TextInput` is not the only type of item that will be supported by modals
* Some minor fixes and additions in `nextcord.types` related to Modal and TextInput
* Fixed two docstring errors in TextInput

### Example

https://paste.nextcord.dev/?id=1654744456901818

![image](https://user-images.githubusercontent.com/20955511/172756542-a810c90b-738a-45d9-85ea-0c12b3c008be.png)

![image](https://user-images.githubusercontent.com/20955511/172756687-55712caa-05e4-45a1-bf44-590adcf5410e.png)


## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
  - [x] I have updated the documentation to reflect the changes.
  - [x] I have run `task pyright` and fixed the relevant issues.
- [x] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
