### PR TITLE
fix: bound interaction.client to either client/autoshardedclient instance/subclass instead of explictly lock return type to client

### DIFF
--- a/nextcord/interactions.py
+++ b/nextcord/interactions.py
@@ -28,7 +28,7 @@ from __future__ import annotations
 
 import asyncio
 from datetime import datetime, timedelta
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Union
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Union, TTypeVar
 
 from . import utils
 from .channel import ChannelType, PartialMessageable
@@ -75,6 +75,7 @@ if TYPE_CHECKING:
     InteractionChannel = Union[
         VoiceChannel, StageChannel, TextChannel, CategoryChannel, Thread, PartialMessageable
     ]
+    C = TypeVar("C", bound=Client)
 
 MISSING: Any = utils.MISSING
 
@@ -225,7 +226,7 @@ class Interaction:
                 pass
 
     @property
-    def client(self) -> Client:
+    def client(self) -> C:
         """:class:`Client`: The client that handled the interaction."""
         return self._state._get_client()
 

--- a/nextcord/interactions.py
+++ b/nextcord/interactions.py
@@ -28,7 +28,7 @@ from __future__ import annotations
 
 import asyncio
 from datetime import datetime, timedelta
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Union, TTypeVar
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Union, Typevar
 
 from . import utils
 from .channel import ChannelType, PartialMessageable
@@ -63,7 +63,7 @@ if TYPE_CHECKING:
         TextChannel,
         VoiceChannel,
     )
-    from .client import Client
+    from .client import Client, AutoShardedClient
     from .guild import Guild
     from .message import AllowedMentions
     from .state import ConnectionState
@@ -75,7 +75,8 @@ if TYPE_CHECKING:
     InteractionChannel = Union[
         VoiceChannel, StageChannel, TextChannel, CategoryChannel, Thread, PartialMessageable
     ]
-    C = TypeVar("C", bound=Client)
+
+C = TypeVar("C", bound="Union[Client, AutoShardedClient]")
 
 MISSING: Any = utils.MISSING
 

--- a/nextcord/interactions.py
+++ b/nextcord/interactions.py
@@ -28,7 +28,7 @@ from __future__ import annotations
 
 import asyncio
 from datetime import datetime, timedelta
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Union, TypeVar
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, TypeVar, Union
 
 from . import utils
 from .channel import ChannelType, PartialMessageable
@@ -63,7 +63,7 @@ if TYPE_CHECKING:
         TextChannel,
         VoiceChannel,
     )
-    from .client import Client, AutoShardedClient
+    from .client import AutoShardedClient, Client
     from .guild import Guild
     from .message import AllowedMentions
     from .state import ConnectionState

--- a/nextcord/interactions.py
+++ b/nextcord/interactions.py
@@ -28,7 +28,7 @@ from __future__ import annotations
 
 import asyncio
 from datetime import datetime, timedelta
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Union, Typevar
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Union, TypeVar
 
 from . import utils
 from .channel import ChannelType, PartialMessageable


### PR DESCRIPTION
## Summary

<!-- What is this pull request for? Does it fix any issues? -->

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
  - [ ] I have updated the documentation to reflect the changes.
  - [ ] I have run `task pyright` and fixed the relevant issues.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
