### PR TITLE
fix(interactions): get info from cache first if available

### DIFF
--- a/nextcord/interactions.py
+++ b/nextcord/interactions.py
@@ -211,13 +211,12 @@ class Interaction:
 
         # TODO: there's a potential data loss here
         if self.guild_id:
+            guild = self.guild or Object(int(self.guild_id))
             try:
                 member = data["member"]
             except KeyError:
                 pass
             else:
-                guild = self.guild or Object(int(self.guild_id))
-
                 user_id = int(member["user"]["id"])  # type: ignore
                 cached_member = self.guild and self.guild.get_member(user_id)
                 self.user = cached_member or Member(state=self._state, guild=guild, data=member)  # type: ignore

--- a/nextcord/interactions.py
+++ b/nextcord/interactions.py
@@ -217,8 +217,8 @@ class Interaction:
             except KeyError:
                 pass
             else:
-                cached_member = self.guild and self.guild.get_member(int(member["user"]["id"]))  # type: ignore
-                self.user = cached_member or Member(state=self._state, guild=guild, data=member)  # type: ignore
+                cached_member = self.guild and self.guild.get_member(int(member["user"]["id"]))  # type: ignore # user key should be present here
+                self.user = cached_member or Member(state=self._state, guild=guild, data=member)  # type: ignore # user key should be present here
                 self._permissions = int(member.get("permissions", 0))
         else:
             try:

--- a/nextcord/interactions.py
+++ b/nextcord/interactions.py
@@ -217,8 +217,7 @@ class Interaction:
             except KeyError:
                 pass
             else:
-                user_id = int(member["user"]["id"])  # type: ignore
-                cached_member = self.guild and self.guild.get_member(user_id)
+                cached_member = self.guild and self.guild.get_member(int(member["user"]["id"]))  # type: ignore
                 self.user = cached_member or Member(state=self._state, guild=guild, data=member)  # type: ignore
                 self._permissions = int(member.get("permissions", 0))
         else:

--- a/nextcord/interactions.py
+++ b/nextcord/interactions.py
@@ -211,7 +211,7 @@ class Interaction:
 
         # TODO: there's a potential data loss here
         if self.guild_id:
-            guild = self.guild or Object(int(self.guild_id))
+            guild = self.guild or Object(id=self.guild_id)
             try:
                 member = data["member"]
             except KeyError:


### PR DESCRIPTION
## Summary

Fixes #605

This PR changes the assignment of the following attributes for `Interaction` to try cache before constructing the object: `.message, .user`

This is needed because fields like `status` are not sent in the Interaction member payload but are usually cached.

Preview: ![image](https://i.imgur.com/ql0MZJe.png)
I don't know how to test `.message` and User for `.user` but the correct object is returned.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
  - [ ] I have updated the documentation to reflect the changes.
  - [x] I have run `task pyright` and fixed the relevant issues.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
