### PR TITLE
fix(app-cmds): two application commands with the same signatures could be registered

### DIFF
--- a/nextcord/client.py
+++ b/nextcord/client.py
@@ -2072,7 +2072,11 @@ class Client:
         return self._connection.get_global_application_commands(rollout=rollout)
 
     def add_application_command(
-        self, command: BaseApplicationCommand, overwrite: bool = False, use_rollout: bool = False, pre_remove: bool = True
+        self,
+        command: BaseApplicationCommand,
+        overwrite: bool = False,
+        use_rollout: bool = False,
+        pre_remove: bool = True,
     ) -> None:
         """Adds a BaseApplicationCommand object to the client for use.
 

--- a/nextcord/client.py
+++ b/nextcord/client.py
@@ -2072,7 +2072,7 @@ class Client:
         return self._connection.get_global_application_commands(rollout=rollout)
 
     def add_application_command(
-        self, command: BaseApplicationCommand, overwrite: bool = False, use_rollout: bool = False
+        self, command: BaseApplicationCommand, overwrite: bool = False, use_rollout: bool = False, pre_remove: bool = True
     ) -> None:
         """Adds a BaseApplicationCommand object to the client for use.
 
@@ -2084,9 +2084,12 @@ class Client:
             If to overwrite any existing commands that would conflict with this one. Defaults to ``False``
         use_rollout: :class:`bool`
             If to apply the rollout signatures instead of existing ones. Defaults to ``False``
+        pre_remove: :class:`bool`
+            If the command should be removed before adding it. This will clear all signatures from storage, including
+            rollout ones.
         """
         self._connection.add_application_command(
-            command, overwrite=overwrite, use_rollout=use_rollout
+            command, overwrite=overwrite, use_rollout=use_rollout, pre_remove=pre_remove
         )
 
     async def sync_all_application_commands(
@@ -2452,14 +2455,14 @@ class Client:
         for command in self._application_commands_to_add:
             command.from_callback(command.callback)
 
-            self.add_application_command(command, use_rollout=True)
+            self.add_application_command(command, use_rollout=True, pre_remove=False)
 
     def add_all_cog_commands(self) -> None:
         """Adds all :class:`ApplicationCommand` objects inside added cogs to the application command list."""
         for cog in self._client_cogs:
             if to_register := cog.application_commands:
                 for cmd in to_register:
-                    self.add_application_command(cmd, use_rollout=True)
+                    self.add_application_command(cmd, use_rollout=True, pre_remove=False)
 
     def add_cog(self, cog: ClientCog) -> None:
         # cog.process_app_cmds()


### PR DESCRIPTION
## Summary

This PR fixes an issue where two application commands with the same signatures could be registered. What happens now is a `ValueError` exception is raised when two application commands with the same signatures are detected.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
  - [x] I have updated the documentation to reflect the changes.
  - [ ] I have run `task pyright` and fixed the relevant issues.
- [x] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
