### PR TITLE
refactor(member): remove deprecated nickname mention syntax

### DIFF
--- a/nextcord/member.py
+++ b/nextcord/member.py
@@ -509,8 +509,6 @@ class Member(abc.Messageable, _UserTag):
     @property
     def mention(self) -> str:
         """:class:`str`: Returns a string that allows you to mention the member."""
-        if self.nick:
-            return f"<@!{self._user.id}>"
         return f"<@{self._user.id}>"
 
     @property

--- a/nextcord/member.py
+++ b/nextcord/member.py
@@ -508,7 +508,11 @@ class Member(abc.Messageable, _UserTag):
 
     @property
     def mention(self) -> str:
-        """:class:`str`: Returns a string that allows you to mention the member."""
+        """:class:`str`: Returns a string that allows you to mention the member.
+
+        .. versionchanged:: 2.2
+            The nickname mention syntax is no longer returned as it is deprecated by Discord.
+        """
         return f"<@{self._user.id}>"
 
     @property


### PR DESCRIPTION
## Summary

Reference: https://github.com/discord/discord-api-docs/commit/e3921e168aa167503ae193439abe70106b58d914

From my understanding, Discord wants users to no longer create mentions with this syntax, however they should still be parsed as user mentions for backward compatibility with older messages.

Currently, when typing a user mention (eg. `<@!310618854734954497>`) the Discord client converts it to `<@310618854734954497>` before sending.

Bots can still send nickname mentions which are treated the same as user mentions, but it seems that Discord is trying to get these types of mentions to stop appearing, so this PR changes `Member.mention` to no longer use the deprecated mention syntax.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
  - [x] I have updated the documentation to reflect the changes.
  - [x] I have run `task pyright` and fixed the relevant issues.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
