### PR TITLE
feat(app-cmds): add get_mention to Slash Commands

### DIFF
--- a/nextcord/application_command.py
+++ b/nextcord/application_command.py
@@ -1751,7 +1751,7 @@ class SlashCommandMixin(CallbackMixin):
                 raise ValueError(
                     "The command is not registered in the guild provided to get_mention."
                 )
-        return f"</{self.qualified_name}:{command_id}>" if command_id else f"/{self.qualified_name}"
+        return f"</{self.qualified_name}:{command_id}>"
 
 
 class BaseApplicationCommand(CallbackMixin, CallbackWrapperMixin):

--- a/nextcord/application_command.py
+++ b/nextcord/application_command.py
@@ -2688,6 +2688,8 @@ class SlashApplicationCommand(SlashCommandMixin, BaseApplicationCommand, Autocom
     def get_mention(self, guild: Optional[Snowflake] = None) -> str:
         """Returns a string that allows you to mention the application command.
 
+        .. versionadded:: 2.2
+
         Parameters
         ----------
         guild: Optional[:class:`~abc.Snowflake`]

--- a/nextcord/application_command.py
+++ b/nextcord/application_command.py
@@ -1626,9 +1626,10 @@ class SlashCommandOption(BaseCommandOption, SlashOption, AutocompleteOptionMixin
 
 
 class SlashCommandMixin(CallbackMixin):
-    _description: Optional[str]
-    command_ids: Dict[Optional[int], int]
-    qualified_name: str
+    if TYPE_CHECKING:
+        _description: Optional[str]
+        command_ids: Dict[Optional[int], int]
+        qualified_name: str
 
     def __init__(self, callback: Optional[Callable], parent_cog: Optional[ClientCog]):
         CallbackMixin.__init__(self, callback=callback, parent_cog=parent_cog)

--- a/nextcord/application_command.py
+++ b/nextcord/application_command.py
@@ -1627,6 +1627,8 @@ class SlashCommandOption(BaseCommandOption, SlashOption, AutocompleteOptionMixin
 
 class SlashCommandMixin(CallbackMixin):
     _description: Optional[str]
+    command_ids: Dict[Optional[int], int]
+    qualified_name: str
 
     def __init__(self, callback: Optional[Callable], parent_cog: Optional[ClientCog]):
         CallbackMixin.__init__(self, callback=callback, parent_cog=parent_cog)
@@ -1717,7 +1719,9 @@ class SlashCommandMixin(CallbackMixin):
             await self.invoke_callback_with_hooks(state, interaction, **kwargs)
 
     def get_mention(self, guild: Optional[Snowflake] = None) -> str:
-        """Returns a string that allows you to mention the slash command.
+        """Returns a string that allows you to mention the slash command. If no command ID is found for the
+        :class:`Guild` provided, or a guild is passed but the command is global, a text representation of the
+        command name is returned instead.
 
         .. versionadded:: 2.2
 
@@ -1731,8 +1735,8 @@ class SlashCommandMixin(CallbackMixin):
         :class:`str`
             The string that allows you to mention the slash command.
         """
-        command_id = self.command_ids.get(guild.id if guild else None)  # type: ignore
-        return f"</{self.qualified_name}:{command_id}>"  # type: ignore
+        command_id = self.command_ids.get(guild.id if guild else None)
+        return f"</{self.qualified_name}:{command_id}>" if command_id else f"/{self.qualified_name}"
 
 
 class BaseApplicationCommand(CallbackMixin, CallbackWrapperMixin):
@@ -2542,8 +2546,10 @@ class SlashApplicationSubcommand(SlashCommandMixin, AutocompleteCommandMixin, Ca
 
     @property
     def command_ids(self) -> Dict[Optional[int], int]:
-        """Dict[Optional[:class:`int`], :class:`int`]: Command IDs that this application command currently has.
+        """Dict[Optional[:class:`int`], :class:`int`]: Command IDs the parent command of this subcommand currently has.
         Schema: {Guild ID (None for global): command ID}
+
+        .. versionadded:: 2.2
         """
         return self.parent_cmd.command_ids if self.parent_cmd else {}
 

--- a/nextcord/application_command.py
+++ b/nextcord/application_command.py
@@ -1719,9 +1719,7 @@ class SlashCommandMixin(CallbackMixin):
             await self.invoke_callback_with_hooks(state, interaction, **kwargs)
 
     def get_mention(self, guild: Optional[Snowflake] = None) -> str:
-        """Returns a string that allows you to mention the slash command. If no command ID is found for the
-        :class:`Guild` provided, or a guild is passed but the command is global, a text representation of the
-        command name is returned instead.
+        """Returns a string that allows you to mention the slash command.
 
         .. versionadded:: 2.2
 
@@ -1734,8 +1732,25 @@ class SlashCommandMixin(CallbackMixin):
         -------
         :class:`str`
             The string that allows you to mention the slash command.
+
+        Raises
+        ------
+        ValueError
+            If no guild was provided and the command is not registered globally, or the command is not registered
+            in the guild provided.
         """
         command_id = self.command_ids.get(guild.id if guild else None)
+        if command_id is None:
+            if None in self.command_ids:
+                command_id = self.command_ids[None]
+            elif guild is None:
+                raise ValueError(
+                    "No guild was passed to get_mention, but the command is not global."
+                )
+            else:
+                raise ValueError(
+                    "The command is not registered in the guild provided to get_mention."
+                )
         return f"</{self.qualified_name}:{command_id}>" if command_id else f"/{self.qualified_name}"
 
 

--- a/nextcord/application_command.py
+++ b/nextcord/application_command.py
@@ -2523,7 +2523,7 @@ class SlashApplicationSubcommand(SlashCommandMixin, AutocompleteCommandMixin, Ca
         return decorator
 
     def get_mention(self, guild: Optional[Snowflake] = None) -> str:
-        """Returns a string that allows you to mention the application command.
+        """Returns a string that allows you to mention the slash subcommand.
 
         .. versionadded:: 2.2
 
@@ -2535,7 +2535,7 @@ class SlashApplicationSubcommand(SlashCommandMixin, AutocompleteCommandMixin, Ca
         Returns
         -------
         :class:`str`
-            The string that allows you to mention the application command.
+            The string that allows you to mention the slash subcommand.
         """
         parent_cmd = self.parent_cmd
         while not isinstance(parent_cmd, SlashApplicationCommand):
@@ -2709,7 +2709,7 @@ class SlashApplicationCommand(SlashCommandMixin, BaseApplicationCommand, Autocom
         return decorator
 
     def get_mention(self, guild: Optional[Snowflake] = None) -> str:
-        """Returns a string that allows you to mention the application command.
+        """Returns a string that allows you to mention the slash command.
 
         .. versionadded:: 2.2
 
@@ -2721,7 +2721,7 @@ class SlashApplicationCommand(SlashCommandMixin, BaseApplicationCommand, Autocom
         Returns
         -------
         :class:`str`
-            The string that allows you to mention the application command.
+            The string that allows you to mention the slash command.
         """
         command_id = self.command_ids.get(guild.id if guild else None)
         return f"</{self.qualified_name}:{command_id}>"

--- a/nextcord/application_command.py
+++ b/nextcord/application_command.py
@@ -81,6 +81,7 @@ from .user import User
 from .utils import MISSING, find, maybe_coroutine, parse_docstring
 
 if TYPE_CHECKING:
+    from .abc import Snowflake
     from .state import ConnectionState
     from .types.checks import ApplicationCheck, ApplicationErrorCallback, ApplicationHook
     from .types.interactions import ApplicationCommand as ApplicationCommandPayload
@@ -2683,6 +2684,22 @@ class SlashApplicationCommand(SlashCommandMixin, BaseApplicationCommand, Autocom
             return ret
 
         return decorator
+
+    def get_mention(self, guild: Optional[Snowflake] = None) -> str:
+        """Returns a string that allows you to mention the application command.
+
+        Parameters
+        ----------
+        guild: Optional[:class:`~abc.Snowflake`]
+            The :class:`Guild` of the command to mention. If ``None``, then the global command will be mentioned.
+
+        Returns
+        -------
+        :class:`str`
+            The string that allows you to mention the application command.
+        """
+        command_id = self.command_ids.get(guild.id if guild else None)
+        return f"</{self.qualified_name}:{command_id}>"
 
 
 class UserApplicationCommand(BaseApplicationCommand):

--- a/nextcord/application_command.py
+++ b/nextcord/application_command.py
@@ -2538,12 +2538,10 @@ class SlashApplicationSubcommand(SlashCommandMixin, AutocompleteCommandMixin, Ca
             The string that allows you to mention the application command.
         """
         parent_cmd = self.parent_cmd
-        while not hasattr(parent_cmd, "command_ids"):
-            if not hasattr(parent_cmd, "parent_cmd"):
-                break
-            parent_cmd = parent_cmd.parent_cmd  # type: ignore
-        if not isinstance(parent_cmd, SlashApplicationCommand):
-            return ""
+        while not isinstance(parent_cmd, SlashApplicationCommand):
+            if parent_cmd is None:
+                return ""
+            parent_cmd = parent_cmd.parent_cmd
         command_id = parent_cmd.command_ids.get(guild.id if guild else None)
         return f"</{self.qualified_name}:{command_id}>"
 

--- a/nextcord/application_command.py
+++ b/nextcord/application_command.py
@@ -2522,6 +2522,31 @@ class SlashApplicationSubcommand(SlashCommandMixin, AutocompleteCommandMixin, Ca
         self.type = ApplicationCommandOptionType.sub_command_group
         return decorator
 
+    def get_mention(self, guild: Optional[Snowflake] = None) -> str:
+        """Returns a string that allows you to mention the application command.
+
+        .. versionadded:: 2.2
+
+        Parameters
+        ----------
+        guild: Optional[:class:`~abc.Snowflake`]
+            The :class:`Guild` of the command to mention. If ``None``, then the global command will be mentioned.
+
+        Returns
+        -------
+        :class:`str`
+            The string that allows you to mention the application command.
+        """
+        parent_cmd = self.parent_cmd
+        while not hasattr(parent_cmd, "command_ids"):
+            if not hasattr(parent_cmd, "parent_cmd"):
+                break
+            parent_cmd = parent_cmd.parent_cmd  # type: ignore
+        if not isinstance(parent_cmd, SlashApplicationCommand):
+            return ""
+        command_id = parent_cmd.command_ids.get(guild.id if guild else None)
+        return f"</{self.qualified_name}:{command_id}>"
+
 
 class SlashApplicationCommand(SlashCommandMixin, BaseApplicationCommand, AutocompleteCommandMixin):
     def __init__(


### PR DESCRIPTION
## Summary

Adds `SlashApplicationCommand.get_mention` and `SlashApplicationSubcommand.get_mention` for getting the string that allows you to mention the application command.

Note: This is not a property since commands can have multiple IDs if they are in multiple guilds. The naming `get_mention()` is used instead of `mention` to make this distinction.

This also adds `SlashApplicationSubcommand.command_ids` (a shortcut to the parent command's IDs) in order to simplify the implementation making it so the same code can be used for `SlashApplicationCommand` and `SlashApplicationSubcommand`

Usage:

```py
@bot.slash_command()
async def cmd1(interaction: Interaction):
    await interaction.send(f"{interaction.application_command.get_mention()} {cmd1.get_mention()}")

@bot.slash_command(guild_ids=[TESTING_GUILD_ID])
async def cmd2(interaction: Interaction):
    guild = interaction.guild
    await interaction.send(f"{interaction.application_command.get_mention(guild)} {cmd2.get_mention(guild)}")

@bot.slash_command()
async def group(interaction: Interaction):
    ...

@group.subcommand()
async def sub1(interaction: Interaction):
    await interaction.send(
        f"{interaction.application_command.get_mention()} {sub1.get_mention()}"
    )

@group.subcommand()
async def sub2(interaction: Interaction):
    ...

@sub2.subcommand()
async def subsub1(interaction: Interaction):
    await interaction.send(
        f"{interaction.application_command.get_mention()} {subsub1.get_mention()}"
    )
```

![image](https://user-images.githubusercontent.com/20955511/186041891-c089aee6-c504-475b-a6af-07976c7c044b.png)

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
  - [x] I have updated the documentation to reflect the changes.
  - [x] I have run `task pyright` and fixed the relevant issues.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
