### PR TITLE
feat(app-cmds): support min/max length for string options

### DIFF
--- a/nextcord/application_command.py
+++ b/nextcord/application_command.py
@@ -235,8 +235,12 @@ class ApplicationCommandOption:
         Minimum value the user can input. Should only be set if this is an integer or number option.
     min_length: :class:`int`
         Minimum length of a string the user can input. Should only be set if this is a string option.
+
+        .. versionadded:: 2.1
     max_length: :class:`int`
         Maximum length of a string the user can input. Should only be set if this is a string option.
+
+        .. versionadded:: 2.1
     autocomplete: :class:`bool`
         If the command option should have autocomplete enabled.
     """
@@ -1163,9 +1167,13 @@ class SlashOption(ApplicationCommandOption, _CustomTypingMetaBase):
     min_length: :class:`int`
         Minimum length for a string value the user is allowed to input. The parameter must be typed as a
         :class:`str` for this to function.
+
+        .. versionadded:: 2.1
     max_length: :class:`int`
         Maximum length for a string value the user is allowed to input. The parameter must be typed as a
         :class:`str` for this to function.
+
+        .. versionadded:: 2.1
     autocomplete: :class:`bool`
         If this parameter has an autocomplete function decorated for it. If unset, it will automatically be `True`
         if an autocomplete function for it is found.

--- a/nextcord/application_command.py
+++ b/nextcord/application_command.py
@@ -233,6 +233,10 @@ class ApplicationCommandOption:
         Minimum value the user can input. Should only be set if this is an integer or number option.
     max_value: Union[:class:`int`, :class:`float`]
         Minimum value the user can input. Should only be set if this is an integer or number option.
+    min_length: :class:`int`
+        Minimum length of a string the user can input. Should only be set if this is a string option.
+    max_length: :class:`int`
+        Maximum length of a string the user can input. Should only be set if this is a string option.
     autocomplete: :class:`bool`
         If the command option should have autocomplete enabled.
     """
@@ -253,6 +257,8 @@ class ApplicationCommandOption:
         channel_types: Optional[List[ChannelType]] = None,
         min_value: Union[int, float, None] = None,
         max_value: Union[int, float, None] = None,
+        min_length: Optional[int] = None,
+        max_length: Optional[int] = None,
         autocomplete: Optional[bool] = None,
     ):
         self.type: Optional[ApplicationCommandOptionType] = cmd_type
@@ -272,6 +278,8 @@ class ApplicationCommandOption:
         self.channel_types: Optional[List[ChannelType]] = channel_types
         self.min_value: Optional[Union[int, float]] = min_value
         self.max_value: Optional[Union[int, float]] = max_value
+        self.min_length: Optional[int] = min_length
+        self.max_length: Optional[int] = max_length
         self.autocomplete: Optional[bool] = autocomplete
 
     def get_name_localization_payload(self) -> Optional[Dict[str, str]]:
@@ -347,6 +355,12 @@ class ApplicationCommandOption:
 
         if self.max_value is not None:
             ret["max_value"] = self.max_value
+
+        if self.min_length is not None:
+            ret["min_length"] = self.min_length
+
+        if self.max_length is not None:
+            ret["max_length"] = self.max_length
 
         if self.autocomplete:
             ret["autocomplete"] = self.autocomplete
@@ -1146,6 +1160,12 @@ class SlashOption(ApplicationCommandOption, _CustomTypingMetaBase):
     max_value: Union[:class:`int`, :class:`float`]
         Maximum integer or floating point value the user is allowed to input. The parameter must be typed as an
         :class:`int` or :class:`float` for this to function.
+    min_length: :class:`int`
+        Minimum length for a string value the user is allowed to input. The parameter must be typed as a
+        :class:`str` for this to function.
+    max_length: :class:`int`
+        Maximum length for a string value the user is allowed to input. The parameter must be typed as a
+        :class:`str` for this to function.
     autocomplete: :class:`bool`
         If this parameter has an autocomplete function decorated for it. If unset, it will automatically be `True`
         if an autocomplete function for it is found.
@@ -1173,6 +1193,8 @@ class SlashOption(ApplicationCommandOption, _CustomTypingMetaBase):
         channel_types: Optional[List[ChannelType]] = None,
         min_value: Union[int, float, None] = None,
         max_value: Union[int, float, None] = None,
+        min_length: Optional[int] = None,
+        max_length: Optional[int] = None,
         autocomplete: Optional[bool] = None,
         autocomplete_callback: Optional[Callable] = None,
         default: Any = MISSING,
@@ -1189,6 +1211,8 @@ class SlashOption(ApplicationCommandOption, _CustomTypingMetaBase):
             channel_types=channel_types,
             min_value=min_value,
             max_value=max_value,
+            min_length=min_length,
+            max_length=max_length,
             autocomplete=autocomplete,
         )
 
@@ -1265,6 +1289,8 @@ class SlashCommandOption(BaseCommandOption, SlashOption, AutocompleteOptionMixin
         self.channel_types = cmd_arg.channel_types
         self.min_value = cmd_arg.min_value
         self.max_value = cmd_arg.max_value
+        self.min_length = cmd_arg.min_length
+        self.max_length = cmd_arg.max_length
         self.autocomplete = cmd_arg.autocomplete
         self.autocomplete_callback = cmd_arg.autocomplete_callback
         if self.autocomplete_callback and self.autocomplete is None:
@@ -1376,6 +1402,19 @@ class SlashCommandOption(BaseCommandOption, SlashOption, AutocompleteOptionMixin
         ):
             raise ValueError(
                 "min_value or max_value can only be set if the type is integer or number."
+            )
+
+        if self.min_length is not None and not isinstance(self.min_length, int):
+            raise ValueError("min_length must be an int.")
+
+        if self.max_length is not None and not isinstance(self.max_length, int):
+            raise ValueError("max_length must be an int.")
+
+        if (self.min_length is not None or self.max_length is not None) and self.type is not (
+            ApplicationCommandOptionType.string
+        ):
+            raise ValueError(
+                "min_length or max_length can only be set if the type is a string."
             )
 
         return True

--- a/nextcord/application_command.py
+++ b/nextcord/application_command.py
@@ -1410,6 +1410,12 @@ class SlashCommandOption(BaseCommandOption, SlashOption, AutocompleteOptionMixin
         if self.max_length is not None and not isinstance(self.max_length, int):
             raise ValueError("max_length must be an int.")
 
+        if self.min_length is not None and self.min_length < 0:
+            raise ValueError("min_length must be greater than or equal to 0.")
+
+        if self.max_length is not None and self.max_length < 1:
+            raise ValueError("max_length must be greater than or equal to 1.")
+
         if (self.min_length is not None or self.max_length is not None) and self.type is not (
             ApplicationCommandOptionType.string
         ):

--- a/nextcord/application_command.py
+++ b/nextcord/application_command.py
@@ -1416,6 +1416,11 @@ class SlashCommandOption(BaseCommandOption, SlashOption, AutocompleteOptionMixin
         if self.max_length is not None and self.max_length < 1:
             raise ValueError("max_length must be greater than or equal to 1.")
 
+        # we check this ourselves because Discord doesn't do it yet
+        # see here: https://github.com/discord/discord-api-docs/issues/5149
+        if (self.min_length is not None and self.max_length is not None) and self.min_length > self.max_length:
+            raise ValueError("min_length must be less than or equal to max_length")
+
         if (self.min_length is not None or self.max_length is not None) and self.type is not (
             ApplicationCommandOptionType.string
         ):

--- a/nextcord/application_command.py
+++ b/nextcord/application_command.py
@@ -1413,9 +1413,7 @@ class SlashCommandOption(BaseCommandOption, SlashOption, AutocompleteOptionMixin
         if (self.min_length is not None or self.max_length is not None) and self.type is not (
             ApplicationCommandOptionType.string
         ):
-            raise ValueError(
-                "min_length or max_length can only be set if the type is a string."
-            )
+            raise ValueError("min_length or max_length can only be set if the type is a string.")
 
         return True
 

--- a/nextcord/application_command.py
+++ b/nextcord/application_command.py
@@ -1418,7 +1418,9 @@ class SlashCommandOption(BaseCommandOption, SlashOption, AutocompleteOptionMixin
 
         # we check this ourselves because Discord doesn't do it yet
         # see here: https://github.com/discord/discord-api-docs/issues/5149
-        if (self.min_length is not None and self.max_length is not None) and self.min_length > self.max_length:
+        if (
+            self.min_length is not None and self.max_length is not None
+        ) and self.min_length > self.max_length:
             raise ValueError("min_length must be less than or equal to max_length")
 
         if (self.min_length is not None or self.max_length is not None) and self.type is not (

--- a/nextcord/types/interactions.py
+++ b/nextcord/types/interactions.py
@@ -69,6 +69,8 @@ class _ApplicationCommandOptionOptional(TypedDict, total=False):
     channel_types: List[ChannelType]
     min_value: Union[int, float]
     max_value: Union[int, float]
+    min_length: int
+    max_length: int
     autocomplete: bool
 
 


### PR DESCRIPTION
## Summary

This adds support for the newly added `min_length` and `max_length` fields in Slash Command options. 
More information about this: https://github.com/discord/discord-api-docs/pull/5143

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
  - [ ] I have updated the documentation to reflect the changes.
  - [ ] I have run `task pyright` and fixed the relevant issues.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
