### PR TITLE
chore: fix incorrect type ignore comments

### DIFF
--- a/nextcord/ext/commands/converter.py
+++ b/nextcord/ext/commands/converter.py
@@ -411,7 +411,7 @@ class MessageConverter(IDConverter[nextcord.Message]):
         except nextcord.NotFound:
             raise MessageNotFound(argument)
         except nextcord.Forbidden:
-            raise ChannelNotReadable(channel)  # type: ignore weird type conflict
+            raise ChannelNotReadable(channel)  # type: ignore  # weird type conflict
 
 
 class GuildChannelConverter(IDConverter[nextcord.abc.GuildChannel]):
@@ -477,7 +477,7 @@ class GuildChannelConverter(IDConverter[nextcord.abc.GuildChannel]):
         else:
             thread_id = int(match.group(1))
             if guild:
-                result = guild.get_thread(thread_id)  # type: ignore handled below
+                result = guild.get_thread(thread_id)  # type: ignore  # handled below
 
         if not result or not isinstance(result, type):
             raise ThreadNotFound(argument)


### PR DESCRIPTION
## Summary

I wrote `# type: ignore(?!\[)(?!.*#).+$` regex for it, and found only two invalid comments. Hopping this is all.
![](https://user-images.githubusercontent.com/68118654/175617951-8fc5f48c-226d-482e-a206-48069caf121b.png)

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
  - [ ] I have updated the documentation to reflect the changes.
  - [ ] I have run `task pyright` and fixed the relevant issues.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)

Fixes #635.
