### PR TITLE
fix(commands): resolve unexpected kwarg errors with GroupMixin

### DIFF
--- a/nextcord/ext/commands/core.py
+++ b/nextcord/ext/commands/core.py
@@ -1207,7 +1207,6 @@ class GroupMixin(Generic[CogT]):
             _CaseInsensitiveDict() if case_insensitive else {}
         )
         self.case_insensitive: bool = case_insensitive
-        super().__init__(*args, **kwargs)
 
     @property
     def commands(self) -> Set[Command[CogT, Any, Any]]:
@@ -1482,7 +1481,8 @@ class Group(GroupMixin[CogT], Command[CogT, P, T]):
 
     def __init__(self, *args: Any, **attrs: Any) -> None:
         self.invoke_without_command: bool = attrs.pop("invoke_without_command", False)
-        super().__init__(*args, **attrs)
+        GroupMixin.__init__(self, *args, **attrs)
+        Command.__init__(self, *args, **attrs)  # type: ignore
 
     def copy(self: GroupT) -> GroupT:
         """Creates a copy of this :class:`Group`.

--- a/nextcord/ext/commands/core.py
+++ b/nextcord/ext/commands/core.py
@@ -1202,11 +1202,12 @@ class GroupMixin(Generic[CogT]):
         Whether the commands should be case insensitive. Defaults to ``False``.
     """
 
-    def __init__(self, *, case_insensitive: bool = False) -> None:
+    def __init__(self, *args, case_insensitive: bool = False, **kwargs) -> None:
         self.all_commands: Dict[str, Command[CogT, Any, Any]] = (
             _CaseInsensitiveDict() if case_insensitive else {}
         )
         self.case_insensitive: bool = case_insensitive
+        super().__init__(*args, **kwargs)
 
     @property
     def commands(self) -> Set[Command[CogT, Any, Any]]:


### PR DESCRIPTION
## Summary

Return the catchall `**kwargs` to fix `TypeError: GroupMixin.__init__() got an unexpected keyword argument 'name'` and `Client` being initialised multiple times from the blind super init.
This is a temporary fix and I do not like this, but it will have to do for now.
<!-- What is this pull request for? Does it fix any issues? -->

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
  - [ ] I have updated the documentation to reflect the changes.
  - [x] I have run `task pyright` and fixed the relevant issues.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
