### PR TITLE
feat: add on_application_command_completion event

### DIFF
--- a/docs/ext/application_checks/index.rst
+++ b/docs/ext/application_checks/index.rst
@@ -88,6 +88,13 @@ Events
     :param error: The error that occurred.
     :type error: :class:`Exception`
 
+.. function:: on_application_command_completion(interaction)
+
+    The event that is fired when the application command invoked completed successfully without any errors.
+
+    :param interaction: The interaction of the invoked application command.
+    :type interaction: :class:`~.Interaction`
+
 Exceptions
 ----------
 

--- a/nextcord/application_command.py
+++ b/nextcord/application_command.py
@@ -825,6 +825,8 @@ class CallbackMixin:
                     ApplicationInvokeError(error),
                 )
                 await self.invoke_error(interaction, error)
+            else:
+                state.dispatch("application_command_completion", interaction)
             finally:
                 if self._callback_after_invoke is not None:
                     await self._callback_after_invoke(interaction)  # type: ignore


### PR DESCRIPTION
## Summary

This adds a new event that is dispatched whenever an application command callback finishes executing with no errors. Closes #676.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
  - [ ] I have updated the documentation to reflect the changes.
  - [ ] I have run `task pyright` and fixed the relevant issues.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
