### PR TITLE
feat: support for lambdas in slash options

### DIFF
--- a/nextcord/application_command.py
+++ b/nextcord/application_command.py
@@ -1542,7 +1542,7 @@ class SlashCommandMixin(CallbackMixin):
                     raise ValueError(f"default lambda has to take in one parameter, not {len_params}!")
                 default = default(interaction)
 
-            kwargs[uncalled_arg.functional_name] = uncalled_arg.default
+            kwargs[uncalled_arg.functional_name] = default
 
         return kwargs
 

--- a/nextcord/application_command.py
+++ b/nextcord/application_command.py
@@ -1535,6 +1535,13 @@ class SlashCommandMixin(CallbackMixin):
                 )
 
         for uncalled_arg in uncalled_args.values():
+            default = uncalled_arg.default
+            if callable(default):
+                len_params = len(signature(default).parameters)
+                if len_params != 1:
+                    raise ValueError(f"default lambda has to take in one parameter, not {len_params}!")
+                default = default(interaction)
+
             kwargs[uncalled_arg.functional_name] = uncalled_arg.default
 
         return kwargs

--- a/nextcord/application_command.py
+++ b/nextcord/application_command.py
@@ -1539,7 +1539,9 @@ class SlashCommandMixin(CallbackMixin):
             if callable(default):
                 len_params = len(signature(default).parameters)
                 if len_params != 1:
-                    raise ValueError(f"default lambda has to take in one parameter, not {len_params}!")
+                    raise ValueError(
+                        f"default lambda has to take in one parameter, not {len_params}!"
+                    )
                 default = default(interaction)
 
             kwargs[uncalled_arg.functional_name] = default


### PR DESCRIPTION
## Summary

This PR allows for the user to set the default in `SlashOption` to a lambda. This lambda can be used to set the default of an option to something from the interaction. Supersedes #708. 

For example: 
```python
import nextcord

client = nextcord.Client()

@client.slash_command()
async def greet(inter: nextcord.Interaction, target: nextcord.User = nextcord.SlashOption(default=lambda inter: inter.user)):
    await inter.response.send_message(f"Yo {target.display_name}!")

client.run("token")
```
### Current Issues

- Pyright complains that the type of the parameter in the Slash Option lambda (if provided) is unknown. This could possibly be fixed by changing how we type hint `default`.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
  - [ ] I have updated the documentation to reflect the changes.
  - [ ] I have run `task pyright` and fixed the relevant issues.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
