### PR TITLE
docs(api): move float near to other python types

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -4710,6 +4710,9 @@ Slash Options
     * - :class:`int`
       - Integer
       - Any integer between -2^53 and 2^53
+    * - :class:`float`
+      - Number
+      - Any double between -2^53 and 2^53
     * - :class:`bool`
       - Boolean
       -
@@ -4752,9 +4755,6 @@ Slash Options
     * - :class:`Mentionable`
       - Mentionable
       - Includes Users and Roles.
-    * - :class:`float`
-      - Number
-      - Any double between -2^53 and 2^53
     * - :class:`Attachment`
       - Attachment
       -


### PR DESCRIPTION
## Summary

The `float` slash option is not with the other standard types, I though this should be fixed.
Issue found by EpicEmre3133#9943

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
  - [ ] I have updated the documentation to reflect the changes.
  - [ ] I have run `task pyright` and fixed the relevant issues.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
