### PR TITLE
feat(interactions): add the app_permissions field

### DIFF
--- a/nextcord/interactions.py
+++ b/nextcord/interactions.py
@@ -274,7 +274,7 @@ class Interaction:
 
     @property
     def permissions(self) -> Permissions:
-        """:class:`Permissions`: The resolved permissions of the member in the channel, including overwrites
+        """:class:`Permissions`: The resolved permissions of the member in the channel, including overwrites.
 
         In a non-guild context where this doesn't apply, an empty permissions object is returned.
         """
@@ -282,7 +282,7 @@ class Interaction:
 
     @property
     def app_permissions(self) -> Permissions:
-        """:class:`Permissions` The resolved permissions of the bot in the channel, including overwrites
+        """:class:`Permissions` The resolved permissions of the bot in the channel, including overwrites.
 
         In a non-guild context where this doesn't apply, an empty permissions object is returned.
         """

--- a/nextcord/interactions.py
+++ b/nextcord/interactions.py
@@ -207,7 +207,7 @@ class Interaction:
         self._app_permissions: int = 0
 
         if self.guild_id:
-            self._app_permissions = int(data.get("app_permissions"))
+            self._app_permissions = int(data.get("app_permissions"))  # type: ignore
 
     @property
     def client(self) -> Client:

--- a/nextcord/interactions.py
+++ b/nextcord/interactions.py
@@ -165,7 +165,7 @@ class Interaction:
         "version",
         "application_command",
         "attached",
-        "_permissions",
+        "_app_permissions",
         "_state",
         "_session",
         "_original_message",
@@ -204,23 +204,10 @@ class Interaction:
             self.message = None
 
         self.user: Optional[Union[User, Member]] = None
-        self._permissions: int = 0
+        self._app_permissions: int = 0
 
-        # TODO: there's a potential data loss here
         if self.guild_id:
-            guild = self.guild or Object(id=self.guild_id)
-            try:
-                member = data["member"]
-            except KeyError:
-                pass
-            else:
-                self.user = Member(state=self._state, guild=guild, data=member)  # type: ignore
-                self._permissions = int(member.get("permissions", 0))
-        else:
-            try:
-                self.user = User(state=self._state, data=data["user"])
-            except KeyError:
-                pass
+            self._app_permissions = int(data.get("app_permissions"))
 
     @property
     def client(self) -> Client:
@@ -272,11 +259,11 @@ class Interaction:
 
     @property
     def permissions(self) -> Permissions:
-        """:class:`Permissions`: The resolved permissions of the member in the channel, including overwrites.
+        """:class:`Permissions`: The app permissions for this bot sent by Discord.
 
         In a non-guild context where this doesn't apply, an empty permissions object is returned.
         """
-        return Permissions(self._permissions)
+        return Permissions(self._app_permissions)
 
     @utils.cached_slot_property("_cs_response")
     def response(self) -> InteractionResponse:

--- a/nextcord/interactions.py
+++ b/nextcord/interactions.py
@@ -166,6 +166,7 @@ class Interaction:
         "application_command",
         "attached",
         "_permissions",
+        "_app_permissions",
         "_state",
         "_session",
         "_original_message",
@@ -204,7 +205,24 @@ class Interaction:
             self.message = None
 
         self.user: Optional[Union[User, Member]] = None
-        self._permissions: int = int(data.get("app_permissions", 0))
+        self._app_permissions: int = int(data.get("app_permissions", 0))
+        self._permissions: int = 0
+
+        # TODO: there's a potential data loss here
+        if self.guild_id:
+            guild = self.guild or Object(id=self.guild_id)
+            try:
+                member = data["member"]
+            except KeyError:
+                pass
+            else:
+                self.user = Member(state=self._state, guild=guild, data=member)  # type: ignore
+                self._permissions = int(member.get("permissions", 0))
+        else:
+            try:
+                self.user = User(state=self._state, data=data["user"])
+            except KeyError:
+                pass
 
     @property
     def client(self) -> Client:
@@ -256,11 +274,19 @@ class Interaction:
 
     @property
     def permissions(self) -> Permissions:
-        """:class:`Permissions`: The app permissions for this bot sent by Discord.
+        """:class:`Permissions`: The resolved permissions of the member in the channel, including overwrites
 
         In a non-guild context where this doesn't apply, an empty permissions object is returned.
         """
         return Permissions(self._permissions)
+
+    @property
+    def app_permissions(self) -> Permissions:
+        """:class:`Permissions` The resolved permissions of the bot in the channel, including overwrites
+
+        In a non-guild context where this doesn't apply, an empty permissions object is returned.
+        """
+        return Permissions(self._app_permissions)
 
     @utils.cached_slot_property("_cs_response")
     def response(self) -> InteractionResponse:

--- a/nextcord/interactions.py
+++ b/nextcord/interactions.py
@@ -165,7 +165,7 @@ class Interaction:
         "version",
         "application_command",
         "attached",
-        "_app_permissions",
+        "_permissions",
         "_state",
         "_session",
         "_original_message",
@@ -204,10 +204,7 @@ class Interaction:
             self.message = None
 
         self.user: Optional[Union[User, Member]] = None
-        self._app_permissions: int = 0
-
-        if self.guild_id:
-            self._app_permissions = int(data.get("app_permissions"))  # type: ignore
+        self._permissions: int = int(data.get("app_permissions", 0))
 
     @property
     def client(self) -> Client:
@@ -263,7 +260,7 @@ class Interaction:
 
         In a non-guild context where this doesn't apply, an empty permissions object is returned.
         """
-        return Permissions(self._app_permissions)
+        return Permissions(self._permissions)
 
     @utils.cached_slot_property("_cs_response")
     def response(self) -> InteractionResponse:

--- a/nextcord/types/interactions.py
+++ b/nextcord/types/interactions.py
@@ -218,6 +218,7 @@ class _InteractionOptional(TypedDict, total=False):
     message: Message
     locale: str
     guild_locale: str
+    app_permissions: str
 
 
 class Interaction(_InteractionOptional):


### PR DESCRIPTION
## Summary

This uses the newly added `app_permissions` field for the permissions property in Interactions. Closes #720.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
  - [ ] I have updated the documentation to reflect the changes.
  - [ ] I have run `task pyright` and fixed the relevant issues.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
