### PR TITLE
docs: fixes several warnings in the docs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -57,7 +57,7 @@ extlinks = {
 intersphinx_mapping = {
     "py": ("https://docs.python.org/3", None),
     "aio": ("https://docs.aiohttp.org/en/stable/", None),
-    "req": ("https://docs.python-requests.org/en/latest/", None),
+    "req": ("https://requests.readthedocs.io/en/latest/", None),
 }
 
 rst_prolog = """

--- a/docs/migrating_2.rst
+++ b/docs/migrating_2.rst
@@ -31,7 +31,7 @@ Overview
 - Many arguments are now specified as positional-only or keyword-only; e.g. :func:`oauth_url` now takes keyword-only arguments, and methods starting with ``get_`` or ``fetch_`` take positional-only arguments.
 - You must explicitly enable the :attr:`~Intents.message_content` intent to receive message :attr:`~Message.content`, :attr:`~Message.embeds`, :attr:`~Message.attachments`, and :attr:`~Message.components` in most messages.
 - :meth:`Guild.bans` is no longer a coroutine and returns an :class:`~nextcord.AsyncIterator` instead of a :class:`list`.
-- ``StoreChannel`` is removed as it is deprecated by Discord, see `here <https://support.discord.com/hc/en-us/articles/4688647258007-Self-serve-Game-Selling-Deprecation>`_ for more info.
+- ``StoreChannel`` is removed as it is deprecated by Discord, see `here <https://support.discord.com/hc/en-us/articles/4688647258007-Self-serve-Game-Selling-Deprecation>`__ for more info.
 - ``ChannelType.store`` is removed.
 - ``AppInfo.summary``, ``AppInfo.guild_id``, ``AppInfo.primary_sku_id`` and ``AppInfo.slug`` are removed.
 - ``PartialAppInfo.summary`` is removed.
@@ -390,7 +390,7 @@ This was renamed to :attr:`MessageType.chat_input_command` due to Discord adding
 
 StoreChannel has been removed
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-``StoreChannel`` has been removed as it has been deprecated by Discord, see `here <https://support-dev.discord.com/hc/en-us/articles/4414590563479>`_ for more info.
+``StoreChannel`` has been removed as it has been deprecated by Discord, see `here <https://support-dev.discord.com/hc/en-us/articles/4414590563479>`__ for more info.
 
 Meta Change
 -----------

--- a/nextcord/client.py
+++ b/nextcord/client.py
@@ -2157,7 +2157,7 @@ class Client:
 
         Parameters
         ----------
-        data: Optional[List[:class:`dict]]
+        data: Optional[List[:class:`dict`]]
             Payload from `HTTPClient.get_guild_commands` or `HTTPClient.get_global_commands` to deploy with. If None,
             the payload will be retrieved from Discord.
         guild_id: Optional[:class:`int`]

--- a/nextcord/ext/commands/bot.py
+++ b/nextcord/ext/commands/bot.py
@@ -372,15 +372,19 @@ class BotBase(GroupMixin):
         """|coro|
         Checks if a :class:`~nextcord.User` or :class:`~nextcord.Member` is the owner of
         this bot.
+
         If an :attr:`owner_id` is not set, it is fetched automatically
         through the use of :meth:`~.Bot.application_info`.
+
         .. versionchanged:: 1.3
             The function also checks if the application is team-owned if
             :attr:`owner_ids` is not set.
+
         Parameters
         -----------
         user: :class:`.abc.User`
             The user to check for.
+
         Returns
         --------
         :class:`bool`
@@ -1212,18 +1216,23 @@ class BotBase(GroupMixin):
 
     def application_command_before_invoke(self, coro: ApplicationHook) -> ApplicationHook:
         """A decorator that registers a coroutine as a pre-invoke hook.
+
         A pre-invoke hook is called directly before the command is
         called. This makes it a useful function to set up database
         connections or any type of set up required.
         This pre-invoke hook takes a sole parameter, a :class:`.Interaction`.
+
         .. note::
+
             The :meth:`.application_command_before_invoke` and :meth:`.application_command_after_invoke`
             hooks are only called if all checks pass without error. If any check fails, then the hooks
             are not called.
+
         Parameters
         -----------
         coro: :ref:`coroutine <coroutine>`
             The coroutine to register as the pre-invoke hook.
+
         Raises
         -------
         TypeError

--- a/nextcord/ext/commands/bot.py
+++ b/nextcord/ext/commands/bot.py
@@ -1220,6 +1220,7 @@ class BotBase(GroupMixin):
         A pre-invoke hook is called directly before the command is
         called. This makes it a useful function to set up database
         connections or any type of set up required.
+
         This pre-invoke hook takes a sole parameter, a :class:`.Interaction`.
 
         .. note::

--- a/nextcord/message.py
+++ b/nextcord/message.py
@@ -656,10 +656,6 @@ class Message(Hashable):
         A list of components in the message.
 
         .. versionadded:: 2.0
-    thread: Optional[:class:`Thread`]
-        The thread created from a message, if any.
-
-        .. versionadded:: 2.0
     guild: Optional[:class:`Guild`]
         The guild that the message belongs to, if applicable.
     """

--- a/nextcord/widget.py
+++ b/nextcord/widget.py
@@ -154,7 +154,6 @@ class WidgetMember(BaseUser):
         "status",
         "nick",
         "avatar",
-        "id",
         "activity",
         "deafened",
         "suppress",

--- a/nextcord/widget.py
+++ b/nextcord/widget.py
@@ -153,7 +153,8 @@ class WidgetMember(BaseUser):
     __slots__ = (
         "status",
         "nick",
-        "avatar" "id",
+        "avatar",
+        "id",
         "activity",
         "deafened",
         "suppress",


### PR DESCRIPTION
## Summary

Fixes several warnings in the docs:

```py
nextcord/nextcord/client.py:docstring of nextcord.client.Client.discover_application_commands:9: WARNING: Inline interpreted text or phrase reference start-string without end-string.
nextcord/nextcord/message.py:docstring of nextcord.Message.thread:1: WARNING: duplicate object description of nextcord.Message.thread, other instance in api, use :noindex: for one of them
nextcord/nextcord/widget.py:docstring of nextcord.WidgetMember.avatar:1: WARNING: duplicate object description of nextcord.WidgetMember.avatar, other instance in api, use :noindex: for one of them
nextcord/nextcord/ext/commands/bot.py:docstring of nextcord.ext.commands.bot.BotBase.application_command_before_invoke:7: ERROR: Unexpected indentation.
nextcord/nextcord/ext/commands/bot.py:docstring of nextcord.ext.commands.bot.BotBase.application_command_before_invoke:10: WARNING: Literal block ends without a blank line; unexpected unindent.
nextcord/nextcord/ext/commands/bot.py:docstring of nextcord.client.Client.discover_application_commands:9: WARNING: Inline interpreted text or phrase reference start-string without end-string.
nextcord/nextcord/ext/commands/bot.py:docstring of nextcord.ext.commands.bot.BotBase.is_owner:7: ERROR: Unexpected indentation.
nextcord/nextcord/ext/commands/bot.py:docstring of nextcord.ext.commands.bot.BotBase.is_owner:9: WARNING: Block quote ends without a blank line; unexpected unindent.
nextcord/docs/migrating_2.rst:6: WARNING: Duplicate explicit target name: "here".
nextcord/docs/faq.rst:56: WARNING: unknown document: req:index
nextcord/docs/faq.rst:56: WARNING: unknown document: req:index
```

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
  - [ ] I have updated the documentation to reflect the changes.
  - [ ] I have run `task pyright` and fixed the relevant issues.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
