### PR TITLE
fix(ui): Modal & View dispatch orders

### DIFF
--- a/nextcord/ui/modal.py
+++ b/nextcord/ui/modal.py
@@ -311,8 +311,8 @@ class Modal:
         if self.__stopped.done():
             return
 
-        self.__stopped.set_result(True)
         asyncio.create_task(self.on_timeout(), name=f"discord-ui-modal-timeout-{self.id}")
+        self.__stopped.set_result(True)
 
     def _dispatch(self, interaction: Interaction):
         if self.__stopped.done():

--- a/nextcord/ui/view.py
+++ b/nextcord/ui/view.py
@@ -411,8 +411,8 @@ class View:
         if self.__stopped.done():
             return
 
-        self.__stopped.set_result(True)
         asyncio.create_task(self.on_timeout(), name=f"discord-ui-view-timeout-{self.id}")
+        self.__stopped.set_result(True)
 
     def _dispatch_item(self, item: Item, interaction: Interaction):
         if self.__stopped.done():


### PR DESCRIPTION
## Summary

Currently, the following code found [here](https://paste.nextcord.dev/?id=1656854674165819) will print "Finished waiting" before it prints "Ran timeout". 

This pr fixes this dispatch order for both View's and Modal's so that `on_timeout` is ran first, before anything after `Modal.wait`

## Checklist

- [x] If code changes were made then they have been tested.
  - [ ] I have updated the documentation to reflect the changes.
  - [ ] I have run `task pyright` and fixed the relevant issues.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
