### PR TITLE
docs(migrating): fix broken link and reword "info"

### DIFF
--- a/docs/migrating_2.rst
+++ b/docs/migrating_2.rst
@@ -31,7 +31,7 @@ Overview
 - Many arguments are now specified as positional-only or keyword-only; e.g. :func:`oauth_url` now takes keyword-only arguments, and methods starting with ``get_`` or ``fetch_`` take positional-only arguments.
 - You must explicitly enable the :attr:`~Intents.message_content` intent to receive message :attr:`~Message.content`, :attr:`~Message.embeds`, :attr:`~Message.attachments`, and :attr:`~Message.components` in most messages.
 - :meth:`Guild.bans` is no longer a coroutine and returns an :class:`~nextcord.AsyncIterator` instead of a :class:`list`.
-- ``StoreChannel`` is removed as it is deprecated by Discord, see `here <https://support-dev.discord.com/hc/en-us/articles/4414590563479>`_ for more info.
+- ``StoreChannel`` is removed as it is deprecated by Discord, see `here <https://support.discord.com/hc/en-us/articles/4688647258007-Self-serve-Game-Selling-Deprecation>`_ for more info.
 - ``ChannelType.store`` is removed.
 - ``AppInfo.summary``, ``AppInfo.guild_id``, ``AppInfo.primary_sku_id`` and ``AppInfo.slug`` are removed.
 - ``PartialAppInfo.summary`` is removed.


### PR DESCRIPTION
## Summary

+ Dead link got fixed
+ `Info` got reworded to `Information`

resolves #702 

<!-- What is this pull request for? Does it fix any issues? -->

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
  - [ ] I have updated the documentation to reflect the changes.
  - [ ] I have run `task pyright` and fixed the relevant issues.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
