### PR TITLE
fix(commands): help commands not getting added

### DIFF
--- a/nextcord/ext/commands/bot.py
+++ b/nextcord/ext/commands/bot.py
@@ -278,9 +278,9 @@ class BotBase(GroupMixin):
             )
 
         if help_command is MISSING:
-            self._help_command = DefaultHelpCommand()
+            self.help_command = DefaultHelpCommand()
         else:
-            self._help_command = help_command
+            self.help_command = help_command
 
     # internal helpers
 


### PR DESCRIPTION
## Summary

Fixes help commands. They were broken in #719.

The `@help_command.setter` was not getting called, causing the bot to not have the help command added.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
  - [x] I have updated the documentation to reflect the changes.
  - [x] I have run `task pyright` and fixed the relevant issues.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
