### PR TITLE
refactor(bot)!: remove the use of **options for options

### DIFF
--- a/nextcord/application_command.py
+++ b/nextcord/application_command.py
@@ -758,7 +758,7 @@ class CallbackMixin:
         # Global checks
         for check in interaction.client._connection._application_command_checks:
             try:
-                check_result = await maybe_coroutine(check, interaction)
+                check_result = await maybe_coroutine(check, interaction)  # type: ignore
             # To catch any subclasses of ApplicationCheckFailure.
             except ApplicationCheckFailure:
                 raise
@@ -782,7 +782,7 @@ class CallbackMixin:
         # Command checks
         for check in self.checks:
             try:
-                check_result = await maybe_coroutine(check, interaction)
+                check_result = await maybe_coroutine(check, interaction)  # type: ignore
             # To catch any subclasses of ApplicationCheckFailure.
             except ApplicationCheckFailure:
                 raise

--- a/nextcord/ext/commands/bot.py
+++ b/nextcord/ext/commands/bot.py
@@ -52,9 +52,6 @@ from typing import (
 )
 
 import nextcord
-from nextcord.activity import BaseActivity
-from nextcord.enums import Status
-from nextcord.flags import Intents
 
 from . import errors
 from .cog import Cog
@@ -69,6 +66,8 @@ if TYPE_CHECKING:
     import aiohttp
     from typing_extensions import Self
 
+    from nextcord.activity import BaseActivity
+    from nextcord.enums import Status
     from nextcord.flags import MemberCacheFlags
     from nextcord.mentions import AllowedMentions
     from nextcord.message import Message
@@ -181,7 +180,7 @@ class BotBase(GroupMixin):
         shard_id: Optional[int] = None,
         shard_count: Optional[int] = None,
         application_id: Optional[int] = None,
-        intents: Intents = Intents.default(),
+        intents: nextcord.Intents = nextcord.Intents.default(),
         member_cache_flags: MemberCacheFlags = MISSING,
         chunk_guilds_at_startup: bool = MISSING,
         status: Optional[Status] = None,

--- a/nextcord/ext/commands/bot.py
+++ b/nextcord/ext/commands/bot.py
@@ -172,6 +172,8 @@ class BotBase(GroupMixin):
             _NonCallablePrefix,
             Callable[[Self, Message], Union[Awaitable[_NonCallablePrefix], _NonCallablePrefix]],
         ] = tuple(),
+        help_command: Optional[HelpCommand] = MISSING,
+        description: Optional[str] = None,
         *,
         max_messages: Optional[int] = 1000,
         connector: Optional[aiohttp.BaseConnector] = None,
@@ -197,11 +199,9 @@ class BotBase(GroupMixin):
         rollout_register_new: bool = True,
         rollout_update_known: bool = True,
         rollout_all_guilds: bool = False,
-        description: Optional[str] = None,
         owner_id: Optional[int] = None,
         owner_ids: Iterable[int] = set(),
         strip_after_prefix: bool = False,
-        help_command: Optional[HelpCommand] = MISSING,
         case_insensitive: bool = False,
     ):
         nextcord.Client.__init__(

--- a/nextcord/ext/commands/bot.py
+++ b/nextcord/ext/commands/bot.py
@@ -142,14 +142,6 @@ def _is_submodule(parent: str, child: str) -> bool:
     return parent == child or child.startswith(parent + ".")
 
 
-class _DefaultRepr(HelpCommand):
-    def __repr__(self):
-        return "<default-help-command>"
-
-
-_default = _DefaultRepr()
-
-
 class MissingMessageContentIntentWarning(UserWarning):
     """Warning category raised when instantiating a :class:`~nextcord.ext.commands.Bot` with a
     :attr:`~nextcord.ext.commands.Bot.command_prefix` but without the :attr:`~nextcord.Intents.message_content`
@@ -210,7 +202,7 @@ class BotBase(GroupMixin):
         owner_id: Optional[int] = None,
         owner_ids: Iterable[int] = set(),
         strip_after_prefix: bool = False,
-        help_command: Optional[HelpCommand] = _default,
+        help_command: Optional[HelpCommand] = MISSING,
         case_insensitive: bool = False,
     ):
         nextcord.Client.__init__(
@@ -286,7 +278,7 @@ class BotBase(GroupMixin):
                 stacklevel=0,
             )
 
-        if help_command is _default:
+        if help_command is MISSING:
             self._help_command = DefaultHelpCommand()
         else:
             self._help_command = help_command

--- a/nextcord/ext/commands/bot.py
+++ b/nextcord/ext/commands/bot.py
@@ -175,7 +175,7 @@ class BotBase(GroupMixin):
         self,
         command_prefix: Union[
             str, Sequence[str], Callable[[Self, Message], Union[Awaitable[str], str]]
-        ],
+        ] = tuple(),
         *,
         max_messages: Optional[int] = 1000,
         connector: Optional[aiohttp.BaseConnector] = None,

--- a/nextcord/ext/commands/bot.py
+++ b/nextcord/ext/commands/bot.py
@@ -171,11 +171,15 @@ class MissingMessageContentIntentWarning(UserWarning):
     pass
 
 
+_NonCallablePrefix = Union[str, Sequence[str]]
+
+
 class BotBase(GroupMixin):
     def __init__(
         self,
         command_prefix: Union[
-            str, Sequence[str], Callable[[Self, Message], Union[Awaitable[str], str]]
+            _NonCallablePrefix,
+            Callable[[Self, Message], Union[Awaitable[_NonCallablePrefix], _NonCallablePrefix]],
         ] = tuple(),
         *,
         max_messages: Optional[int] = 1000,
@@ -250,10 +254,10 @@ class BotBase(GroupMixin):
         self._before_invoke = None
         self._after_invoke = None
         self._help_command: Optional[HelpCommand] = None
-        self.description: str = inspect.cleandoc(description) if description else ""
-        self.owner_id: Optional[int] = owner_id
-        self.owner_ids: Iterable[int] = owner_ids
-        self.strip_after_prefix: bool = strip_after_prefix
+        self.description = inspect.cleandoc(description) if description else ""
+        self.owner_id = owner_id
+        self.owner_ids = owner_ids
+        self.strip_after_prefix = strip_after_prefix
 
         if self.owner_id and self.owner_ids:
             raise TypeError("Both owner_id and owner_ids are set.")

--- a/nextcord/ext/commands/bot.py
+++ b/nextcord/ext/commands/bot.py
@@ -41,6 +41,7 @@ from typing import (
     Awaitable,
     Callable,
     Dict,
+    Iterable,
     List,
     Mapping,
     Optional,
@@ -203,7 +204,7 @@ class BotBase(GroupMixin):
         rollout_all_guilds: bool = False,
         description: Optional[str] = None,
         owner_id: Optional[int] = None,
-        owner_ids: set[int] = set(),
+        owner_ids: Iterable[int] = set(),
         strip_after_prefix: bool = False,
         help_command: Optional[HelpCommand] = _default,
         case_insensitive: bool = False,
@@ -248,11 +249,11 @@ class BotBase(GroupMixin):
         self._check_once = []
         self._before_invoke = None
         self._after_invoke = None
-        self._help_command = None
-        self.description = inspect.cleandoc(description) if description else ""
-        self.owner_id = owner_id
-        self.owner_ids = owner_ids
-        self.strip_after_prefix = strip_after_prefix
+        self._help_command: Optional[HelpCommand] = None
+        self.description: str = inspect.cleandoc(description) if description else ""
+        self.owner_id: Optional[int] = owner_id
+        self.owner_ids: Iterable[int] = owner_ids
+        self.strip_after_prefix: bool = strip_after_prefix
 
         if self.owner_id and self.owner_ids:
             raise TypeError("Both owner_id and owner_ids are set.")
@@ -282,9 +283,9 @@ class BotBase(GroupMixin):
             )
 
         if help_command is _default:
-            self.help_command = DefaultHelpCommand()
+            self._help_command = DefaultHelpCommand()
         else:
-            self.help_command = help_command
+            self._help_command = help_command
 
     # internal helpers
 

--- a/nextcord/ext/commands/core.py
+++ b/nextcord/ext/commands/core.py
@@ -1202,13 +1202,11 @@ class GroupMixin(Generic[CogT]):
         Whether the commands should be case insensitive. Defaults to ``False``.
     """
 
-    def __init__(self, *args: Any, **kwargs: Any) -> None:
-        case_insensitive = kwargs.get("case_insensitive", False)
+    def __init__(self, *, case_insensitive: bool = False) -> None:
         self.all_commands: Dict[str, Command[CogT, Any, Any]] = (
             _CaseInsensitiveDict() if case_insensitive else {}
         )
         self.case_insensitive: bool = case_insensitive
-        super().__init__(*args, **kwargs)
 
     @property
     def commands(self) -> Set[Command[CogT, Any, Any]]:

--- a/nextcord/utils.py
+++ b/nextcord/utils.py
@@ -524,13 +524,15 @@ def _parse_ratelimit_header(request: Any, *, use_clock: bool = False) -> float:
 
 
 async def maybe_coroutine(
-    f: Callable[P, Union[Any, Awaitable[Any]]], *args: P.args, **kwargs: P.kwargs
-) -> Any:
+    f: Callable[P, Union[T, Awaitable[T]]], *args: P.args, **kwargs: P.kwargs
+) -> T:
     value = f(*args, **kwargs)
     if _isawaitable(value):
         return await value
     else:
-        return value
+        return value  # type: ignore
+        # type ignored as `_isawaitable` provides `TypeGuard[Awaitable[Any]]`
+        # yet we need a more specific type guard
 
 
 async def async_all(gen, *, check=_isawaitable):

--- a/nextcord/utils.py
+++ b/nextcord/utils.py
@@ -43,6 +43,7 @@ from typing import (
     TYPE_CHECKING,
     Any,
     AsyncIterator,
+    Awaitable,
     Callable,
     Dict,
     ForwardRef,
@@ -522,7 +523,9 @@ def _parse_ratelimit_header(request: Any, *, use_clock: bool = False) -> float:
         return float(reset_after)
 
 
-async def maybe_coroutine(f, *args, **kwargs):
+async def maybe_coroutine(
+    f: Callable[P, Union[Any, Awaitable[Any]]], *args: P.args, **kwargs: P.kwargs
+) -> Any:
     value = f(*args, **kwargs)
     if _isawaitable(value):
         return await value


### PR DESCRIPTION
## Summary

Continuation of #695
Uses actual kwargs over pass-down, ignored `**kwargs`.

### Breaking Changes

This is breaking for the same reason as #695.

### Reasons for seemingly unrelated edits

`_DefaultRepr` inherits from `HelpCommand` so it can continue to be used as the default for `help_command` without type issues.
`Client.__init__` is called manually so `GroupMixin` does not need pass-down `**kwargs` to call `super().__init__` another time unnecessarily. `bot.py` *may* need to have the idea of `BotBase` removed to eliminate similar issues such as this (different PR).
`get_prefix` is edited to use an else clause over overwriting the value so the type checker is aware of the `TypeGuard` which `callable` provides.
`maybe_coroutine` is included to have types so the type checker is at least aware that this will not spit out the original callable, `Any` unfortunately has to be used as thats the `TypeGuard` that `_isawaitable` provides.

### Test Code

https://paste.nextcord.dev/?id=1656448764816195

<!-- What is this pull request for? Does it fix any issues? -->

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
  - [x] I have updated the documentation to reflect the changes.
  - [x] I have run `task pyright` and fixed the relevant issues.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [x] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)

## Priority

High as the last PR broke all bot-specific kwargs :confused: