### PR TITLE
feat(ClientCog): remove ClientCog.to_register

### DIFF
--- a/nextcord/application_command.py
+++ b/nextcord/application_command.py
@@ -531,16 +531,6 @@ class ClientCog:
         """
         pass
 
-    @property
-    def to_register(self) -> List[BaseApplicationCommand]:
-        warnings.warn(
-            ".to_register is deprecated, please use .application_commands instead.",
-            stacklevel=2,
-            category=FutureWarning,
-        )
-        # TODO: Remove at later date.
-        return self.__cog_application_commands__
-
 
 class CallbackMixin:
     name: Optional[str]


### PR DESCRIPTION
## Summary

This PR removes the deprecated `to_register` property from ClientCog.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
  - [ ] I have updated the documentation to reflect the changes.
  - [ ] I have run `task pyright` and fixed the relevant issues.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [x] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
