### PR TITLE
fix(app-cmds): Slash Commands cannot have options with the name "state"

### DIFF
--- a/nextcord/application_command.py
+++ b/nextcord/application_command.py
@@ -835,7 +835,7 @@ class CallbackMixin:
         return True
 
     async def invoke_callback_with_hooks(
-        self, state: ConnectionState, interaction: Interaction, *args, **kwargs
+        self, state: ConnectionState, interaction: Interaction, args: List[Any] = [], kwargs: Dict[str, Any] = {}
     ) -> None:
         """|coro|
         Invokes the callback with all hooks and checks.
@@ -1730,7 +1730,7 @@ class SlashCommandMixin(CallbackMixin):
             )
         else:
             kwargs = await self.get_slash_kwargs(state, interaction, option_data)
-            await self.invoke_callback_with_hooks(state, interaction, **kwargs)
+            await self.invoke_callback_with_hooks(state, interaction, kwargs=kwargs)
 
     def get_mention(self, guild: Optional[Snowflake] = None) -> str:
         """Returns a string that allows you to mention the slash command.
@@ -2809,7 +2809,7 @@ class UserApplicationCommand(BaseApplicationCommand):
 
     async def call(self, state: ConnectionState, interaction: Interaction):
         await self.invoke_callback_with_hooks(
-            state, interaction, get_users_from_interaction(state, interaction)[0]
+            state, interaction, args=[get_users_from_interaction(state, interaction)[0]]
         )
 
     def from_callback(
@@ -2883,7 +2883,7 @@ class MessageApplicationCommand(BaseApplicationCommand):
 
     async def call(self, state: ConnectionState, interaction: Interaction):
         await self.invoke_callback_with_hooks(
-            state, interaction, get_messages_from_interaction(state, interaction)[0]
+            state, interaction, args=[get_messages_from_interaction(state, interaction)[0]]
         )
 
     def from_callback(


### PR DESCRIPTION
## Summary

This PR fixes an issue found in the Nextcord Discord server where a Slash Command cannot have an option with the name "state" without raising an exception.

Traceback (from original help thread): 
```
Ignoring exception in on_interaction
Traceback (most recent call last):
  File "/root/env/lib/python3.8/site-packages/nextcord/client.py", line 499, in _run_event
    await coro(*args, **kwargs)
  File "/root/env/lib/python3.8/site-packages/nextcord/client.py", line 1924, in on_interaction
    await self.process_application_commands(interaction)
  File "/root/env/lib/python3.8/site-packages/nextcord/client.py", line 1944, in process_application_commands
    await app_cmd.call_from_interaction(interaction)
  File "/root/env/lib/python3.8/site-packages/nextcord/application_command.py", line 2255, in call_from_interaction
    await self.call(self._state, interaction)  # type: ignore
  File "/root/env/lib/python3.8/site-packages/nextcord/application_command.py", line 2619, in call
    await self.call_slash(state, interaction, option_data)
  File "/root/env/lib/python3.8/site-packages/nextcord/application_command.py", line 1716, in call_slash
    await self.invoke_callback_with_hooks(state, interaction, **kwargs)
TypeError: invoke_callback_with_hooks() got multiple values for argument 'state'
```

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
  - [ ] I have updated the documentation to reflect the changes.
  - [ ] I have run `task pyright` and fixed the relevant issues.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [x] This PR is a breaking change (e.g. methods or parameters removed/renamed) (technically more of an internal breaking change)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
