### PR TITLE
feat: add File.force_close to close bytesio files

### DIFF
--- a/nextcord/asset.py
+++ b/nextcord/asset.py
@@ -171,7 +171,11 @@ class AssetMixin:
         data = await self.read()
         file_filename = filename if filename is not MISSING else yarl.URL(self.url).name
         return File(
-            io.BytesIO(data), filename=file_filename, description=description, spoiler=spoiler, force_close=force_close
+            io.BytesIO(data),
+            filename=file_filename,
+            description=description,
+            spoiler=spoiler,
+            force_close=force_close,
         )
 
 

--- a/nextcord/asset.py
+++ b/nextcord/asset.py
@@ -149,6 +149,8 @@ class AssetMixin:
             memory after it is sent or used once.
             Keep this enabled if you don't wish to reuse the same bytes.
 
+            .. versionadded:: 2.2
+
         Raises
         ------
         DiscordException

--- a/nextcord/asset.py
+++ b/nextcord/asset.py
@@ -124,6 +124,7 @@ class AssetMixin:
         filename: Optional[str] = MISSING,
         description: Optional[str] = None,
         spoiler: bool = False,
+        force_close: bool = True,
     ) -> File:
         """|coro|
 
@@ -141,6 +142,12 @@ class AssetMixin:
             The description for the file.
         spoiler: :class:`bool`
             Whether the file is a spoiler.
+        force_close: :class:`bool`
+            Whether to forcibly close the bytes used to create the file
+            when ``.close()`` is called.
+            This will also make the file bytes unusable by flusing it from
+            memory after it is sent or used once.
+            Keep this enabled if you don't wish to reuse the same bytes.
 
         Raises
         ------
@@ -164,7 +171,7 @@ class AssetMixin:
         data = await self.read()
         file_filename = filename if filename is not MISSING else yarl.URL(self.url).name
         return File(
-            io.BytesIO(data), filename=file_filename, description=description, spoiler=spoiler
+            io.BytesIO(data), filename=file_filename, description=description, spoiler=spoiler, force_close=force_close
         )
 
 

--- a/nextcord/asset.py
+++ b/nextcord/asset.py
@@ -145,7 +145,7 @@ class AssetMixin:
         force_close: :class:`bool`
             Whether to forcibly close the bytes used to create the file
             when ``.close()`` is called.
-            This will also make the file bytes unusable by flusing it from
+            This will also make the file bytes unusable by flushing it from
             memory after it is sent or used once.
             Keep this enabled if you don't wish to reuse the same bytes.
 

--- a/nextcord/file.py
+++ b/nextcord/file.py
@@ -167,7 +167,6 @@ class File:
             self.fp.seek(self._original_pos)
 
     def close(self) -> None:
+        self.fp.close = self._closer
         if self._owner or self.force_close:
             self._closer()
-        else:
-            self.fp.close = self._closer

--- a/nextcord/file.py
+++ b/nextcord/file.py
@@ -68,7 +68,7 @@ class File:
         when ``.close()`` is called.
         This will also make the file bytes unusable by flushing it from
         memory after it is sent once.
-        Keep this enabled if you don't wish to reuse the same bytes.
+        Enable this if you don't wish to reuse the same bytes.
 
     Attributes
     -----------

--- a/nextcord/file.py
+++ b/nextcord/file.py
@@ -92,7 +92,16 @@ class File:
         Keep this enabled if you don't wish to reuse the same bytes.
     """
 
-    __slots__ = ("fp", "filename", "spoiler", "force_close", "_original_pos", "_owner", "_closer", "description")
+    __slots__ = (
+        "fp",
+        "filename",
+        "spoiler",
+        "force_close",
+        "_original_pos",
+        "_owner",
+        "_closer",
+        "description",
+    )
 
     if TYPE_CHECKING:
         fp: Union[io.BufferedReader, io.BufferedIOBase]
@@ -108,7 +117,7 @@ class File:
         *,
         description: Optional[str] = None,
         spoiler: bool = False,
-        force_close: bool = True, # Accessed in .close()
+        force_close: bool = True,  # Accessed in .close()
     ):
         if isinstance(fp, io.IOBase):
             if not (fp.seekable() and fp.readable()):

--- a/nextcord/file.py
+++ b/nextcord/file.py
@@ -129,7 +129,7 @@ class File:
             self.fp = open(fp, "rb")
             self._original_pos = 0
             self._owner = True
-        
+
         self.force_close = force_close
 
         # aiohttp only uses two methods from IOBase

--- a/nextcord/file.py
+++ b/nextcord/file.py
@@ -66,7 +66,7 @@ class File:
     force_close: :class:`bool`
         Whether to forcibly close the bytes used to create the file
         when ``.close()`` is called.
-        This will also make the file bytes unusable by flusing it from
+        This will also make the file bytes unusable by flushing it from
         memory after it is sent once.
         Keep this enabled if you don't wish to reuse the same bytes.
 

--- a/nextcord/file.py
+++ b/nextcord/file.py
@@ -92,6 +92,8 @@ class File:
         This will also make the file bytes unusable by flushing it from
         memory after it is sent or used once.
         Enable this if you don't wish to reuse the same bytes.
+
+        .. versionadded:: 2.2
     """
 
     __slots__ = (

--- a/nextcord/file.py
+++ b/nextcord/file.py
@@ -145,5 +145,4 @@ class File:
 
     def close(self) -> None:
         self.fp.close = self._closer
-        if self._owner:
-            self._closer()
+        self._closer()

--- a/nextcord/file.py
+++ b/nextcord/file.py
@@ -87,9 +87,9 @@ class File:
     force_close: :class:`bool`
         Whether to forcibly close the bytes used to create the file
         when ``.close()`` is called.
-        This will also make the file bytes unusable by flusing it from
+        This will also make the file bytes unusable by flushing it from
         memory after it is sent or used once.
-        Keep this enabled if you don't wish to reuse the same bytes.
+        Enable this if you don't wish to reuse the same bytes.
     """
 
     __slots__ = (

--- a/nextcord/file.py
+++ b/nextcord/file.py
@@ -70,6 +70,8 @@ class File:
         memory after it is sent once.
         Enable this if you don't wish to reuse the same bytes.
 
+        .. versionadded:: 2.2
+
     Attributes
     -----------
     fp: Union[:class:`io.BufferedReader`, :class:`io.BufferedIOBase`]

--- a/nextcord/file.py
+++ b/nextcord/file.py
@@ -129,6 +129,8 @@ class File:
             self.fp = open(fp, "rb")
             self._original_pos = 0
             self._owner = True
+        
+        self.force_close = force_close
 
         # aiohttp only uses two methods from IOBase
         # read and close, since I want to control when the files

--- a/nextcord/file.py
+++ b/nextcord/file.py
@@ -117,7 +117,7 @@ class File:
         *,
         description: Optional[str] = None,
         spoiler: bool = False,
-        force_close: bool = True,  # Accessed in .close()
+        force_close: bool = False,
     ):
         if isinstance(fp, io.IOBase):
             if not (fp.seekable() and fp.readable()):

--- a/nextcord/message.py
+++ b/nextcord/message.py
@@ -296,7 +296,7 @@ class Attachment(Hashable):
         description: Optional[str] = MISSING,
         use_cached: bool = False,
         spoiler: bool = False,
-        force_close=True,
+        force_close: bool = True,
     ) -> File:
         """|coro|
 

--- a/nextcord/message.py
+++ b/nextcord/message.py
@@ -296,6 +296,7 @@ class Attachment(Hashable):
         description: Optional[str] = MISSING,
         use_cached: bool = False,
         spoiler: bool = False,
+        force_close = True,
     ) -> File:
         """|coro|
 
@@ -329,6 +330,14 @@ class Attachment(Hashable):
             Whether the file is a spoiler.
 
             .. versionadded:: 1.4
+        force_close: :class:`bool`
+            Whether to forcibly close the bytes used to create the file
+            when ``.close()`` is called.
+            This will also make the file bytes unusable by flushing it from
+            memory after it is sent or used once.
+            Keep this enabled if you don't wish to reuse the same bytes.
+           
+           .. versionadded:: 2.2
 
         Raises
         ------
@@ -349,7 +358,7 @@ class Attachment(Hashable):
         file_filename = filename if filename is not MISSING else self.filename
         file_description = description if description is not MISSING else self.description
         return File(
-            io.BytesIO(data), filename=file_filename, description=file_description, spoiler=spoiler
+            io.BytesIO(data), filename=file_filename, description=file_description, spoiler=spoiler, force_close=force_close
         )
 
     def to_dict(self) -> AttachmentPayload:

--- a/nextcord/message.py
+++ b/nextcord/message.py
@@ -296,7 +296,7 @@ class Attachment(Hashable):
         description: Optional[str] = MISSING,
         use_cached: bool = False,
         spoiler: bool = False,
-        force_close = True,
+        force_close=True,
     ) -> File:
         """|coro|
 
@@ -336,7 +336,7 @@ class Attachment(Hashable):
             This will also make the file bytes unusable by flushing it from
             memory after it is sent or used once.
             Keep this enabled if you don't wish to reuse the same bytes.
-           
+
            .. versionadded:: 2.2
 
         Raises
@@ -358,7 +358,11 @@ class Attachment(Hashable):
         file_filename = filename if filename is not MISSING else self.filename
         file_description = description if description is not MISSING else self.description
         return File(
-            io.BytesIO(data), filename=file_filename, description=file_description, spoiler=spoiler, force_close=force_close
+            io.BytesIO(data),
+            filename=file_filename,
+            description=file_description,
+            spoiler=spoiler,
+            force_close=force_close,
         )
 
     def to_dict(self) -> AttachmentPayload:


### PR DESCRIPTION
## Summary

Added force_close to `File` class that will prevent memory leak to occur when a message containing a file is sent if enabled.
`nextcord.abc` calls `File.close()` for each file after the message is sent.
Files bytes could not be deleted after `File.close()` is called.
Causing uploaded files to linger in memory until the garbage collector removes them, usually after a few hours.

## Checklist

- [x] If code changes were made then they have been tested.
  - [x] I have updated the documentation to reflect the changes.
  - [x] I have run `task pyright` and fixed the relevant issues.
- [x] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
