### PR TITLE
docs(version_guarantees): add minor may break

### DIFF
--- a/docs/version_guarantees.rst
+++ b/docs/version_guarantees.rst
@@ -3,9 +3,25 @@
 Version Guarantees
 ==================
 
-The library follows a `semantic versioning principle <https://semver.org/>`_ which means that the major version is updated every time there is an incompatible API change. However due to the lack of guarantees on the Discord side when it comes to breaking changes along with the fairly dynamic nature of Python it can be hard to discern what can be considered a breaking change and what isn't.
+Nextcord does not follow semantic versioning exactly, The main difference is that breaking changes may also be made on minor version bumps (similar to Python's scheme).
+The reason for this is the Discord API lacks guarantees on breaking changes per API version, so library breaking changes unfortunately have to be made to match.
 
-The first thing to keep in mind is that breaking changes only apply to **publicly documented functions and classes**. If it's not listed in the documentation here then it is not part of the public API and is thus bound to change. This includes attributes that start with an underscore or functions without underscores that are not documented.
+However, any breaking changes will always be marked as such in the release notes/changelogs.
+
+Summary of The Versioning Scheme
+--------------------------------
+
+The version scheme ``major.minor.micro`` used aims to follow these rules:
+
+- ``major`` bumps usually contain large refactors/changes (most likely containing breaking changes).
+- ``minor`` bumps contain new features, sometimes bug fixes, and **may contain breaking changes**.
+- ``micro`` bumps only contain bug fixes, so no new features and no breaking changes.
+
+.. note::
+
+    Breaking changes are not applied on **privately documented functions and classes**.
+    A function/class is not part of the public API if it is not listed in the documentation.
+    Attributes and functions that start with an underscore are also not part of the public API.
 
 .. note::
 

--- a/docs/version_guarantees.rst
+++ b/docs/version_guarantees.rst
@@ -3,7 +3,7 @@
 Version Guarantees
 ==================
 
-Nextcord does not follow semantic versioning exactly, The main difference is that breaking changes may also be made on minor version bumps (similar to Python's scheme).
+Nextcord does not follow semantic versioning exactly, the main difference is that breaking changes may also be made on minor version bumps (similar to Python's scheme).
 The reason for this is the Discord API lacks guarantees on breaking changes per API version, so library breaking changes unfortunately have to be made to match.
 
 However, any breaking changes will always be marked as such in the release notes/changelogs.


### PR DESCRIPTION
## Summary

Minor version bumps can actually contain breaking changes, this lists in the guarantees that this may be the case.
<!-- What is this pull request for? Does it fix any issues? -->

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
  - [ ] I have updated the documentation to reflect the changes.
  - [ ] I have run `task pyright` and fixed the relevant issues.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
