### PR TITLE
fix: avoid appending children on view refresh

### DIFF
--- a/nextcord/ui/view.py
+++ b/nextcord/ui/view.py
@@ -25,6 +25,7 @@ DEALINGS IN THE SOFTWARE.
 from __future__ import annotations
 
 import asyncio
+import logging
 import os
 import sys
 import time
@@ -56,12 +57,13 @@ from .item import Item, ItemCallbackType
 
 __all__ = ("View",)
 
-
 if TYPE_CHECKING:
     from ..interactions import Interaction
     from ..message import Message
     from ..state import ConnectionState
     from ..types.components import ActionRow as ActionRowPayload, Component as ComponentPayload
+
+_log = logging.getLogger(__name__)
 
 
 def _walk_all_components(components: List[Component]) -> Iterator[Component]:
@@ -417,25 +419,29 @@ class View:
         )
 
     def refresh(self, components: List[Component]):
-        # This is pretty hacky at the moment
         # fmt: off
-        old_state: Dict[Tuple[int, str], Item] = {
-            (item.type.value, item.custom_id): item  # type: ignore
+        old_state: Dict[str, Item[Any]] = {
+            item.custom_id: item  # type: ignore
             for item in self.children
             if item.is_dispatchable()
         }
         # fmt: on
-        children: List[Item] = []
+
         for component in _walk_all_components(components):
+            custom_id = getattr(component, "custom_id", None)
+            if custom_id is None:
+                continue
+
             try:
-                older = old_state[(component.type.value, component.custom_id)]  # type: ignore
-            except (KeyError, AttributeError):
-                children.append(_component_to_item(component))
+                older = old_state[custom_id]
+            except KeyError:
+                _log.debug(
+                    "View interaction referenced an unknown item custom_id %s. Discarding",
+                    custom_id,
+                )
+                continue
             else:
                 older.refresh_component(component)
-                children.append(older)
-
-        self.children = children
 
     def stop(self) -> None:
         """Stops listening to interaction events from this view.


### PR DESCRIPTION
## Summary

Fixes #331 

Credit to Danny (https://github.com/Rapptz/discord.py/commit/e198a0e7e6df58bdfcba1cdbf31345ed67c5f10e) for this fix.

> The older code attempted to be clever and sync component additions and
> removals with what the message edit is doing. In some cases, this led
> to the re-creation of those components causing lost attributes to be
> dropped such as `_rendered_row` which would mess up handling of view
> weights.
> 
> Instead of recreating the children list every time and keeping track
> of additions and removals, this change just updates the old state with
> the new state while ignoring any new or removed additions. This should
> work fine in theory due to additions or removals already being present
> before editing the View instance in the first place.

Also fixes an issue where components get added extra times and cause a maximum width error:

```py
nextcord.errors.HTTPException: 400 Bad Request (error code: 50035): Invalid Form Body
In components.0.components.1: The specified component exceeds the maximum width
In components.0.components.2: The specified component exceeds the maximum width
In components.0.components.3: The specified component exceeds the maximum width
```

Test code: https://paste.nextcord.dev/?id=1655057132841671

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
  - [x] I have updated the documentation to reflect the changes.
  - [x] I have run `task pyright` and fixed the relevant issues.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
