### PR TITLE
Update reaction.users docs

### DIFF
--- a/nextcord/reaction.py
+++ b/nextcord/reaction.py
@@ -205,10 +205,8 @@ class Reaction:
         Yields
         --------
         Union[:class:`User`, :class:`Member`]
-            The member (if retrievable) or the user that has reacted
-            to this message. The case where it can be a :class:`Member` is
-            in a guild message context. Sometimes it can be a :class:`User`
-            if the member has left the guild.
+            Bot reactions will return a :class:`Member`, while user reactions will return a :class:`User`.
+            All reactions will be a :class:`User`, if the member has left.
         """
 
         if not isinstance(self.emoji, str):


### PR DESCRIPTION
## Summary

Update docs to reflect changes in API:
I recently ran into errors due to a change in the Discord API: reaction.users will not return a User object for left members anymore but for all members that reacted.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
  - [x] I have updated the documentation to reflect the changes.
  - [ ] I have run `task pyright` and fixed the relevant issues.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
