### PR TITLE
fix: Support unicode emojis in PartialEmojiConverter

### DIFF
--- a/nextcord/ext/commands/converter.py
+++ b/nextcord/ext/commands/converter.py
@@ -814,16 +814,19 @@ class PartialEmojiConverter(Converter[nextcord.PartialEmoji]):
     """
 
     async def convert(self, ctx: Context, argument: str) -> nextcord.PartialEmoji:
-        match = re.match(r"<(a?):([a-zA-Z0-9\_]{1,32}):([0-9]{15,20})>$", argument)
-
-        if match:
-            emoji_animated = bool(match.group(1))
-            emoji_name = match.group(2)
-            emoji_id = int(match.group(3))
+        custom_emoji_match = re.match(r"<(a?):([a-zA-Z0-9\_]{1,32}):([0-9]{15,20})>$", argument)
+        if custom_emoji_match:
+            emoji_animated = bool(custom_emoji_match.group(1))
+            emoji_name = custom_emoji_match.group(2)
+            emoji_id = int(custom_emoji_match.group(3))
 
             return nextcord.PartialEmoji.with_state(
                 ctx.bot._connection, animated=emoji_animated, name=emoji_name, id=emoji_id
             )
+
+        unicode_emoji_match = re.match(r"^[\U00002000-\U0010ffff]{1,3}$", argument)
+        if unicode_emoji_match:
+            return nextcord.PartialEmoji.with_state(ctx.bot._connection, name=argument)
 
         raise PartialEmojiConversionFailure(argument)
 

--- a/nextcord/ext/commands/converter.py
+++ b/nextcord/ext/commands/converter.py
@@ -813,6 +813,9 @@ class PartialEmojiConverter(Converter[nextcord.PartialEmoji]):
 
     .. versionchanged:: 1.5
          Raise :exc:`.PartialEmojiConversionFailure` instead of generic :exc:`.BadArgument`
+
+    .. versionchanged:: 2.0
+        Add support for converting unicode emojis
     """
 
     async def convert(self, ctx: Context, argument: str) -> nextcord.PartialEmoji:

--- a/nextcord/ext/commands/converter.py
+++ b/nextcord/ext/commands/converter.py
@@ -824,7 +824,9 @@ class PartialEmojiConverter(Converter[nextcord.PartialEmoji]):
                 ctx.bot._connection, animated=emoji_animated, name=emoji_name, id=emoji_id
             )
 
-        unicode_emoji_match = re.match(r"^[\U00002000-\U0010ffff]{1,3}$", argument)
+        unicode_emoji_match = re.match(
+            r"^[\u0023-\u0039]?[\u00ae\u00a9\U00002000-\U0010ffff]+$", argument
+        )
         if unicode_emoji_match:
             return nextcord.PartialEmoji.with_state(ctx.bot._connection, name=argument)
 

--- a/nextcord/ext/commands/converter.py
+++ b/nextcord/ext/commands/converter.py
@@ -819,20 +819,19 @@ class PartialEmojiConverter(Converter[nextcord.PartialEmoji]):
     """
 
     async def convert(self, ctx: Context, argument: str) -> nextcord.PartialEmoji:
-        custom_emoji_match = re.match(r"<(a?):([a-zA-Z0-9\_]{1,32}):([0-9]{15,20})>$", argument)
-        if custom_emoji_match:
-            emoji_animated = bool(custom_emoji_match.group(1))
-            emoji_name = custom_emoji_match.group(2)
-            emoji_id = int(custom_emoji_match.group(3))
+        match = re.match(r"<(a?):([a-zA-Z0-9\_]{1,32}):([0-9]{15,20})>$", argument)
+
+        if match:
+            emoji_animated = bool(match.group(1))
+            emoji_name = match.group(2)
+            emoji_id = int(match.group(3))
 
             return nextcord.PartialEmoji.with_state(
                 ctx.bot._connection, animated=emoji_animated, name=emoji_name, id=emoji_id
             )
 
-        unicode_emoji_match = re.match(
-            r"^[\u0023-\u0039]?[\u00ae\u00a9\U00002000-\U0010ffff]+$", argument
-        )
-        if unicode_emoji_match:
+        # If the emoji is a unicode emoji, then the name is the unicode character.
+        if re.match(r"^[\u0023-\u0039]?[\u00ae\u00a9\U00002000-\U0010ffff]+$", argument):
             return nextcord.PartialEmoji.with_state(ctx.bot._connection, name=argument)
 
         raise PartialEmojiConversionFailure(argument)

--- a/nextcord/ext/commands/converter.py
+++ b/nextcord/ext/commands/converter.py
@@ -814,7 +814,7 @@ class PartialEmojiConverter(Converter[nextcord.PartialEmoji]):
     .. versionchanged:: 1.5
          Raise :exc:`.PartialEmojiConversionFailure` instead of generic :exc:`.BadArgument`
 
-    .. versionchanged:: 2.0
+    .. versionchanged:: 2.1
         Add support for converting unicode emojis
     """
 

--- a/nextcord/ext/commands/converter.py
+++ b/nextcord/ext/commands/converter.py
@@ -809,6 +809,8 @@ class PartialEmojiConverter(Converter[nextcord.PartialEmoji]):
 
     This is done by extracting the animated flag, name and ID from the emoji.
 
+    If the emoji is a unicode emoji, then the name is the unicode character.
+
     .. versionchanged:: 1.5
          Raise :exc:`.PartialEmojiConversionFailure` instead of generic :exc:`.BadArgument`
     """


### PR DESCRIPTION
## Summary

Fixes #710 

Previously only custom emojis worked with `PartialEmojiConverter`. This adds support for all kinds of unicode emojis.

Note: The regex is a bit loose but all emojis are covered by the regex.

Test code:

```py
@bot.command()
async def test(ctx: commands.Context[commands.Bot], emoji: nextcord.PartialEmoji):
    await ctx.message.add_reaction(emoji)
```

![image](https://user-images.githubusercontent.com/20955511/175830618-8e450a74-328c-4e8f-b2f9-b478b1324472.png)

The regex has been tested for correctness using a third-party [emoji](https://pypi.org/project/emoji/) package:

```py
from emoji import UNICODE_EMOJI
import re
# output should be empty
print(*["" if re.match(r"^[\u0023-\u0039]?[\u00ae\u00a9\U00002000-\U0010ffff]+$", argument) else f"{argument} {[hex(ord(c)) for c in argument]}\n" for argument in UNICODE_EMOJI['en']], sep="")
```

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
  - [x] I have updated the documentation to reflect the changes.
  - [x] I have run `task pyright` and fixed the relevant issues.
- [x] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
