### PR TITLE
chore: bump version_info to beta release level

### DIFF
--- a/nextcord/__init__.py
+++ b/nextcord/__init__.py
@@ -74,6 +74,6 @@ class VersionInfo(NamedTuple):
     serial: int
 
 
-version_info: VersionInfo = VersionInfo(major=2, minor=0, micro=0, releaselevel="alpha", serial=0)
+version_info: VersionInfo = VersionInfo(major=2, minor=0, micro=0, releaselevel="beta", serial=0)
 
 logging.getLogger(__name__).addHandler(logging.NullHandler())

--- a/nextcord/__init__.py
+++ b/nextcord/__init__.py
@@ -74,6 +74,6 @@ class VersionInfo(NamedTuple):
     serial: int
 
 
-version_info: VersionInfo = VersionInfo(major=2, minor=0, micro=0, releaselevel="beta", serial=0)
+version_info: VersionInfo = VersionInfo(major=2, minor=0, micro=0, releaselevel="beta", serial=3)
 
 logging.getLogger(__name__).addHandler(logging.NullHandler())


### PR DESCRIPTION
## Summary

This effects the version info printed by `nextcord.__main__.show_version()` or `py -m nextcord -v`

The output currently says "alpha" for nextcord, and not "beta".
```diff
Python v3.10.5-final
- nextcord v2.0.0-alpha
+ nextcord v2.0.0-beta
    nextcord pkg_resources: v2.0.0b3
aiohttp v3.8.1
 ```

We may want to bump the serial code at each release as well when `__version__` is bumped, although it isn't printed by `show_version` and the pkg_resources is printed when the release level is not final so it's not entirely necessary as of now.

Thoughts @ooliver1?

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
  - [x] I have updated the documentation to reflect the changes.
  - [x] I have run `task pyright` and fixed the relevant issues.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
