### PR TITLE
fix(message): initialization failing with threads and no intents

### DIFF
--- a/nextcord/message.py
+++ b/nextcord/message.py
@@ -836,7 +836,7 @@ class Message(Hashable):
                 self.guild = None
 
         if thread_data := data.get("thread"):
-            if not self.thread and self.guild:
+            if not self.thread and isinstance(self.guild, Guild):
                 self.guild._store_thread(thread_data)
 
         try:
@@ -1156,7 +1156,10 @@ class Message(Hashable):
     @property
     def thread(self) -> Optional[Thread]:
         """Optional[:class:`Thread`]: The thread started from this message. None if no thread was started."""
-        return self.guild and self.guild.get_thread(self.id)
+        if not isinstance(self.guild, Guild):
+            return None
+
+        return self.guild.get_thread(self.id)
 
     def is_system(self) -> bool:
         """:class:`bool`: Whether the message is a system message.


### PR DESCRIPTION
## Summary

Fixes message initialization failing with threads and no intents by explicitly checking we have a guild object where one is required.

Closes:
- #772 

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
  - [ ] I have updated the documentation to reflect the changes.
  - [x] I have run `task pyright` and fixed the relevant issues.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
