### PR TITLE
feat(app-cmds): add qualified_name

### DIFF
--- a/nextcord/application_command.py
+++ b/nextcord/application_command.py
@@ -2155,9 +2155,7 @@ class SlashApplicationSubcommand(SlashCommandMixin, AutocompleteCommandMixin, Ca
         .. versionadded:: 2.1
         """
         return (
-            f"{self.parent_cmd.qualified_name} {self.name}"
-            if self.parent_cmd
-            else str(self.name)
+            f"{self.parent_cmd.qualified_name} {self.name}" if self.parent_cmd else str(self.name)
         )
 
     async def call(

--- a/nextcord/application_command.py
+++ b/nextcord/application_command.py
@@ -1583,6 +1583,11 @@ class BaseApplicationCommand(CallbackMixin, CallbackWrapperMixin):
     # Simple-ish getter + setter methods.
 
     @property
+    def qualified_name(self) -> str:
+        """Retrieves the fully qualified command name."""
+        return self.name
+
+    @property
     def description(self) -> str:
         """The description the command should have in Discord. Should be 1-100 characters long."""
         return self._description or DEFAULT_SLASH_DESCRIPTION
@@ -2137,6 +2142,10 @@ class SlashApplicationSubcommand(SlashCommandMixin, AutocompleteCommandMixin, Ca
 
         self.options: Dict[str, SlashCommandOption] = {}
         self.children: Dict[str, SlashApplicationSubcommand] = {}
+
+    @property
+    def qualified_name(self) -> str:
+        return self.parent_cmd.qualified_name + " " + self.name if self.parent_cmd else self.name
 
     async def call(
         self, state: ConnectionState, interaction: Interaction, option_data: List[dict]

--- a/nextcord/application_command.py
+++ b/nextcord/application_command.py
@@ -2146,7 +2146,7 @@ class SlashApplicationSubcommand(SlashCommandMixin, AutocompleteCommandMixin, Ca
     @property
     def qualified_name(self) -> str:
         """:class:`str`: Retrieve the command name including all parents space separated.
-        
+
         An example of the output would be `parent group subcommand`.
 
         .. versionadded:: 2.1

--- a/nextcord/application_command.py
+++ b/nextcord/application_command.py
@@ -2150,7 +2150,7 @@ class SlashApplicationSubcommand(SlashCommandMixin, AutocompleteCommandMixin, Ca
     def qualified_name(self) -> str:
         """:class:`str`: Retrieve the command name including all parents space separated.
 
-        An example of the output would be `parent group subcommand`.
+        An example of the output would be ``parent group subcommand``.
 
         .. versionadded:: 2.1
         """

--- a/nextcord/application_command.py
+++ b/nextcord/application_command.py
@@ -2146,7 +2146,7 @@ class SlashApplicationSubcommand(SlashCommandMixin, AutocompleteCommandMixin, Ca
     @property
     def qualified_name(self) -> str:
         return (
-            self.parent_cmd.qualified_name + " " + str(self.name) if self.parent_cmd else self.name
+            self.parent_cmd.qualified_name + " " + str(self.name) if self.parent_cmd else str(self.name)
         )
 
     async def call(

--- a/nextcord/application_command.py
+++ b/nextcord/application_command.py
@@ -1584,7 +1584,7 @@ class BaseApplicationCommand(CallbackMixin, CallbackWrapperMixin):
 
     @property
     def qualified_name(self) -> str:
-        """Retrieves the fully qualified command name."""
+        """:class:`str`: Retrieves the fully qualified command name."""
         return str(self.name)
 
     @property
@@ -2145,6 +2145,12 @@ class SlashApplicationSubcommand(SlashCommandMixin, AutocompleteCommandMixin, Ca
 
     @property
     def qualified_name(self) -> str:
+        """:class:`str`: Retrieve the command name including all parents space separated.
+        
+        An example of the output would be `parent group subcommand`.
+
+        .. versionadded:: 2.1
+        """
         return (
             self.parent_cmd.qualified_name + " " + str(self.name)
             if self.parent_cmd

--- a/nextcord/application_command.py
+++ b/nextcord/application_command.py
@@ -2145,7 +2145,9 @@ class SlashApplicationSubcommand(SlashCommandMixin, AutocompleteCommandMixin, Ca
 
     @property
     def qualified_name(self) -> str:
-        return self.parent_cmd.qualified_name + " " + str(self.name) if self.parent_cmd else self.name
+        return (
+            self.parent_cmd.qualified_name + " " + str(self.name) if self.parent_cmd else self.name
+        )
 
     async def call(
         self, state: ConnectionState, interaction: Interaction, option_data: List[dict]

--- a/nextcord/application_command.py
+++ b/nextcord/application_command.py
@@ -1585,7 +1585,7 @@ class BaseApplicationCommand(CallbackMixin, CallbackWrapperMixin):
     @property
     def qualified_name(self) -> str:
         """Retrieves the fully qualified command name."""
-        return self.name
+        return str(self.name)
 
     @property
     def description(self) -> str:
@@ -2145,7 +2145,7 @@ class SlashApplicationSubcommand(SlashCommandMixin, AutocompleteCommandMixin, Ca
 
     @property
     def qualified_name(self) -> str:
-        return self.parent_cmd.qualified_name + " " + self.name if self.parent_cmd else self.name
+        return self.parent_cmd.qualified_name + " " + str(self.name) if self.parent_cmd else self.name
 
     async def call(
         self, state: ConnectionState, interaction: Interaction, option_data: List[dict]

--- a/nextcord/application_command.py
+++ b/nextcord/application_command.py
@@ -1584,7 +1584,10 @@ class BaseApplicationCommand(CallbackMixin, CallbackWrapperMixin):
 
     @property
     def qualified_name(self) -> str:
-        """:class:`str`: Retrieves the fully qualified command name."""
+        """:class:`str`: Retrieves the fully qualified command name.
+
+        .. versionadded:: 2.1
+        """
         return str(self.name)
 
     @property
@@ -2152,7 +2155,7 @@ class SlashApplicationSubcommand(SlashCommandMixin, AutocompleteCommandMixin, Ca
         .. versionadded:: 2.1
         """
         return (
-            self.parent_cmd.qualified_name + " " + str(self.name)
+            f"{self.parent_cmd.qualified_name} {self.name}"
             if self.parent_cmd
             else str(self.name)
         )

--- a/nextcord/application_command.py
+++ b/nextcord/application_command.py
@@ -2146,7 +2146,9 @@ class SlashApplicationSubcommand(SlashCommandMixin, AutocompleteCommandMixin, Ca
     @property
     def qualified_name(self) -> str:
         return (
-            self.parent_cmd.qualified_name + " " + str(self.name) if self.parent_cmd else str(self.name)
+            self.parent_cmd.qualified_name + " " + str(self.name)
+            if self.parent_cmd
+            else str(self.name)
         )
 
     async def call(


### PR DESCRIPTION
## Summary

Re-adds the `app_cmd.qualified_name` property that was accidentally removed in #530. Is this a feat or a fix??

<!-- What is this pull request for? Does it fix any issues? -->

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [X] If code changes were made then they have been tested.
  - [x] I have updated the documentation to reflect the changes.
  - [ ] I have run `task pyright` and fixed the relevant issues.
- [ ] This PR fixes an issue.
- [X] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
