### PR TITLE
fix(app-cmds): stop syncing on no options/channel type sorting

### DIFF
--- a/nextcord/application_command.py
+++ b/nextcord/application_command.py
@@ -2597,8 +2597,9 @@ class SlashApplicationCommand(SlashCommandMixin, BaseApplicationCommand, Autocom
         ret = super().get_payload(guild_id)
         if self.children:
             ret["options"] = [child.payload for child in self.children.values()]
-        else:
+        elif self.options:
             ret["options"] = [parameter.payload for parameter in self.options.values()]
+
         return ret
 
     async def call(self, state: ConnectionState, interaction: Interaction) -> None:

--- a/nextcord/application_command.py
+++ b/nextcord/application_command.py
@@ -367,6 +367,8 @@ class ApplicationCommandOption:
         if self.channel_types:
             # noinspection PyUnresolvedReferences
             ret["channel_types"] = [channel_type.value for channel_type in self.channel_types]
+            ret["channel_types"].sort()  # When reading application commands from Discord, they return the channel types
+            #  sorted. To prevent needless syncing and allow lazy loading, we need to sort them as well.
 
         if self.min_value is not None:
             ret["min_value"] = self.min_value

--- a/nextcord/application_command.py
+++ b/nextcord/application_command.py
@@ -366,11 +366,9 @@ class ApplicationCommandOption:
 
         if self.channel_types:
             # noinspection PyUnresolvedReferences
-            ret["channel_types"] = [channel_type.value for channel_type in self.channel_types]
-            ret[
-                "channel_types"
-            ].sort()  # When reading application commands from Discord, they return the channel types
-            #  sorted. To prevent needless syncing and allow lazy loading, we need to sort them as well.
+            # When reading application commands from Discord, they return the channel types sorted.
+            # To prevent needless syncing and allow lazy loading, we need to sort them as well.
+            ret["channel_types"] = sorted([channel_type.value for channel_type in self.channel_types])
 
         if self.min_value is not None:
             ret["min_value"] = self.min_value

--- a/nextcord/application_command.py
+++ b/nextcord/application_command.py
@@ -368,7 +368,9 @@ class ApplicationCommandOption:
             # noinspection PyUnresolvedReferences
             # When reading application commands from Discord, they return the channel types sorted.
             # To prevent needless syncing and allow lazy loading, we need to sort them as well.
-            ret["channel_types"] = sorted([channel_type.value for channel_type in self.channel_types])
+            ret["channel_types"] = sorted(
+                [channel_type.value for channel_type in self.channel_types]
+            )
 
         if self.min_value is not None:
             ret["min_value"] = self.min_value

--- a/nextcord/application_command.py
+++ b/nextcord/application_command.py
@@ -367,7 +367,9 @@ class ApplicationCommandOption:
         if self.channel_types:
             # noinspection PyUnresolvedReferences
             ret["channel_types"] = [channel_type.value for channel_type in self.channel_types]
-            ret["channel_types"].sort()  # When reading application commands from Discord, they return the channel types
+            ret[
+                "channel_types"
+            ].sort()  # When reading application commands from Discord, they return the channel types
             #  sorted. To prevent needless syncing and allow lazy loading, we need to sort them as well.
 
         if self.min_value is not None:


### PR DESCRIPTION
## Summary

<!-- What is this pull request for? Does it fix any issues? -->
Does the following:
* Stops the slash command payload from always setting "options", even when they have no options or children.
  * This fixes possible needless resyncing of option-less commands.
  * This fixes lazy loading of option-less commands.
* Sorts the command option payload "channel_types" list due to Discord sending them back sorted.
  * This fixes needless resyncing of commands with an option that has channel_types set out of order.
  * This fixes lazy loading of ^

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [X] If code changes were made then they have been tested.
  - [ ] I have updated the documentation to reflect the changes.
  - [ ] I have run `task pyright` and fixed the relevant issues.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
