### PR TITLE
fix: Empty lists not sent in payload when files sent

### DIFF
--- a/nextcord/http.py
+++ b/nextcord/http.py
@@ -468,33 +468,32 @@ class HTTPClient:
         stickers: Optional[List[int]] = None,
         components: Optional[List[components.Component]] = None,
     ) -> Dict[str, Any]:
-        payload = {}
+        payload: Dict[str, Any] = {
+            "tts": tts,
+        }
 
-        if content:
+        if content is not None:
             payload["content"] = content
 
-        if tts:
-            payload["tts"] = True
-
-        if embed:
+        if embed is not None:
             payload["embeds"] = [embed]
 
-        if embeds:
+        if embeds is not None:
             payload["embeds"] = embeds
 
-        if nonce:
+        if nonce is not None:
             payload["nonce"] = nonce
 
-        if allowed_mentions:
+        if allowed_mentions is not None:
             payload["allowed_mentions"] = allowed_mentions
 
-        if message_reference:
+        if message_reference is not None:
             payload["message_reference"] = message_reference
 
-        if components:
+        if components is not None:
             payload["components"] = components
 
-        if stickers:
+        if stickers is not None:
             payload["sticker_ids"] = stickers
 
         return payload


### PR DESCRIPTION
## Summary

Fixes #795 

This should remove the components and embeds but since #608 it does not.

```py
@bot.command()
async def test(ctx):
    view = nextcord.ui.View()
    view.add_item(
        nextcord.ui.Button(label="Test", style=nextcord.ButtonStyle.link, url="https://google.com")
    )
    embed = nextcord.Embed(title="Test", description="Test")
    msg = await ctx.send("test", view=view, embeds=[embed])
    await msg.edit(
        "test - should have no buttons or embeds",
        view=None,
        embeds=[],
        file=await ctx.author.display_avatar.to_file(),
    )
```

Some of the refactoring done in #608 to reduce repetition of handling message parameters used code meant for sending for editing messages with files and these did not check for `is not None`, but rather for truthy values, meaning that empty lists do not get passed in payloads, so you could no longer remove all embeds, components, etc from a message when editing a message with files.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
  - [ ] I have updated the documentation to reflect the changes.
  - [x] I have run `task pyright` and fixed the relevant issues.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
