### PR TITLE
fix(commands): only set flag annotation if not set yet

### DIFF
--- a/nextcord/ext/commands/flags.py
+++ b/nextcord/ext/commands/flags.py
@@ -168,7 +168,8 @@ def get_flags(
     for name, annotation in annotations.items():
         flag = namespace.pop(name, MISSING)
         if isinstance(flag, Flag):
-            flag.annotation = annotation
+            if flag.annotation is MISSING:
+                flag.annotation = annotation
         else:
             flag = Flag(name=name, annotation=annotation, default=flag)
 


### PR DESCRIPTION
## Summary

fixes #16
only set `flag.annotation` if it has not been provided to the dataclass (`MISSING` by default in `Flag`)
<!-- What is this pull request for? Does it fix any issues? -->

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
  - [x] I have updated the documentation to reflect the changes.
  - [x] I have run `task pyright` and fixed the relevant issues.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
