### PR TITLE
feat(commands): CommandNotFound now has command_name shortcut to ctx.invoked_with

### DIFF
--- a/nextcord/ext/commands/bot.py
+++ b/nextcord/ext/commands/bot.py
@@ -1118,7 +1118,7 @@ class BotBase(GroupMixin):
             else:
                 self.dispatch("command_completion", ctx)
         elif ctx.invoked_with:
-            exc = errors.CommandNotFound(f'Command "{ctx.invoked_with}" is not found')
+            exc = errors.CommandNotFound(f'Command "{ctx.invoked_with}" is not found', command_name=ctx.invoked_with)
             self.dispatch("command_error", ctx, exc)
 
     async def process_commands(self, message: Message) -> None:

--- a/nextcord/ext/commands/bot.py
+++ b/nextcord/ext/commands/bot.py
@@ -1118,9 +1118,7 @@ class BotBase(GroupMixin):
             else:
                 self.dispatch("command_completion", ctx)
         elif ctx.invoked_with:
-            exc = errors.CommandNotFound(
-                f'Command "{ctx.invoked_with}" is not found', command_name=ctx.invoked_with
-            )
+            exc = errors.CommandNotFound(ctx.invoked_with)
             self.dispatch("command_error", ctx, exc)
 
     async def process_commands(self, message: Message) -> None:

--- a/nextcord/ext/commands/bot.py
+++ b/nextcord/ext/commands/bot.py
@@ -1118,7 +1118,9 @@ class BotBase(GroupMixin):
             else:
                 self.dispatch("command_completion", ctx)
         elif ctx.invoked_with:
-            exc = errors.CommandNotFound(f'Command "{ctx.invoked_with}" is not found', command_name=ctx.invoked_with)
+            exc = errors.CommandNotFound(
+                f'Command "{ctx.invoked_with}" is not found', command_name=ctx.invoked_with
+            )
             self.dispatch("command_error", ctx, exc)
 
     async def process_commands(self, message: Message) -> None:

--- a/nextcord/ext/commands/errors.py
+++ b/nextcord/ext/commands/errors.py
@@ -167,10 +167,9 @@ class CommandNotFound(CommandError):
         The command that was not found.
     """
 
-    def __init__(self, message: Optional[str] = None, *, command_name: str) -> None:
-        self.message: Optional[str] = message
+    def __init__(self, command_name: str) -> None:
         self.command_name: str = command_name
-        super().__init__(message or f'Command "{self.command_name}" is not found')
+        super().__init__(f'Command "{self.command_name}" is not found')
 
 
 class MissingRequiredArgument(UserInputError):

--- a/nextcord/ext/commands/errors.py
+++ b/nextcord/ext/commands/errors.py
@@ -161,6 +161,9 @@ class CommandNotFound(CommandError):
 
     This inherits from :exc:`CommandError`.
 
+    .. versionchanged:: 2.1
+        Added :attr:`command_name` as a parameter.
+
     Attributes
     -----------
     command_name: :class:`str`

--- a/nextcord/ext/commands/errors.py
+++ b/nextcord/ext/commands/errors.py
@@ -160,9 +160,17 @@ class CommandNotFound(CommandError):
     initial main command that is attempted to be invoked.
 
     This inherits from :exc:`CommandError`.
+
+    Attributes
+    -----------
+    command_name: :class:`str`
+        The command that was not found.
     """
 
-    pass
+    def __init__(self, message: Optional[str] = None, *, command_name: str) -> None:
+        self.message: str = message
+        self.command_name: str = command_name
+        super().__init__(message or f'Command "{self.command_name}" is not found')
 
 
 class MissingRequiredArgument(UserInputError):

--- a/nextcord/ext/commands/errors.py
+++ b/nextcord/ext/commands/errors.py
@@ -168,7 +168,7 @@ class CommandNotFound(CommandError):
     """
 
     def __init__(self, message: Optional[str] = None, *, command_name: str) -> None:
-        self.message: str = message
+        self.message: Optional[str] = message
         self.command_name: str = command_name
         super().__init__(message or f'Command "{self.command_name}" is not found')
 


### PR DESCRIPTION
## Summary

Add a shortcut to command_name in the `CommandNotFound` error. 
I found that using ctx.invoked_with is a bit more "complicated" to figure out than just a `command_name` parameter on the error itself.
resolves #382


## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
  - [x] I have updated the documentation to reflect the changes.
  - [x] I have run `task pyright` and fixed the relevant issues.
- [x] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
