### PR TITLE
docs(examples): Add select example in modal

### DIFF
--- a/examples/modals/modal.py
+++ b/examples/modals/modal.py
@@ -27,8 +27,23 @@ class Pet(nextcord.ui.Modal):
         )
         self.add_item(self.description)
 
+        self.pet_type = nextcord.ui.Select(
+            options=[
+                nextcord.SelectOption(label="Dog", emoji="🐶"),
+                nextcord.SelectOption(label="Cat", emoji="🐱"),
+                nextcord.SelectOption(label="Bird", emoji="🐦"),
+                nextcord.SelectOption(label="Fish", emoji="🐟"),
+                nextcord.SelectOption(label="Other", emoji="🐰"),
+            ],
+            min_values=1,
+            max_values=1,
+            placeholder="Type of pet",
+        )
+        self.add_item(self.pet_type)
+
     async def callback(self, interaction: nextcord.Interaction) -> None:
         response = f"{interaction.user.mention}'s favourite pet's name is {self.name.value}."
+        response += f"\nThe type of pet is {self.pet_type.values[0]}."
         if self.description.value != "":
             response += (
                 f"\nTheir pet can be recognized by this information:\n{self.description.value}"


### PR DESCRIPTION
## Summary

* Adds an example of a select menu in a modal.

* This reverts #780 and adds back the example from #692.

> [!WARNING]
> **As of now, select menus in modals are disabled on all clients and the code in this PR will probably not work**

> [!WARNING]
> **This should wait for Discord to announce select menus in modals are ready for production before merging**

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
  - [x] I have updated the documentation to reflect the changes.
  - [x] I have run `task pyright` and fixed the relevant issues.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)