### PR TITLE
refactor(embeds): deprecate Embed.Empty in favour of None

### DIFF
--- a/nextcord/embeds.py
+++ b/nextcord/embeds.py
@@ -224,7 +224,7 @@ class Embed:
 
         # fill in the basic fields
 
-        self.title = data.get("title", None)
+        self.title = data.get("title")
         self.type = data.get("type", None)
         self.description = data.get("description", None)
         self.url = data.get("url", None)
@@ -554,7 +554,7 @@ class Embed:
 
     @property
     def fields(self) -> List[_EmbedFieldProxy]:
-        """List[Union[``EmbedProxy``, ``None``]]: Returns a :class:`list` of ``EmbedProxy`` denoting the field contents.
+        """List[Optional[``EmbedProxy``]]: Returns a :class:`list` of ``EmbedProxy`` denoting the field contents.
 
         See :meth:`add_field` for possible values you can access.
 

--- a/nextcord/embeds.py
+++ b/nextcord/embeds.py
@@ -25,7 +25,6 @@ DEALINGS IN THE SOFTWARE.
 from __future__ import annotations
 
 import datetime
-
 from typing import (
     TYPE_CHECKING,
     Any,

--- a/nextcord/embeds.py
+++ b/nextcord/embeds.py
@@ -125,7 +125,8 @@ class Embed:
 
     .. versionchanged:: 2.2
         ``Embed.Empty`` is now an alias for ``None`` for a non-breaking change, every field uses ``None``
-            and is typed as `Optional[]` over ``Embed.Empty`` now.
+            and is typed as `Optional[]` over ``Embed.Empty``.
+            This also means that you can no longer use ``len()`` on an empty field.
 
     Attributes
     -----------
@@ -170,7 +171,7 @@ class Embed:
     )
 
     # backwards compatibility
-    Empty: Literal[None] = None
+    Empty = EmptyEmbed
 
     def __init__(
         self,
@@ -184,7 +185,7 @@ class Embed:
         timestamp: Optional[datetime.datetime] = None,
     ):
 
-        self.colour = colour or color
+        self.colour = colour if colour is not None else color
         self.title = title
         self.type = type
         self.url = url
@@ -308,10 +309,12 @@ class Embed:
 
     @colour.setter
     def colour(self, value: Optional[Union[int, Colour]]):  # type: ignore
-        if value is None:
-            self._colour = None
+        if isinstance(value, Colour):
+            self._colour = value
         elif isinstance(value, int):
             self._colour = Colour(value=value)
+        elif value is None:
+            self._colour = None
         else:
             raise TypeError(
                 f"Expected nextcord.Colour, int, or None but received {value.__class__.__name__} instead."
@@ -325,12 +328,12 @@ class Embed:
 
     @timestamp.setter
     def timestamp(self, value: Optional[datetime.datetime]):
-        if value is None:
-            self._timestamp = None
-        elif isinstance(value, datetime.datetime):
+        if isinstance(value, datetime.datetime):
             if value.tzinfo is None:
                 value = value.astimezone()
             self._timestamp = value
+        elif value is None:
+            self._timestamp = None
         else:
             raise TypeError(
                 f"Expected datetime.datetime or None received {value.__class__.__name__} instead"
@@ -354,9 +357,9 @@ class Embed:
 
         Parameters
         -----------
-        text: :class:`str`
+        text: Optional[:class:`str`]
             The footer text.
-        icon_url: :class:`str`
+        icon_url: Optional[:class:`str`]
             The URL of the footer icon. Only HTTP(S) is supported.
         """
 
@@ -410,7 +413,7 @@ class Embed:
 
         Parameters
         -----------
-        url: :class:`str`
+        url: Optional[:class:`str`]
             The source URL for the image. Only HTTP(S) is supported.
         """
 
@@ -516,11 +519,11 @@ class Embed:
 
         Parameters
         -----------
-        name: :class:`str`
+        name: Optional[:class:`str`]
             The name of the author.
-        url: :class:`str`
+        url: Optional[:class:`str`]
             The URL for the author.
-        icon_url: :class:`str`
+        icon_url: Optional[:class:`str`]
             The URL of the author icon. Only HTTP(S) is supported.
         """
 
@@ -574,7 +577,7 @@ class Embed:
         value: :class:`str`
             The value of the field.
         inline: :class:`bool`
-            Whether the field should be displayed inline.
+            Whether the field should be displayed inline. Defaults to ``True``.
         """
 
         field = {
@@ -607,7 +610,7 @@ class Embed:
         value: :class:`str`
             The value of the field.
         inline: :class:`bool`
-            Whether the field should be displayed inline.
+            Whether the field should be displayed inline. Defaults to ``True``.
         """
 
         field = {

--- a/nextcord/embeds.py
+++ b/nextcord/embeds.py
@@ -233,9 +233,9 @@ class Embed:
         # fill in the basic fields
 
         self.title = data.get("title")
-        self.type = data.get("type", None)
-        self.description = data.get("description", None)
-        self.url = data.get("url", None)
+        self.type = data.get("type")
+        self.description = data.get("description")
+        self.url = data.get("url")
 
         if self.title is not None:
             self.title = str(self.title)

--- a/nextcord/embeds.py
+++ b/nextcord/embeds.py
@@ -309,12 +309,10 @@ class Embed:
 
     @colour.setter
     def colour(self, value: Optional[Union[int, Colour]]):  # type: ignore
-        if isinstance(value, Colour):
+        if isinstance(value, Colour) or value is None:
             self._colour = value
         elif isinstance(value, int):
             self._colour = Colour(value=value)
-        elif value is None:
-            self._colour = None
         else:
             raise TypeError(
                 f"Expected nextcord.Colour, int, or None but received {value.__class__.__name__} instead."
@@ -328,12 +326,12 @@ class Embed:
 
     @timestamp.setter
     def timestamp(self, value: Optional[datetime.datetime]):
-        if isinstance(value, datetime.datetime):
+        if value is None:
+            self._timestamp = value
+        elif isinstance(value, datetime.datetime):
             if value.tzinfo is None:
                 value = value.astimezone()
             self._timestamp = value
-        elif value is None:
-            self._timestamp = None
         else:
             raise TypeError(
                 f"Expected datetime.datetime or None received {value.__class__.__name__} instead"

--- a/nextcord/embeds.py
+++ b/nextcord/embeds.py
@@ -25,12 +25,12 @@ DEALINGS IN THE SOFTWARE.
 from __future__ import annotations
 
 import datetime
+import warnings
 from typing import (
     TYPE_CHECKING,
     Any,
     Dict,
     List,
-    Literal,
     Mapping,
     Optional,
     Protocol,
@@ -42,10 +42,11 @@ from typing import (
 from . import utils
 from .colour import Colour
 
+
 __all__ = ("Embed",)
 
 # Backwards compatibility
-EmptyEmbed: Literal[None] = None
+EmptyEmbed = None
 
 
 class EmbedProxy:
@@ -170,9 +171,6 @@ class Embed:
         "description",
     )
 
-    # backwards compatibility
-    Empty = EmptyEmbed
-
     def __init__(
         self,
         *,
@@ -202,6 +200,16 @@ class Embed:
 
         if timestamp:
             self.timestamp = timestamp
+
+    # backwards compatibility
+    @property
+    def Empty(self) -> None:
+        warnings.warn(
+            "Empty is deprecated and will be removed in a future version. Use None instead.",
+            FutureWarning,
+            stacklevel=2,
+        )
+        return None
 
     @classmethod
     def from_dict(cls: Type[E], data: Mapping[str, Any]) -> E:


### PR DESCRIPTION
## Summary

This PR removes `EmptyEmbed` and everything related to it.
`EmptyEmbed` and `Embed.Empty` are kept but are assigned to `None` to make this a non-breaking for users, comparing and using it still works.
One thing that does make it a breaking change is `len()` on an empty field which is not possible on None.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
  - [x] I have updated the documentation to reflect the changes.
  - [x] I have run `task pyright` and fixed the relevant issues.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [x] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
