### PR TITLE
fix: Apply checks to context menu commands

### DIFF
--- a/nextcord/application_command.py
+++ b/nextcord/application_command.py
@@ -2236,6 +2236,7 @@ class SlashApplicationSubcommand(SlashCommandMixin, AutocompleteCommandMixin, Ca
             self.checks.extend(self.parent_cmd.checks)
             self._callback_before_invoke = self.parent_cmd._callback_before_invoke
             self._callback_after_invoke = self.parent_cmd._callback_after_invoke
+
         super().from_autocomplete()
 
     def subcommand(

--- a/nextcord/application_command.py
+++ b/nextcord/application_command.py
@@ -2027,6 +2027,8 @@ class BaseApplicationCommand(CallbackMixin, CallbackWrapperMixin):
         option_class: Optional[Type[BaseCommandOption]] = BaseCommandOption,
     ) -> None:
         super().from_callback(callback=callback, option_class=option_class)
+        for modify_callback in self.modify_callbacks:
+            modify_callback(self)
 
     async def call_from_interaction(self, interaction: Interaction) -> None:
         """|coro|
@@ -2234,10 +2236,7 @@ class SlashApplicationSubcommand(SlashCommandMixin, AutocompleteCommandMixin, Ca
             self.checks.extend(self.parent_cmd.checks)
             self._callback_before_invoke = self.parent_cmd._callback_before_invoke
             self._callback_after_invoke = self.parent_cmd._callback_after_invoke
-
         super().from_autocomplete()
-        for modify_callback in self.modify_callbacks:
-            modify_callback(self)
 
     def subcommand(
         self,
@@ -2407,9 +2406,6 @@ class SlashApplicationCommand(SlashCommandMixin, BaseApplicationCommand, Autocom
                 child.from_callback(
                     callback=child.callback, option_class=option_class, call_children=call_children
                 )
-
-        for modify_callback in self.modify_callbacks:
-            modify_callback(self)
 
     def subcommand(
         self,

--- a/nextcord/application_command.py
+++ b/nextcord/application_command.py
@@ -195,6 +195,10 @@ class CallbackWrapperMixin:
         if isinstance(callback, CallbackWrapper):
             self.modify_callbacks += callback.modify_callbacks
 
+    def modify(self) -> None:
+        for modify_callback in self.modify_callbacks:
+            modify_callback(self)
+
 
 class ApplicationCommandOption:
     """This represents the `Application Command Option Structure
@@ -2027,8 +2031,6 @@ class BaseApplicationCommand(CallbackMixin, CallbackWrapperMixin):
         option_class: Optional[Type[BaseCommandOption]] = BaseCommandOption,
     ) -> None:
         super().from_callback(callback=callback, option_class=option_class)
-        for modify_callback in self.modify_callbacks:
-            modify_callback(self)
 
     async def call_from_interaction(self, interaction: Interaction) -> None:
         """|coro|
@@ -2238,6 +2240,7 @@ class SlashApplicationSubcommand(SlashCommandMixin, AutocompleteCommandMixin, Ca
             self._callback_after_invoke = self.parent_cmd._callback_after_invoke
 
         super().from_autocomplete()
+        CallbackWrapperMixin.modify(self)
 
     def subcommand(
         self,
@@ -2408,6 +2411,8 @@ class SlashApplicationCommand(SlashCommandMixin, BaseApplicationCommand, Autocom
                     callback=child.callback, option_class=option_class, call_children=call_children
                 )
 
+        CallbackWrapperMixin.modify(self)
+
     def subcommand(
         self,
         name: Optional[str] = None,
@@ -2529,6 +2534,7 @@ class UserApplicationCommand(BaseApplicationCommand):
         option_class: Optional[Type[BaseCommandOption]] = None,
     ):
         super().from_callback(callback, option_class=option_class)
+        CallbackWrapperMixin.modify(self)
 
 
 class MessageApplicationCommand(BaseApplicationCommand):
@@ -2602,6 +2608,7 @@ class MessageApplicationCommand(BaseApplicationCommand):
         option_class: Optional[Type[BaseCommandOption]] = None,
     ):
         super().from_callback(callback, option_class=option_class)
+        CallbackWrapperMixin.modify(self)
 
 
 def slash_command(


### PR DESCRIPTION
## Summary

Fixes #697 

Cals the callback modifiers for all types of application commands instead of just Slash commands.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
  - [x] I have updated the documentation to reflect the changes.
  - [x] I have run `task pyright` and fixed the relevant issues.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
