### PR TITLE
feat: add the ability to use custom interactions

### DIFF
--- a/examples/custom_interaction.py
+++ b/examples/custom_interaction.py
@@ -20,9 +20,8 @@ class Client(nextcord.Client):
         return super().get_interaction(data, cls=MyInteraction)
 
 
+client = Client()
 TESTING_GUILD_ID = 123456789  # Replace with your testing guild id
-intents = nextcord.Intents.default()
-client = Client(intents=intents)
 
 
 @client.slash_command(guild_ids=[TESTING_GUILD_ID])

--- a/examples/custom_interaction.py
+++ b/examples/custom_interaction.py
@@ -1,0 +1,33 @@
+import nextcord
+
+
+class MyInteraction(nextcord.Interaction):
+    async def send_embed(self, *, title: str, description: str):
+        """Easily send a basic embed."""
+        embed: nextcord.Embed = nextcord.Embed(
+            title=title,
+            description=description,
+        )
+        embed.set_author(name=self.user.display_name, icon_url=self.user.display_avatar)
+        await self.send(embed=embed)
+
+
+class Client(nextcord.Client):
+    def get_interaction(self, data, *, cls=nextcord.Interaction):
+        # when you override this method, you pass your new Interaction
+        # subclass to the super() method, which tells the bot to
+        # use the new MyInteraction class
+        return super().get_interaction(data, cls=MyInteraction)
+
+
+TESTING_GUILD_ID = 123456789  # Replace with your testing guild id
+intents = nextcord.Intents.default()
+client = Client(intents=intents)
+
+
+@client.slash_command(guild_ids=[TESTING_GUILD_ID])
+async def create_embed(interaction: MyInteraction, title: str, description: str):
+    await interaction.send_embed(title=title, description=description)
+
+
+client.run("token")

--- a/nextcord/client.py
+++ b/nextcord/client.py
@@ -49,6 +49,7 @@ from typing import (
     TypeVar,
     Union,
     cast,
+    overload,
 )
 
 import aiohttp
@@ -2654,6 +2655,18 @@ class Client:
 
         it = filter(None, map(self.get_user, utils.parse_raw_mentions(text)))
         return utils._unique(it)
+
+    @overload
+    def get_interaction(self, data) -> Interaction:
+        ...
+
+    @overload
+    def get_interaction(self, data, *, cls: Type[Interaction]) -> Interaction:
+        ...
+
+    @overload
+    def get_interaction(self, data, *, cls: Type[InterT]) -> InterT:
+        ...
 
     def get_interaction(
         self, data, *, cls: Type[InterT] = Interaction

--- a/nextcord/client.py
+++ b/nextcord/client.py
@@ -45,6 +45,7 @@ from typing import (
     Sequence,
     Set,
     Tuple,
+    Type,
     TypeVar,
     Union,
     cast,
@@ -109,6 +110,7 @@ if TYPE_CHECKING:
 __all__ = ("Client",)
 
 Coro = TypeVar("Coro", bound=Callable[..., Coroutine[Any, Any, Any]])
+InterT = TypeVar("InterT", bound="Interaction")
 
 
 _log = logging.getLogger(__name__)
@@ -2652,3 +2654,28 @@ class Client:
 
         it = filter(None, map(self.get_user, utils.parse_raw_mentions(text)))
         return utils._unique(it)
+
+    def get_interaction(
+        self, data, *, cls: Type[InterT] = Interaction
+    ) -> Union[Interaction, InterT]:
+        """Returns an interaction for a gateway event.
+
+        Parameters
+        ----------
+        data
+            The data direct from the gateway.
+        cls
+            The factory class that will be used to create the interaction.
+            By default, this is :py:class:`Interaction`. Should a custom
+            class be provided, it should be a subclass of :py:class:`Interaction`.
+
+        Returns
+        -------
+        Interaction
+            An instance :py:class:`Interaction` or the provided subclass.
+
+        Notes
+        -----
+        This is synchronous due to how slash commands are implemented.
+        """
+        return cls(data=data, state=self._connection)

--- a/nextcord/client.py
+++ b/nextcord/client.py
@@ -2687,8 +2687,8 @@ class Client:
         Interaction
             An instance :py:class:`Interaction` or the provided subclass.
 
-        Notes
-        -----
-        This is synchronous due to how slash commands are implemented.
+        .. note::
+
+            This is synchronous due to how slash commands are implemented.
         """
         return cls(data=data, state=self._connection)

--- a/nextcord/state.py
+++ b/nextcord/state.py
@@ -1367,7 +1367,7 @@ class ConnectionState:
                     self.dispatch("reaction_clear_emoji", reaction)
 
     def parse_interaction_create(self, data) -> None:
-        interaction = Interaction(data=data, state=self)
+        interaction = self._get_client().get_interaction(data=data)
         if data["type"] == 3:  # interaction component
             custom_id = interaction.data["custom_id"]  # type: ignore
             component_type = interaction.data["component_type"]  # type: ignore


### PR DESCRIPTION
## Summary

Adds the ability to provide a custom interaction class which the library will use.

Closes #757 


Note the return type of `get_interaction` varies from it's `get_context` counterpart as this was the only way I could find that would appease `task pyright`. If you are aware of an alternative where the return type can simply be `InterT` please let me know.

## Checklist

- [x] If code changes were made then they have been tested.
  - [x] I have updated the documentation to reflect the changes.
  - [x] I have run `task pyright` and fixed the relevant issues.
- [x] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)

## Test code

```python
import os

from nextcord import Interaction, Client

TESTING_GUILD_ID = 500525882226769931


class CustomInter(Interaction):
    @property
    def custom_prop(self) -> bool:
        return True


class CustomClient(Client):
    def get_interaction(self, data, *, cls=Interaction):
        return super().get_interaction(data, cls=CustomInter)


client = CustomClient()


@client.event
async def on_ready():
    print("...")


@client.slash_command(guild_ids=[TESTING_GUILD_ID])
async def test(interaction: CustomInter):
    await interaction.send(f"{isinstance(interaction, CustomInter)=}, {interaction.custom_prop}")


client.run(os.environ["TOKEN"])
```