### PR TITLE
Remove Select Menu From Modal in example

### DIFF
--- a/examples/modals/modal.py
+++ b/examples/modals/modal.py
@@ -27,23 +27,9 @@ class Pet(nextcord.ui.Modal):
         )
         self.add_item(self.description)
 
-        self.pet_type = nextcord.ui.Select(
-            options=[
-                nextcord.SelectOption(label="Dog", emoji="🐶"),
-                nextcord.SelectOption(label="Cat", emoji="🐱"),
-                nextcord.SelectOption(label="Bird", emoji="🐦"),
-                nextcord.SelectOption(label="Fish", emoji="🐟"),
-                nextcord.SelectOption(label="Other", emoji="🐰"),
-            ],
-            min_values=1,
-            max_values=1,
-            placeholder="Type of pet",
-        )
-        self.add_item(self.pet_type)
 
     async def callback(self, interaction: nextcord.Interaction) -> None:
         response = f"{interaction.user.mention}'s favourite pet's name is {self.name.value}."
-        response += f"\nThe type of pet is {self.pet_type.values[0]}."
         if self.description.value != "":
             response += (
                 f"\nTheir pet can be recognized by this information:\n{self.description.value}"


### PR DESCRIPTION
Discord recently dropped support for select drop-downs in modals :(

## Summary

<!-- What is this pull request for? Does it fix any issues? -->
Removes the nextcord.ui.Select from within the example Modal as it is now unsupported by Discord.
If you try to run this example it throws an error similar to - `In data.components.2.components.0: Value of field "type" must be one of (4,).`
## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
  - [ ] I have updated the documentation to reflect the changes.
  - [ ] I have run `task pyright` and fixed the relevant issues.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...) - It's an example
