### PR TITLE
fix(audit-logs): audit logs after strategy

### DIFF
--- a/nextcord/http.py
+++ b/nextcord/http.py
@@ -1563,15 +1563,12 @@ class HTTPClient:
         guild_id: Snowflake,
         limit: int = 100,
         before: Optional[Snowflake] = None,
-        after: Optional[Snowflake] = None,
         user_id: Optional[Snowflake] = None,
         action_type: Optional[AuditLogAction] = None,
     ) -> Response[audit_log.AuditLog]:
         params: Dict[str, Any] = {"limit": limit}
         if before:
             params["before"] = before
-        if after:
-            params["after"] = after
         if user_id:
             params["user_id"] = user_id
         if action_type:


### PR DESCRIPTION
## Summary

Fix for `after` parameter not working.

As pointed out by DeemonRider on Discord, [audit logs](https://discord.com/developers/docs/resources/audit-log#get-guild-audit-log) do not have an after parameter on Discord.

Additionally, the after parameter was being ignored in the code.

This fixes `AuditLogIterator` to filter out logs after a given point in time when `after` is specified.

## Testing

```py
@bot.command()
async def logs1(ctx: commands.Context):
    """Get a list of logs."""
    count = 0
    async for log in ctx.guild.audit_logs(limit=100, after=datetime(2022, 7, 7)):
        print(log.id, nextcord.utils.snowflake_time(log.id), str(log.user), log.action)
        count += 1
    await ctx.send(f"{count} log entries sent to console.")

@bot.command()
async def logs2(ctx: commands.Context):
    """Get a list of logs."""
    count = 0
    async for log in ctx.guild.audit_logs(limit=100, before=datetime(2022, 7, 7)):
        print(log.id, nextcord.utils.snowflake_time(log.id), str(log.user), log.action)
        count += 1
    await ctx.send(f"{count} log entries sent to console.")

@bot.command()
async def logs3(ctx: commands.Context):
    """Get a list of logs."""
    count = 0
    async for log in ctx.guild.audit_logs(
        limit=50,
        after=datetime(2022, 7, 7),
        oldest_first=True,
        user=ctx.author,
        action=nextcord.AuditLogAction.emoji_update,
    ):
        print(log.id, nextcord.utils.snowflake_time(log.id), str(log.user), log.action, log.target)
        count += 1
    await ctx.send(f"{count} log entries sent to console.")
```

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
  - [x] I have updated the documentation to reflect the changes.
  - [x] I have run `task pyright` and fixed the relevant issues.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
