### PR TITLE
feat(interactions): make Interaction generic on Client

### DIFF
--- a/nextcord/application_command.py
+++ b/nextcord/application_command.py
@@ -766,7 +766,7 @@ class CallbackMixin:
         # Global checks
         for check in interaction.client._connection._application_command_checks:
             try:
-                check_result = await maybe_coroutine(check, interaction)  # type: ignore
+                check_result = await maybe_coroutine(check, interaction)
             # To catch any subclasses of ApplicationCheckFailure.
             except ApplicationCheckFailure:
                 raise

--- a/nextcord/ext/application_checks/core.py
+++ b/nextcord/ext/application_checks/core.py
@@ -674,7 +674,7 @@ def is_owner() -> AC:
         if not hasattr(interaction.client, "is_owner"):
             raise ApplicationCheckForBotOnly()
 
-        if not await interaction.client.is_owner(interaction.user):  # type: ignore[handled above]
+        if not await interaction.client.is_owner(interaction.user):
             raise ApplicationNotOwner("You do not own this bot.")
         return True
 

--- a/nextcord/interactions.py
+++ b/nextcord/interactions.py
@@ -28,7 +28,7 @@ from __future__ import annotations
 
 import asyncio
 from datetime import datetime, timedelta
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Union
+from typing import TYPE_CHECKING, Any, Dict, Generic, List, Optional, Tuple, TypeVar, Union
 
 from . import utils
 from .channel import ChannelType, PartialMessageable
@@ -85,6 +85,8 @@ if TYPE_CHECKING:
 
 MISSING: Any = utils.MISSING
 
+ClientT = TypeVar("ClientT", bound=Client)
+
 
 class InteractionAttached(dict):
     """Represents the attached data of an interaction.
@@ -118,7 +120,7 @@ class InteractionAttached(dict):
         return f"<InteractionAttached {super().__repr__()}>"
 
 
-class Interaction(Hashable):
+class Interaction(Hashable, Generic[ClientT]):
     """Represents a Discord interaction.
 
     An interaction happens when a user does an action that needs to
@@ -256,9 +258,9 @@ class Interaction(Hashable):
                 pass
 
     @property
-    def client(self) -> Client:
+    def client(self) -> ClientT:
         """:class:`Client`: The client that handled the interaction."""
-        return self._state._get_client()
+        return self._state._get_client()  # type: ignore
 
     @property
     def guild(self) -> Optional[Guild]:

--- a/nextcord/interactions.py
+++ b/nextcord/interactions.py
@@ -85,7 +85,7 @@ if TYPE_CHECKING:
 
 MISSING: Any = utils.MISSING
 
-ClientT = TypeVar("ClientT", bound=Client)
+ClientT = TypeVar("ClientT", bound="Client")
 
 
 class InteractionAttached(dict):


### PR DESCRIPTION
## Summary

Allows specifying a subclass of `Client` in the `Interaction` type annotation (for example, `Interaction[commands.Bot]`).

This is similar to `commands.Context` which already supports this functionality.

### Current

Here is the behavior using the current code *without* this change:

```py
@bot.slash_command()
async def test1(interaction: Interaction, command: str):
    bot = interaction.client
    cmd = bot.get_command(command)  # ✘ This raises a type warning since Client.get_command is unknown
    await interaction.send(f"{command} {'is' if cmd else 'is not'} a valid prefix command")

@bot.slash_command()
async def test2(interaction: Interaction, command: str):
    bot: commands.Bot = interaction.client  # ✘ This raises a type warning since Client is incompatible with Bot
    cmd = bot.get_command(command)
    await interaction.send(f"{command} {'is' if cmd else 'is not'} a valid prefix command")
```

### New code

Using the changes in this PR, the following options will work without any warnings:

```py
@bot.slash_command()
async def test1(interaction: Interaction[commands.Bot], command: str):
    bot = interaction.client
    cmd = bot.get_command(command)  # ✓ interaction.client is known to be of type Bot because of the type annotation
    await interaction.send(f"{command} {'is' if cmd else 'is not'} a valid prefix command")

@bot.slash_command()
async def test2(interaction: Interaction, command: str):
    bot: commands.Bot = interaction.client  # ✓ interaction.client is Unknown type so can be annotated with Bot
    cmd = bot.get_command(command)
    await interaction.send(f"{command} {'is' if cmd else 'is not'} a valid prefix command")
```

This is not a breaking change since interaction can still be annotated without the client type, they just won't be taking advantage of the potential type information.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
  - [x] I have updated the documentation to reflect the changes.
  - [x] I have run `task pyright` and fixed the relevant issues.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
