### PR TITLE
docs(ui): document public attributes

### DIFF
--- a/nextcord/ui/modal.py
+++ b/nextcord/ui/modal.py
@@ -74,6 +74,8 @@ class Modal:
 
     Attributes
     ------------
+    title: :class:`str`
+        The title of the modal.
     timeout: Optional[:class:`float`]
         Timeout from last interaction with the UI before no longer accepting input.
         If ``None`` then there is no timeout.
@@ -81,6 +83,10 @@ class Modal:
         The list of children attached to this modal.
     custom_id: :class:`str`
         The ID of the modal that gets received during an interaction.
+    auto_defer: :class:`bool` = True
+        Whether or not to automatically defer the modal when the callback completes
+        without responding to the interaction. Set this to ``False`` if you want to
+        handle the modal interaction outside of the callback.
     """
 
     def __init__(

--- a/nextcord/ui/view.py
+++ b/nextcord/ui/view.py
@@ -154,6 +154,10 @@ class View:
         If ``None`` then there is no timeout.
     children: List[:class:`Item`]
         The list of children attached to this view.
+    auto_defer: :class:`bool` = True
+        Whether or not to automatically defer the component interaction when the callback
+        completes without responding to the interaction. Set this to ``False`` if you want to
+        handle view interactions outside of the callback.
     """
 
     __discord_ui_view__: ClassVar[bool] = True


### PR DESCRIPTION
## Summary

Document `ui.Modal.title` and `.auto_defer` to both `ui.Modal` and `ui.View`, which are public attributes.
Yesterday, someone in the nextcord guild's help channel was unaware the title attribute exists and accidentally overrode it, causing a confusing `TextInput is not JSON serializable`
<!-- What is this pull request for? Does it fix any issues? -->

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
  - [ ] I have updated the documentation to reflect the changes.
  - [ ] I have run `task pyright` and fixed the relevant issues.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
