### PR TITLE
feat: Warn when using ext.commands without message content intent

### DIFF
--- a/docs/ext/commands/api.rst
+++ b/docs/ext/commands/api.rst
@@ -443,7 +443,6 @@ Warnings
 ---------
 
 .. autoclass:: nextcord.ext.commands.MissingMessageContentIntentWarning
-    :members:
 
 Exceptions
 -----------

--- a/docs/ext/commands/api.rst
+++ b/docs/ext/commands/api.rst
@@ -439,6 +439,12 @@ Flag Converter
 
 .. _ext_commands_api_errors:
 
+Warnings
+---------
+
+.. autoclass:: nextcord.ext.commands.MissingMessageContentIntentWarning
+    :members:
+
 Exceptions
 -----------
 

--- a/nextcord/ext/commands/bot.py
+++ b/nextcord/ext/commands/bot.py
@@ -128,7 +128,24 @@ _default = _DefaultRepr()
 
 
 class MissingMessageContentIntentWarning(UserWarning):
-    ...
+    """Warning category raised when instantiating a :class:`~nextcord.ext.commands.Bot` with a
+    :attr:`~nextcord.ext.commands.Bot.command_prefix` but without the :attr:`~nextcord.Intents.message_content`
+    intent enabled.
+
+    This warning is not raised when the :attr:`~nextcord.ext.commands.Bot.command_prefix`
+    is set to an empty iterable or :func:`when_mentioned <nextcord.ext.commands.when_mentioned>`.
+
+    This warning can be silenced using :func:`warnings.simplefilter`.
+
+    .. code-block:: python3
+
+        import warnings
+        from nextcord.ext import commands
+
+        warnings.simplefilter('ignore', commands.MissingMessageContentIntentWarning)
+    """
+
+    pass
 
 
 class BotBase(GroupMixin):

--- a/nextcord/ext/commands/bot.py
+++ b/nextcord/ext/commands/bot.py
@@ -142,7 +142,7 @@ class MissingMessageContentIntentWarning(UserWarning):
         import warnings
         from nextcord.ext import commands
 
-        warnings.simplefilter('ignore', commands.MissingMessageContentIntentWarning)
+        warnings.simplefilter("ignore", commands.MissingMessageContentIntentWarning)
     """
 
     pass

--- a/nextcord/ext/commands/bot.py
+++ b/nextcord/ext/commands/bot.py
@@ -160,7 +160,7 @@ class BotBase(GroupMixin):
             (
                 callable(self.command_prefix)
                 or isinstance(self.command_prefix, str)
-                or len(self.command_prefix) > 0  # type: ignore
+                or len(self.command_prefix) > 0
             )
             and self.command_prefix is not when_mentioned
             and hasattr(self, "intents")

--- a/nextcord/ext/commands/bot.py
+++ b/nextcord/ext/commands/bot.py
@@ -34,19 +34,7 @@ import sys
 import traceback
 import types
 import warnings
-from typing import (
-    TYPE_CHECKING,
-    Any,
-    Callable,
-    Dict,
-    Iterable,
-    List,
-    Mapping,
-    Optional,
-    Type,
-    TypeVar,
-    Union,
-)
+from typing import TYPE_CHECKING, Any, Callable, Dict, List, Mapping, Optional, Type, TypeVar, Union
 
 import nextcord
 
@@ -63,9 +51,7 @@ if TYPE_CHECKING:
     from nextcord.message import Message
     from nextcord.types.checks import ApplicationCheck, ApplicationHook
 
-    from ._types import Check, CoroFunc, MaybeCoro
-
-    PrefixType = Union[str, Iterable[str], Callable[..., MaybeCoro[Union[str, Iterable[str]]]]]
+    from ._types import Check, CoroFunc
 
 __all__ = (
     "when_mentioned",
@@ -148,7 +134,7 @@ class MissingMessageContentIntentWarning(UserWarning):
 class BotBase(GroupMixin):
     def __init__(self, command_prefix=MISSING, help_command=_default, description=None, **options):
         super().__init__(**options)
-        self.command_prefix: PrefixType = command_prefix if command_prefix is not MISSING else []
+        self.command_prefix = command_prefix if command_prefix is not MISSING else tuple()
         self.extra_events: Dict[str, List[CoroFunc]] = {}
         self.__cogs: Dict[str, Cog] = {}
         self.__extensions: Dict[str, types.ModuleType] = {}
@@ -991,9 +977,9 @@ class BotBase(GroupMixin):
             A list of prefixes or a single prefix that the bot is
             listening for.
         """
-        ret = self.command_prefix
-        if callable(ret):
-            ret = await nextcord.utils.maybe_coroutine(ret, self, message)
+        prefix = ret = self.command_prefix
+        if callable(prefix):
+            ret = await nextcord.utils.maybe_coroutine(prefix, self, message)
 
         if not isinstance(ret, str):
             try:
@@ -1277,7 +1263,7 @@ class Bot(BotBase, nextcord.Client):
 
     Attributes
     -----------
-    command_prefix: Union[:class:`str`, Iterable[:class:`str`], Callable[..., MaybeCoro[Union[:class:`str`, Iterable[:class:`str`]]]]]
+    command_prefix
         The command prefix is what the message content must contain initially
         to have a command invoked. This prefix could either be a string to
         indicate what the prefix should be, or a callable that takes in the bot


### PR DESCRIPTION
## Summary

Since `commands.Bot` is for the ext commands framework which, for the most part, requires message content to work, there can be a warning on startup if `intents.message_content` is not enabled.

This only applies when creating a bot with `commands.Bot` and the `command_prefix` is not an empty iterable or `commands.when_mentioned` since if there's no prefix, there are obviously no commands to listen for and if it is `when_mentioned`, the bot will receive the message content since it will always be mentioned in the messages.

One issue is that DM commands still work without message content intent and it's hard to know if they intend to only have commands work in DMs or not. In this rare case, the user can disable the warning using:

```py
import warnings

warnings.simplefilter("ignore", category=commands.MissingMessageContentIntentWarning)
```

## Screenshot

![image](https://user-images.githubusercontent.com/20955511/172963243-75687807-87e8-4b81-8b7b-67c5a9909d7c.png)

## Non-compliant code

```py
# command prefix is specified, but no intents are enabled
bot = commands.Bot(command_prefix="$")
```
```py
# command prefix is specified, but message_content is not enabled
intents = nextcord.Intents.default()
bot = commands.Bot(command_prefix="$", intents=intents)
```

## Compliant code

```py
# message content is explicitly enabled
intents = nextcord.Intents.default()
intents.message_content = True
bot = commands.Bot(command_prefix="$", intents=intents)
```
```py
# all intents are enabled
intents = nextcord.Intents.all()
bot = commands.Bot(command_prefix="$", intents=intents)
```
```py
# no command prefixes
bot = commands.Bot()
```
```py
# only responds when mentioned
bot = commands.Bot(command_prefix=commands.when_mentioned)
```

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
  - [x] I have updated the documentation to reflect the changes.
  - [x] I have run `task pyright` and fixed the relevant issues.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
