### PR TITLE
docs: Fix docstring return type of app_permissions

### DIFF
--- a/nextcord/interactions.py
+++ b/nextcord/interactions.py
@@ -282,7 +282,7 @@ class Interaction:
 
     @property
     def app_permissions(self) -> Permissions:
-        """:class:`Permissions` The resolved permissions of the bot in the channel, including overwrites.
+        """:class:`Permissions`: The resolved permissions of the bot in the channel, including overwrites.
 
         In a non-guild context where this doesn't apply, an empty permissions object is returned.
         """


### PR DESCRIPTION
## Summary

Just a 1-character change to make the return type display correctly in the docs.

This was a suggested and applied change in #721 but somehow got reverted right before merging?

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
  - [ ] I have updated the documentation to reflect the changes.
  - [ ] I have run `task pyright` and fixed the relevant issues.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
