### PR TITLE
fix(app-cmds): delete_application_commands for guild commands

### DIFF
--- a/nextcord/client.py
+++ b/nextcord/client.py
@@ -2345,7 +2345,7 @@ class Client:
             from global commands instead. Defaults to `None`.
         """
         for command in commands:
-            await self._connection.delete_application_command(command, guild_id=None)
+            await self._connection.delete_application_command(command, guild_id=guild_id)
 
     def _get_global_commands(self) -> Set[BaseApplicationCommand]:
         ret = set()

--- a/nextcord/state.py
+++ b/nextcord/state.py
@@ -1100,8 +1100,13 @@ class ConnectionState:
             self._application_command_signatures.pop(command.get_signature(guild_id), None)
 
         except KeyError as e:
-            _log.error("Could not globally unregister command %s as it is not a global command.", command.error_name)
-            raise KeyError("This command cannot be globally unregistered, as it is not a global command.")
+            _log.error(
+                "Could not globally unregister command %s as it is not a global command.",
+                command.error_name,
+            )
+            raise KeyError(
+                "This command cannot be globally unregistered, as it is not a global command."
+            )
 
         except Exception as e:
             _log.error("Error unregistering command %s: %s", command.error_name, e)

--- a/nextcord/state.py
+++ b/nextcord/state.py
@@ -1099,14 +1099,25 @@ class ConnectionState:
             self._application_command_ids.pop(command.command_ids[guild_id], None)
             self._application_command_signatures.pop(command.get_signature(guild_id), None)
 
-        except KeyError as e:
-            _log.error(
-                "Could not globally unregister command %s as it is not a global command.",
-                command.error_name,
-            )
-            raise KeyError(
-                "This command cannot be globally unregistered, as it is not a global command."
-            )
+        except KeyError:
+            if guild_id:
+                _log.error(
+                    "Could not globally unregister command %s "
+                    "as it is not registered in the provided guild.",
+                    command.error_name,
+                )
+                raise KeyError(
+                    "This command cannot be globally unregistered, "
+                    "as it is not registered in the provided guild."
+                )
+            else:
+                _log.error(
+                    "Could not globally unregister command %s as it is not a global command.",
+                    command.error_name,
+                )
+                raise KeyError(
+                    "This command cannot be globally unregistered, as it is not a global command."
+                )
 
         except Exception as e:
             _log.error("Error unregistering command %s: %s", command.error_name, e)


### PR DESCRIPTION
## Summary

Fixed the issue regarding delete_application_commands where commands could not be deleted from one guild specifically.
This was caused by a hardcoded value of None for the guild_id being passed to delete_application_command. Additionally, 
logging messages and error messages were added for when a non-global command is attempted to be globally unregistered,
which simply caused a KeyError exception before.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
  - [ ] I have updated the documentation to reflect the changes.
  - [ ] I have run `task pyright` and fixed the relevant issues.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
