### PR TITLE
feat: support resume_gateway_url for resuming

### DIFF
--- a/nextcord/client.py
+++ b/nextcord/client.py
@@ -691,7 +691,7 @@ class Client:
         }
         while not self.is_closed():
             try:
-                coro = DiscordWebSocket.from_client(self, **ws_params)
+                coro = DiscordWebSocket.from_client(self, format_gateway=True, **ws_params)
                 self.ws = await asyncio.wait_for(coro, timeout=60.0)
                 ws_params["initial"] = False
                 while True:
@@ -699,9 +699,23 @@ class Client:
             except ReconnectWebSocket as e:
                 _log.info("Got a request to %s the websocket.", e.op)
                 self.dispatch("disconnect")
-                ws_params.update(
-                    sequence=self.ws.sequence, resume=e.resume, session=self.ws.session_id
-                )
+
+                # Only specify new gateway if resuming, otherwise use the default one
+                if e.resume:
+                    ws_params.update(
+                        sequence=self.ws.sequence,
+                        gateway=self.ws.resume_url,
+                        resume=True,
+                        session=self.ws.session_id,
+                    )
+                else:
+                    ws_params.update(
+                        sequence=None,
+                        gateway=None,
+                        resume=False,
+                        session=None,
+                    )
+
                 continue
             except (
                 OSError,
@@ -727,6 +741,7 @@ class Client:
                 if isinstance(exc, OSError) and exc.errno in (54, 10054):
                     ws_params.update(
                         sequence=self.ws.sequence,
+                        gateway=self.ws.resume_url,
                         initial=False,
                         resume=True,
                         session=self.ws.session_id,
@@ -750,7 +765,13 @@ class Client:
                 # Always try to RESUME the connection
                 # If the connection is not RESUME-able then the gateway will invalidate the session.
                 # This is apparently what the official Discord client does.
-                ws_params.update(sequence=self.ws.sequence, resume=True, session=self.ws.session_id)
+                ws_params.update(
+                    sequence=self.ws.sequence,
+                    gateway=self.ws.resume_url,
+                    initial=False,
+                    resume=True,
+                    session=self.ws.session_id,
+                )
 
     async def close(self) -> None:
         """|coro|

--- a/nextcord/gateway.py
+++ b/nextcord/gateway.py
@@ -544,7 +544,7 @@ class DiscordWebSocket:
             # pass back shard ID to ready handler
             data["__shard_id__"] = self.shard_id
             _log.info(
-                "Shard ID %s has connected to Gateway: %s (Session ID: %s). Reconnect specified as %s",
+                "Shard ID %s has connected to Gateway: %s (Session ID: %s). Resume URL specified as %s",
                 self.shard_id,
                 ", ".join(trace),
                 self.session_id,

--- a/nextcord/http.py
+++ b/nextcord/http.py
@@ -2363,7 +2363,9 @@ class HTTPClient:
 
         return self.format_websocket_url(data["url"], encoding, zlib)
 
-    async def get_bot_gateway(self, *, encoding: str = "json", zlib: bool = True) -> Tuple[int, str]:
+    async def get_bot_gateway(
+        self, *, encoding: str = "json", zlib: bool = True
+    ) -> Tuple[int, str]:
         try:
             data = await self.request(Route("GET", "/gateway/bot"))
         except HTTPException as exc:


### PR DESCRIPTION
## Summary

Resolves #762 

Implements new gateway resume flow by using the `resume_gateway_url` from the `READY` event

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
  - [ ] I have updated the documentation to reflect the changes.
  - [x] I have run `task pyright` and fixed the relevant issues.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [x] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
