### PR TITLE
fix(ext-cmds): copy context before dispatching on_command

### DIFF
--- a/nextcord/ext/commands/bot.py
+++ b/nextcord/ext/commands/bot.py
@@ -28,6 +28,7 @@ from __future__ import annotations
 import asyncio
 import collections
 import collections.abc
+import copy
 import importlib.util
 import inspect
 import sys
@@ -1062,7 +1063,7 @@ class BotBase(GroupMixin):
             The invocation context to invoke.
         """
         if ctx.command is not None:
-            self.dispatch("command", ctx)
+            self.dispatch("command", copy.copy(ctx))
             try:
                 if await self.can_run(ctx, call_once=True):
                     await ctx.command.invoke(ctx)

--- a/nextcord/ext/commands/core.py
+++ b/nextcord/ext/commands/core.py
@@ -1177,18 +1177,14 @@ class Command(_BaseCommand, Generic[CogT, P, T]):
                 if local_check is not None:
                     ret = await nextcord.utils.maybe_coroutine(local_check, ctx)
                     if not ret:
-                        ctx.command = original
                         return False
 
             predicates = self.checks
             if not predicates:
                 # since we have no checks, then we just return True.
-                ctx.command = original
                 return True
 
-            result = await nextcord.utils.async_all(predicate(ctx) for predicate in predicates)  # type: ignore
-            ctx.command = original
-            return result
+            return await nextcord.utils.async_all(predicate(ctx) for predicate in predicates)  # type: ignore
         finally:
             ctx.command = original
 

--- a/nextcord/ext/commands/core.py
+++ b/nextcord/ext/commands/core.py
@@ -1177,13 +1177,16 @@ class Command(_BaseCommand, Generic[CogT, P, T]):
                 if local_check is not None:
                     ret = await nextcord.utils.maybe_coroutine(local_check, ctx)
                     if not ret:
+                        ctx.command = original
                         return False
 
             predicates = self.checks
             if not predicates:
                 # since we have no checks, then we just return True.
+                ctx.command = original
                 return True
 
+            ctx.command = original
             return await nextcord.utils.async_all(predicate(ctx) for predicate in predicates)  # type: ignore
         finally:
             ctx.command = original

--- a/nextcord/ext/commands/core.py
+++ b/nextcord/ext/commands/core.py
@@ -1186,8 +1186,9 @@ class Command(_BaseCommand, Generic[CogT, P, T]):
                 ctx.command = original
                 return True
 
+            result = await nextcord.utils.async_all(predicate(ctx) for predicate in predicates)  # type: ignore
             ctx.command = original
-            return await nextcord.utils.async_all(predicate(ctx) for predicate in predicates)  # type: ignore
+            return result
         finally:
             ctx.command = original
 


### PR DESCRIPTION
## Summary

fixes #105
copies ctx that is dispatched for `on_command` so a race condition on the race track of `ext.commands` doesnt take over
<!-- What is this pull request for? Does it fix any issues? -->

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
  - [x] I have updated the documentation to reflect the changes.
  - [x] I have run `task pyright` and fixed the relevant issues.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
