### PR TITLE
docs(examples): add message_content or remove prefix where applicable

### DIFF
--- a/examples/application_commands/autocompleted_command.py
+++ b/examples/application_commands/autocompleted_command.py
@@ -3,7 +3,7 @@ from nextcord.ext import commands
 
 TESTING_GUILD_ID = 123456789  # Replace with your testing guild id
 
-bot = commands.Bot(command_prefix="$")
+bot = commands.Bot()
 
 list_of_dog_breeds = [
     "German Shepard",

--- a/examples/application_commands/choices.py
+++ b/examples/application_commands/choices.py
@@ -4,7 +4,7 @@ from nextcord.ext import commands
 
 TESTING_GUILD_ID = 123456789  # Replace with your testing guild id
 
-bot = commands.Bot(command_prefix="$")
+bot = commands.Bot()
 
 
 @bot.slash_command(guild_ids=[TESTING_GUILD_ID])

--- a/examples/application_commands/context_menus.py
+++ b/examples/application_commands/context_menus.py
@@ -3,7 +3,7 @@ from nextcord.ext import commands
 
 TESTING_GUILD_ID = 123456789  # Replace with your testing guild id
 
-bot = commands.Bot(command_prefix="$")
+bot = commands.Bot()
 
 
 @bot.user_command(guild_ids=[TESTING_GUILD_ID])

--- a/examples/application_commands/slash_command.py
+++ b/examples/application_commands/slash_command.py
@@ -3,7 +3,7 @@ from nextcord.ext import commands
 
 TESTING_GUILD_ID = 123456789  # Replace with your testing guild id
 
-bot = commands.Bot(command_prefix="$")
+bot = commands.Bot()
 
 
 # command will be global if guild_ids is not specified

--- a/examples/application_commands/sub_commands.py
+++ b/examples/application_commands/sub_commands.py
@@ -3,7 +3,7 @@ from nextcord.ext import commands
 
 TESTING_GUILD_ID = 123456789  # Replace with your testing guild id
 
-bot = commands.Bot(command_prefix="$")
+bot = commands.Bot()
 
 
 @bot.slash_command(guild_ids=[TESTING_GUILD_ID], description="main command")

--- a/examples/background_task.py
+++ b/examples/background_task.py
@@ -22,5 +22,5 @@ class Bot(commands.Bot):
         await self.wait_until_ready()  # wait until the bot logs in
 
 
-bot = Bot(command_prefix="$")
+bot = Bot()
 bot.run("token")

--- a/examples/background_task_asyncio.py
+++ b/examples/background_task_asyncio.py
@@ -20,5 +20,5 @@ class Bot(commands.Bot):
             await asyncio.sleep(60)  # task runs every 60 seconds
 
 
-bot = Bot(command_prefix="$")
+bot = Bot()
 bot.run("token")

--- a/examples/basic_bot.py
+++ b/examples/basic_bot.py
@@ -11,6 +11,7 @@ There are a number of utility commands being showcased here."""
 
 intents = nextcord.Intents.default()
 intents.members = True
+intents.message_content = True
 
 bot = commands.Bot(command_prefix="$", description=description, intents=intents)
 

--- a/examples/basic_voice.py
+++ b/examples/basic_voice.py
@@ -125,7 +125,11 @@ class Music(commands.Cog):
             ctx.voice_client.stop()
 
 
-bot = commands.Bot(command_prefix="$", description="Relatively simple music bot example")
+intents = nextcord.Intents.default()
+intents.message_content = True
+bot = commands.Bot(
+    command_prefix="$", description="Relatively simple music bot example", intents=intents
+)
 
 
 bot.add_cog(Music(bot))

--- a/examples/converters.py
+++ b/examples/converters.py
@@ -6,6 +6,7 @@ from nextcord.ext import commands
 
 intents = nextcord.Intents.default()
 intents.members = True
+intents.message_content = True
 
 bot = commands.Bot(command_prefix="$", intents=intents)
 

--- a/examples/custom_context.py
+++ b/examples/custom_context.py
@@ -32,6 +32,8 @@ class Bot(commands.Bot):
         return await super().get_context(message, cls=cls)
 
 
+intents = nextcord.Intents.default()
+intents.message_content = True
 bot = Bot(command_prefix="$")
 
 

--- a/examples/deleted.py
+++ b/examples/deleted.py
@@ -11,7 +11,9 @@ class Bot(commands.Bot):
         await message.channel.send(msg)
 
 
-bot = Bot(command_prefix="$")
+intents = nextcord.Intents.default()
+intents.message_content = True
+bot = Bot(command_prefix="$", intents=intents)
 
 
 @bot.command()

--- a/examples/edits.py
+++ b/examples/edits.py
@@ -13,7 +13,9 @@ class Bot(commands.Bot):
         await before.channel.send(msg)
 
 
-bot = Bot(command_prefix="$")
+intents = nextcord.Intents.default()
+intents.message_content = True
+bot = Bot(command_prefix="$", intents=intents)
 
 
 @bot.command()

--- a/examples/guessing_game.py
+++ b/examples/guessing_game.py
@@ -1,9 +1,12 @@
 import asyncio
 import random
 
+import nextcord
 from nextcord.ext import commands
 
-bot = commands.Bot(command_prefix="$")
+intents = nextcord.intents.default()
+intents.message_content = True
+bot = commands.Bot(command_prefix="$", intents=intents)
 
 
 @bot.command()

--- a/examples/head_or_tails.py
+++ b/examples/head_or_tails.py
@@ -6,9 +6,12 @@
 
 import random
 
+import nextcord
 from nextcord.ext import commands
 
-bot = commands.Bot(command_prefix="$")
+intents = nextcord.Intents.default()
+intents.message_content = True
+bot = commands.Bot(command_prefix="$", intents=intents)
 
 
 @bot.command()

--- a/examples/modals/modal.py
+++ b/examples/modals/modal.py
@@ -51,7 +51,7 @@ class Pet(nextcord.ui.Modal):
         await interaction.send(response)
 
 
-bot = commands.Bot(command_prefix="$")
+bot = commands.Bot()
 
 
 @bot.slash_command(

--- a/examples/modals/persistent.py
+++ b/examples/modals/persistent.py
@@ -72,7 +72,7 @@ class Bot(commands.Bot):
         print(f"Logged in as {self.user} (ID: {self.user.id})")
 
 
-bot = Bot(command_prefix="$")
+bot = Bot()
 
 
 @bot.slash_command(

--- a/examples/new_member.py
+++ b/examples/new_member.py
@@ -16,6 +16,7 @@ class Bot(commands.Bot):
 
 intents = nextcord.Intents.default()
 intents.members = True
+intents.message_content = True
 
 bot = Bot(command_prefix="$", intents=intents)
 bot.run("token")

--- a/examples/reaction_roles.py
+++ b/examples/reaction_roles.py
@@ -84,6 +84,7 @@ class Bot(commands.Bot):
 
 intents = nextcord.Intents.default()
 intents.members = True
+intents.message_content = True
 
 bot = Bot(command_prefix="$", intents=intents)
 bot.run("token")

--- a/examples/reply.py
+++ b/examples/reply.py
@@ -1,6 +1,9 @@
+import nextcord
 from nextcord.ext import commands
 
-bot = commands.Bot(command_prefix="$")
+intents = nextcord.Intents.default()
+intents.message_content = True
+bot = commands.Bot(command_prefix="$", intents=intents)
 
 
 @bot.command()

--- a/examples/secret.py
+++ b/examples/secret.py
@@ -3,7 +3,9 @@ import typing
 import nextcord
 from nextcord.ext import commands
 
-bot = commands.Bot(command_prefix="$", description="Nothing to see here!")
+intents = nextcord.Intents.default()
+intents.message_content = True
+bot = commands.Bot(command_prefix="$", description="Nothing to see here!", intents=intents)
 
 
 # the `hidden` keyword argument hides it from the help command.

--- a/examples/secure_token_storage.py
+++ b/examples/secure_token_storage.py
@@ -10,7 +10,7 @@ from nextcord.ext import commands
 # load_dotenv reads from a file called .env in the same directory as the python files which should roughly look like BOT_TOKEN="1234567890"
 load_dotenv()
 
-bot = commands.Bot(command_prefix="$")
+bot = commands.Bot()
 
 # run the bot using the token in .env
 bot.run(os.getenv("BOT_TOKEN"))

--- a/examples/views/confirm.py
+++ b/examples/views/confirm.py
@@ -25,15 +25,15 @@ class Confirm(nextcord.ui.View):
         self.stop()
 
 
-bot = commands.Bot(command_prefix="$")
+bot = commands.Bot()
 
 
-@bot.command()
-async def ask(ctx):
+@bot.slash_command()
+async def ask(interaction):
     """Asks the user a question to confirm something."""
     # We create the view and assign it to a variable so we can wait for it later.
     view = Confirm()
-    await ctx.send("Do you want to continue?", view=view)
+    await interaction.send("Do you want to continue?", view=view)
     # Wait for the View to stop listening for input...
     await view.wait()
     if view.value is None:

--- a/examples/views/counter.py
+++ b/examples/views/counter.py
@@ -21,13 +21,13 @@ class Counter(nextcord.ui.View):
         await interaction.response.edit_message(view=self)
 
 
-bot = commands.Bot(command_prefix="$")
+bot = commands.Bot()
 
 
-@bot.command()
-async def counter(ctx):
+@bot.slash_command()
+async def counter(interaction):
     """Starts a counter for pressing."""
-    await ctx.send("Press!", view=Counter())
+    await interaction.send("Press!", view=Counter())
 
 
 bot.run("token")

--- a/examples/views/dropdown.py
+++ b/examples/views/dropdown.py
@@ -47,18 +47,18 @@ class DropdownView(nextcord.ui.View):
         self.add_item(Dropdown())
 
 
-bot = commands.Bot(command_prefix="$")
+bot = commands.Bot()
 
 
-@bot.command()
-async def colour(ctx):
+@bot.slash_command()
+async def colour(interaction):
     """Sends a message with our dropdown containing colours"""
 
     # Create the view containing our dropdown
     view = DropdownView()
 
     # Sending a message containing our view
-    await ctx.send("Pick your favourite colour:", view=view)
+    await interaction.send("Pick your favourite colour:", view=view)
 
 
 bot.run("token")

--- a/examples/views/ephemeral.py
+++ b/examples/views/ephemeral.py
@@ -31,13 +31,13 @@ class EphemeralCounter(nextcord.ui.View):
         await interaction.response.send_message("Enjoy!", view=Counter(), ephemeral=True)
 
 
-bot = commands.Bot(command_prefix="$")
+bot = commands.Bot()
 
 
-@bot.command()
-async def counter(ctx):
+@bot.slash_command()
+async def counter(interaction):
     """Starts a counter for pressing."""
-    await ctx.send("Press!", view=EphemeralCounter())
+    await interaction.send("Press!", view=EphemeralCounter())
 
 
 bot.run("token")

--- a/examples/views/link.py
+++ b/examples/views/link.py
@@ -19,13 +19,13 @@ class Google(nextcord.ui.View):
         self.add_item(nextcord.ui.Button(label="Click Here", url=url))
 
 
-bot = commands.Bot(command_prefix="$")
+bot = commands.Bot()
 
 
-@bot.command()
-async def google(ctx, *, query: str):
+@bot.slash_command()
+async def google(interaction, query: str):
     """Returns a google link for a query"""
-    await ctx.send(f"Google Result for: `{query}`", view=Google(query))
+    await interaction.send(f"Google Result for: `{query}`", view=Google(query))
 
 
 bot.run("token")

--- a/examples/views/persistent.py
+++ b/examples/views/persistent.py
@@ -1,5 +1,5 @@
 import nextcord
-from nextcord.ext import commands
+from nextcord.ext import application_checks, commands
 
 
 # Define a simple View that persists between bot restarts
@@ -51,18 +51,18 @@ class Bot(commands.Bot):
         print(f"Logged in as {self.user} (ID: {self.user.id})")
 
 
-bot = Bot(command_prefix="$")
+bot = Bot()
 
 
-@bot.command()
-@commands.is_owner()
-async def prepare(ctx):
+@bot.slash_command()
+@application_checks.is_owner()
+async def prepare(interaction):
     """Starts a persistent view."""
     # In order for a persistent view to be listened to, it needs to be sent to an actual message.
     # Call this method once just to store it somewhere.
     # In a more complicated program you might fetch the message_id from a database for use later.
     # However this is outside of the scope of this simple example.
-    await ctx.send("What's your favourite colour?", view=PersistentView())
+    await interaction.send("What's your favourite colour?", view=PersistentView())
 
 
 bot.run("token")

--- a/examples/views/tic_tac_toe.py
+++ b/examples/views/tic_tac_toe.py
@@ -120,13 +120,13 @@ class TicTacToe(nextcord.ui.View):
         return None
 
 
-bot = commands.Bot(command_prefix="$")
+bot = commands.Bot()
 
 
-@bot.command()
-async def tic(ctx):
+@bot.slash_command()
+async def tic(interaction):
     """Starts a tic-tac-toe game with yourself."""
-    await ctx.send("Tic Tac Toe: X goes first", view=TicTacToe())
+    await interaction.send("Tic Tac Toe: X goes first", view=TicTacToe())
 
 
 bot.run("token")


### PR DESCRIPTION
## Summary

This uses `Intents.message_content` for `ext.commands` examples, removes prefix when not needed, and uses slash commands when `ext.commands` is not being demonstrated.

closes #728
<!-- What is this pull request for? Does it fix any issues? -->

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
  - [ ] I have updated the documentation to reflect the changes.
  - [ ] I have run `task pyright` and fixed the relevant issues.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
(is a code change but not to the library, its documentation)
