### PR TITLE
docs: fix trailing headers

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -1,7 +1,7 @@
 .. currentmodule:: nextcord
 
 API Reference
-==============
+=============
 
 The following section outlines the API of nextcord.
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -1,7 +1,7 @@
 .. currentmodule:: nextcord
 
 API Reference
-===============
+==============
 
 The following section outlines the API of nextcord.
 
@@ -14,7 +14,7 @@ The following section outlines the API of nextcord.
     nextcord.
 
 Version Related Info
----------------------
+--------------------
 
 There are two main ways to query version information about the library. For guarantees, check :ref:`version_guarantees`.
 
@@ -31,10 +31,10 @@ There are two main ways to query version information about the library. For guar
     off of :pep:`440`.
 
 Clients
---------
+-------
 
 Client
-~~~~~~~
+~~~~~~
 
 .. attributetable:: Client
 
@@ -58,7 +58,7 @@ Client
         :async-for:
 
 AutoShardedClient
-~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~
 
 .. attributetable:: AutoShardedClient
 
@@ -66,10 +66,10 @@ AutoShardedClient
     :members:
 
 Application Info
-------------------
+----------------
 
 AppInfo
-~~~~~~~~
+~~~~~~~
 
 .. attributetable:: AppInfo
 
@@ -77,7 +77,7 @@ AppInfo
     :members:
 
 PartialAppInfo
-~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~
 
 .. attributetable:: PartialAppInfo
 
@@ -85,7 +85,7 @@ PartialAppInfo
     :members:
 
 Team
-~~~~~
+~~~~
 
 .. attributetable:: Team
 
@@ -93,7 +93,7 @@ Team
     :members:
 
 TeamMember
-~~~~~~~~~~~
+~~~~~~~~~~
 
 .. attributetable:: TeamMember
 
@@ -101,10 +101,10 @@ TeamMember
     :members:
 
 Voice Related
----------------
+-------------
 
 VoiceClient
-~~~~~~~~~~~~
+~~~~~~~~~~~
 
 .. attributetable:: VoiceClient
 
@@ -113,7 +113,7 @@ VoiceClient
     :exclude-members: connect, on_voice_state_update, on_voice_server_update
 
 VoiceProtocol
-~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~
 
 .. attributetable:: VoiceProtocol
 
@@ -121,7 +121,7 @@ VoiceProtocol
     :members:
 
 AudioSource
-~~~~~~~~~~~~
+~~~~~~~~~~~
 
 .. attributetable:: AudioSource
 
@@ -129,7 +129,7 @@ AudioSource
     :members:
 
 PCMAudio
-~~~~~~~~~
+~~~~~~~~
 
 .. attributetable:: PCMAudio
 
@@ -137,7 +137,7 @@ PCMAudio
     :members:
 
 FFmpegAudio
-~~~~~~~~~~~~
+~~~~~~~~~~~
 
 .. attributetable:: FFmpegAudio
 
@@ -145,7 +145,7 @@ FFmpegAudio
     :members:
 
 FFmpegPCMAudio
-~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~
 
 .. attributetable:: FFmpegPCMAudio
 
@@ -153,7 +153,7 @@ FFmpegPCMAudio
     :members:
 
 FFmpegOpusAudio
-~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~
 
 .. attributetable:: FFmpegOpusAudio
 
@@ -161,7 +161,7 @@ FFmpegOpusAudio
     :members:
 
 PCMVolumeTransformer
-~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~
 
 .. attributetable:: PCMVolumeTransformer
 
@@ -169,7 +169,7 @@ PCMVolumeTransformer
     :members:
 
 Opus Library
-~~~~~~~~~~~~~
+~~~~~~~~~~~~
 
 .. autofunction:: nextcord.opus.load_opus
 
@@ -1242,7 +1242,7 @@ Utility Functions
 .. _discord-api-enums:
 
 Enumerations
--------------
+------------
 
 The API provides some enumerations for certain types of strings to avoid the API
 from being stringly typed in case the strings change in the future.
@@ -2951,7 +2951,7 @@ of :class:`enum.Enum`.
 
 
 Async Iterator
-----------------
+--------------
 
 Some API functions return an "async iterator". An async iterator is something that is
 capable of being used in an :ref:`async for statement <py:async for>`.
@@ -3082,14 +3082,14 @@ Certain utilities make working with async iterators easier, detailed below.
 .. _discord-api-audit-logs:
 
 Audit Log Data
-----------------
+--------------
 
 Working with :meth:`Guild.audit_logs` is a complicated process with a lot of machinery
 involved. The library attempts to make it easy to use and friendly. To accomplish
 this goal, it must make use of a couple of data classes that aid in this goal.
 
 AuditLogEntry
-~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~
 
 .. attributetable:: AuditLogEntry
 
@@ -3097,7 +3097,7 @@ AuditLogEntry
     :members:
 
 AuditLogChanges
-~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~
 
 .. attributetable:: AuditLogChanges
 
@@ -3146,7 +3146,7 @@ AuditLogChanges
         +----------------------------------------+--------------------------------------------------+
 
 AuditLogDiff
-~~~~~~~~~~~~~
+~~~~~~~~~~~~
 
 .. attributetable:: AuditLogDiff
 
@@ -3648,12 +3648,12 @@ AuditLogDiff
    I'm not sure how to about porting these
 
 Webhook Support
-------------------
+---------------
 
 nextcord offers support for creating, editing, and executing webhooks through the :class:`Webhook` class.
 
 Webhook
-~~~~~~~~~
+~~~~~~~
 
 .. attributetable:: Webhook
 
@@ -3662,7 +3662,7 @@ Webhook
     :inherited-members:
 
 WebhookMessage
-~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~
 
 .. attributetable:: WebhookMessage
 
@@ -3670,7 +3670,7 @@ WebhookMessage
     :members:
 
 SyncWebhook
-~~~~~~~~~~~~
+~~~~~~~~~~~
 
 .. attributetable:: SyncWebhook
 
@@ -3679,7 +3679,7 @@ SyncWebhook
     :inherited-members:
 
 SyncWebhookMessage
-~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~
 
 .. attributetable:: SyncWebhookMessage
 
@@ -3689,7 +3689,7 @@ SyncWebhookMessage
 .. _discord_api_abcs:
 
 Abstract Base Classes
------------------------
+---------------------
 
 An :term:`abstract base class` (also known as an ``abc``) is a class that models can inherit
 to get their behaviour. **Abstract base classes should not be instantiated**.
@@ -3699,7 +3699,7 @@ This library has a module related to abstract base classes, in which all the ABC
 :class:`typing.Protocol`.
 
 Snowflake
-~~~~~~~~~~
+~~~~~~~~~
 
 .. attributetable:: nextcord.abc.Snowflake
 
@@ -3707,7 +3707,7 @@ Snowflake
     :members:
 
 User
-~~~~~
+~~~~
 
 .. attributetable:: nextcord.abc.User
 
@@ -3715,7 +3715,7 @@ User
     :members:
 
 PrivateChannel
-~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~
 
 .. attributetable:: nextcord.abc.PrivateChannel
 
@@ -3723,7 +3723,7 @@ PrivateChannel
     :members:
 
 GuildChannel
-~~~~~~~~~~~~~
+~~~~~~~~~~~~
 
 .. attributetable:: nextcord.abc.GuildChannel
 
@@ -3731,7 +3731,7 @@ GuildChannel
     :members:
 
 Messageable
-~~~~~~~~~~~~
+~~~~~~~~~~~
 
 .. attributetable:: nextcord.abc.Messageable
 
@@ -3746,7 +3746,7 @@ Messageable
         :async-with:
 
 Connectable
-~~~~~~~~~~~~
+~~~~~~~~~~~
 
 .. attributetable:: nextcord.abc.Connectable
 
@@ -3755,7 +3755,7 @@ Connectable
 .. _discord_api_models:
 
 Discord Models
----------------
+--------------
 
 Models are classes that are received from Discord and are not meant to be created by
 the user of the library.
@@ -3780,7 +3780,7 @@ the user of the library.
 
 
 ClientUser
-~~~~~~~~~~~~
+~~~~~~~~~~
 
 .. attributetable:: ClientUser
 
@@ -3789,7 +3789,7 @@ ClientUser
     :inherited-members:
 
 User
-~~~~~
+~~~~
 
 .. attributetable:: User
 
@@ -3805,7 +3805,7 @@ User
         :async-with:
 
 Attachment
-~~~~~~~~~~~
+~~~~~~~~~~
 
 .. attributetable:: Attachment
 
@@ -3830,7 +3830,7 @@ Message
     :members:
 
 Component
-~~~~~~~~~~
+~~~~~~~~~
 
 .. attributetable:: Component
 
@@ -3838,7 +3838,7 @@ Component
     :members:
 
 ActionRow
-~~~~~~~~~~
+~~~~~~~~~
 
 .. attributetable:: ActionRow
 
@@ -3846,7 +3846,7 @@ ActionRow
     :members:
 
 Button
-~~~~~~~
+~~~~~~
 
 .. attributetable:: Button
 
@@ -3855,7 +3855,7 @@ Button
     :inherited-members:
 
 SelectMenu
-~~~~~~~~~~~
+~~~~~~~~~~
 
 .. attributetable:: SelectMenu
 
@@ -3865,7 +3865,7 @@ SelectMenu
 
 
 DeletedReferencedMessage
-~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. attributetable:: DeletedReferencedMessage
 
@@ -3874,7 +3874,7 @@ DeletedReferencedMessage
 
 
 Reaction
-~~~~~~~~~
+~~~~~~~~
 
 .. attributetable:: Reaction
 
@@ -3886,7 +3886,7 @@ Reaction
         :async-for:
 
 Guild
-~~~~~~
+~~~~~
 
 .. attributetable:: Guild
 
@@ -3917,7 +3917,7 @@ Guild
 
 
 Integration
-~~~~~~~~~~~~
+~~~~~~~~~~~
 
 .. autoclass:: Integration()
     :members:
@@ -3935,7 +3935,7 @@ Integration
     :members:
 
 Interaction
-~~~~~~~~~~~~
+~~~~~~~~~~~
 
 .. attributetable:: Interaction
 
@@ -3943,7 +3943,7 @@ Interaction
     :members:
 
 InteractionResponse
-~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~
 
 .. attributetable:: InteractionResponse
 
@@ -3951,7 +3951,7 @@ InteractionResponse
     :members:
 
 InteractionMessage
-~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~
 
 .. attributetable:: InteractionMessage
 
@@ -3960,7 +3960,7 @@ InteractionMessage
     :inherited-members:
 
 PartialInteractionMessage
-~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. attributetable:: PartialInteractionMessage
 
@@ -3993,7 +3993,7 @@ Member
         :async-with:
 
 Spotify
-~~~~~~~~
+~~~~~~~
 
 .. attributetable:: Spotify
 
@@ -4001,7 +4001,7 @@ Spotify
     :members:
 
 VoiceState
-~~~~~~~~~~~
+~~~~~~~~~~
 
 .. attributetable:: VoiceState
 
@@ -4018,7 +4018,7 @@ Emoji
     :inherited-members:
 
 PartialEmoji
-~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~
 
 .. attributetable:: PartialEmoji
 
@@ -4027,7 +4027,7 @@ PartialEmoji
     :inherited-members:
 
 Role
-~~~~~
+~~~~
 
 .. attributetable:: Role
 
@@ -4035,7 +4035,7 @@ Role
     :members:
 
 RoleTags
-~~~~~~~~~~
+~~~~~~~~
 
 .. attributetable:: RoleTags
 
@@ -4043,7 +4043,7 @@ RoleTags
     :members:
 
 PartialMessageable
-~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~
 
 .. attributetable:: PartialMessageable
 
@@ -4052,7 +4052,7 @@ PartialMessageable
     :inherited-members:
 
 TextChannel
-~~~~~~~~~~~~
+~~~~~~~~~~~
 
 .. attributetable:: TextChannel
 
@@ -4068,7 +4068,7 @@ TextChannel
         :async-with:
 
 Thread
-~~~~~~~~
+~~~~~~
 
 .. attributetable:: Thread
 
@@ -4084,7 +4084,7 @@ Thread
         :async-with:
 
 ThreadMember
-~~~~~~~~~~~~~
+~~~~~~~~~~~~
 
 .. attributetable:: ThreadMember
 
@@ -4092,7 +4092,7 @@ ThreadMember
     :members:
 
 VoiceChannel
-~~~~~~~~~~~~~
+~~~~~~~~~~~~
 
 .. attributetable:: VoiceChannel
 
@@ -4101,7 +4101,7 @@ VoiceChannel
     :inherited-members:
 
 StageChannel
-~~~~~~~~~~~~~
+~~~~~~~~~~~~
 
 .. attributetable:: StageChannel
 
@@ -4111,7 +4111,7 @@ StageChannel
 
 
 StageInstance
-~~~~~~~~~~~~~~
+~~~~~~~~~~~~~
 
 .. attributetable:: StageInstance
 
@@ -4119,7 +4119,7 @@ StageInstance
     :members:
 
 CategoryChannel
-~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~
 
 .. attributetable:: CategoryChannel
 
@@ -4169,7 +4169,7 @@ ForumChannel
     :inherited-members:
 
 PartialInviteGuild
-~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~
 
 .. attributetable:: PartialInviteGuild
 
@@ -4177,7 +4177,7 @@ PartialInviteGuild
     :members:
 
 PartialInviteChannel
-~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~
 
 .. attributetable:: PartialInviteChannel
 
@@ -4185,7 +4185,7 @@ PartialInviteChannel
     :members:
 
 Invite
-~~~~~~~
+~~~~~~
 
 .. attributetable:: Invite
 
@@ -4193,7 +4193,7 @@ Invite
     :members:
 
 Template
-~~~~~~~~~
+~~~~~~~~
 
 .. attributetable:: Template
 
@@ -4201,7 +4201,7 @@ Template
     :members:
 
 WidgetChannel
-~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~
 
 .. attributetable:: WidgetChannel
 
@@ -4209,7 +4209,7 @@ WidgetChannel
     :members:
 
 WidgetMember
-~~~~~~~~~~~~~
+~~~~~~~~~~~~
 
 .. attributetable:: WidgetMember
 
@@ -4218,7 +4218,7 @@ WidgetMember
     :inherited-members:
 
 Widget
-~~~~~~~
+~~~~~~
 
 .. attributetable:: Widget
 
@@ -4226,7 +4226,7 @@ Widget
     :members:
 
 StickerPack
-~~~~~~~~~~~~~
+~~~~~~~~~~~
 
 .. attributetable:: StickerPack
 
@@ -4234,7 +4234,7 @@ StickerPack
     :members:
 
 StickerItem
-~~~~~~~~~~~~~
+~~~~~~~~~~~
 
 .. attributetable:: StickerItem
 
@@ -4242,7 +4242,7 @@ StickerItem
     :members:
 
 Sticker
-~~~~~~~~~~~~~~~
+~~~~~~~
 
 .. attributetable:: Sticker
 
@@ -4250,7 +4250,7 @@ Sticker
     :members:
 
 StandardSticker
-~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~
 
 .. attributetable:: StandardSticker
 
@@ -4258,7 +4258,7 @@ StandardSticker
     :members:
 
 GuildSticker
-~~~~~~~~~~~~~
+~~~~~~~~~~~~
 
 .. attributetable:: GuildSticker
 
@@ -4266,7 +4266,7 @@ GuildSticker
     :members:
 
 RawTypingEvent
-~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~
 
 .. attributetable:: RawTypingEvent
 
@@ -4274,7 +4274,7 @@ RawTypingEvent
     :members:
 
 RawMessageDeleteEvent
-~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~
 
 .. attributetable:: RawMessageDeleteEvent
 
@@ -4282,7 +4282,7 @@ RawMessageDeleteEvent
     :members:
 
 RawBulkMessageDeleteEvent
-~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. attributetable:: RawBulkMessageDeleteEvent
 
@@ -4290,7 +4290,7 @@ RawBulkMessageDeleteEvent
     :members:
 
 RawMessageUpdateEvent
-~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~
 
 .. attributetable:: RawMessageUpdateEvent
 
@@ -4298,7 +4298,7 @@ RawMessageUpdateEvent
     :members:
 
 RawReactionActionEvent
-~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~
 
 .. attributetable:: RawReactionActionEvent
 
@@ -4306,7 +4306,7 @@ RawReactionActionEvent
     :members:
 
 RawReactionClearEvent
-~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~
 
 .. attributetable:: RawReactionClearEvent
 
@@ -4314,7 +4314,7 @@ RawReactionClearEvent
     :members:
 
 RawReactionClearEmojiEvent
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. attributetable:: RawReactionClearEmojiEvent
 
@@ -4322,7 +4322,7 @@ RawReactionClearEmojiEvent
     :members:
 
 RawIntegrationDeleteEvent
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. attributetable:: RawIntegrationDeleteEvent
 
@@ -4330,7 +4330,7 @@ RawIntegrationDeleteEvent
     :members:
 
 PartialWebhookGuild
-~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~
 
 .. attributetable:: PartialWebhookGuild
 
@@ -4338,7 +4338,7 @@ PartialWebhookGuild
     :members:
 
 PartialWebhookChannel
-~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~
 
 .. attributetable:: PartialWebhookChannel
 
@@ -4379,7 +4379,7 @@ AutoModerationActionExecution
 .. _discord_api_data:
 
 Data Classes
---------------
+------------
 
 Some classes are just there to be data containers, this lists them.
 
@@ -4394,7 +4394,7 @@ dynamic attributes in mind.
 
 
 Object
-~~~~~~~
+~~~~~~
 
 .. attributetable:: Object
 
@@ -4402,7 +4402,7 @@ Object
     :members:
 
 Embed
-~~~~~~
+~~~~~
 
 .. attributetable:: Embed
 
@@ -4410,7 +4410,7 @@ Embed
     :members:
 
 AllowedMentions
-~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~
 
 .. attributetable:: AllowedMentions
 
@@ -4418,7 +4418,7 @@ AllowedMentions
     :members:
 
 MessageReference
-~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~
 
 .. attributetable:: MessageReference
 
@@ -4426,7 +4426,7 @@ MessageReference
     :members:
 
 PartialMessage
-~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~
 
 .. attributetable:: PartialMessage
 
@@ -4434,7 +4434,7 @@ PartialMessage
     :members:
 
 SelectOption
-~~~~~~~~~~~~~
+~~~~~~~~~~~~
 
 .. attributetable:: SelectOption
 
@@ -4442,7 +4442,7 @@ SelectOption
     :members:
 
 Intents
-~~~~~~~~~~
+~~~~~~~
 
 .. attributetable:: Intents
 
@@ -4450,7 +4450,7 @@ Intents
     :members:
 
 MemberCacheFlags
-~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~
 
 .. attributetable:: MemberCacheFlags
 
@@ -4458,7 +4458,7 @@ MemberCacheFlags
     :members:
 
 ApplicationFlags
-~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~
 
 .. attributetable:: ApplicationFlags
 
@@ -4466,7 +4466,7 @@ ApplicationFlags
     :members:
 
 File
-~~~~~
+~~~~
 
 .. attributetable:: File
 
@@ -4482,7 +4482,7 @@ Colour
     :members:
 
 BaseActivity
-~~~~~~~~~~~~~~
+~~~~~~~~~~~~
 
 .. attributetable:: BaseActivity
 
@@ -4490,7 +4490,7 @@ BaseActivity
     :members:
 
 Activity
-~~~~~~~~~
+~~~~~~~~
 
 .. attributetable:: Activity
 
@@ -4498,7 +4498,7 @@ Activity
     :members:
 
 Game
-~~~~~
+~~~~
 
 .. attributetable:: Game
 
@@ -4506,7 +4506,7 @@ Game
     :members:
 
 Streaming
-~~~~~~~~~~~
+~~~~~~~~~
 
 .. attributetable:: Streaming
 
@@ -4514,7 +4514,7 @@ Streaming
     :members:
 
 CustomActivity
-~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~
 
 .. attributetable:: CustomActivity
 
@@ -4522,7 +4522,7 @@ CustomActivity
     :members:
 
 Permissions
-~~~~~~~~~~~~
+~~~~~~~~~~~
 
 .. attributetable:: Permissions
 
@@ -4530,7 +4530,7 @@ Permissions
     :members:
 
 PermissionOverwrite
-~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~
 
 .. attributetable:: PermissionOverwrite
 
@@ -4538,7 +4538,7 @@ PermissionOverwrite
     :members:
 
 ShardInfo
-~~~~~~~~~~~
+~~~~~~~~~
 
 .. attributetable:: ShardInfo
 
@@ -4546,7 +4546,7 @@ ShardInfo
     :members:
 
 SystemChannelFlags
-~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~
 
 .. attributetable:: SystemChannelFlags
 
@@ -4604,12 +4604,12 @@ AutoModerationAction
 .. _discord_ui_kit:
 
 Bot UI Kit
--------------
+----------
 
 The library has helpers to help create component-based UIs.
 
 View
-~~~~~~~
+~~~~
 
 .. attributetable:: nextcord.ui.View
 
@@ -4617,7 +4617,7 @@ View
     :members:
 
 Modal
-~~~~~~~
+~~~~~
 
 .. attributetable:: nextcord.ui.Modal
 
@@ -4625,7 +4625,7 @@ Modal
     :members:
 
 Item
-~~~~~~~
+~~~~
 
 .. attributetable:: nextcord.ui.Item
 
@@ -4633,7 +4633,7 @@ Item
     :members:
 
 Button
-~~~~~~~
+~~~~~~
 
 .. attributetable:: nextcord.ui.Button
 
@@ -4644,7 +4644,7 @@ Button
 .. autofunction:: nextcord.ui.button
 
 TextInput
-~~~~~~~~~~
+~~~~~~~~~
 
 .. attributetable:: nextcord.ui.TextInput
 
@@ -4653,7 +4653,7 @@ TextInput
     :inherited-members:
 
 Select
-~~~~~~~
+~~~~~~
 
 .. attributetable:: nextcord.ui.Select
 
@@ -4861,7 +4861,7 @@ Cogs
     :members:
 
 Exceptions
-------------
+----------
 
 The following exceptions are thrown by the library.
 
@@ -4907,7 +4907,7 @@ The following exceptions are thrown by the library.
 .. autoexception:: ApplicationCommandOptionMissing
 
 Exception Hierarchy
-~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~
 
 .. exception_hierarchy::
 

--- a/docs/ext/commands/api.rst
+++ b/docs/ext/commands/api.rst
@@ -1,17 +1,17 @@
 .. currentmodule:: nextcord
 
 API Reference
-===============
+=============
 
 The following section outlines the API of nextcord's command extension module.
 
 .. _ext_commands_api_bot:
 
 Bots
-------
+----
 
 Bot
-~~~~
+~~~
 
 .. attributetable:: nextcord.ext.commands.Bot
 
@@ -45,7 +45,7 @@ Bot
         :decorator:
 
 AutoShardedBot
-~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~
 
 .. attributetable:: nextcord.ext.commands.AutoShardedBot
 
@@ -53,7 +53,7 @@ AutoShardedBot
     :members:
 
 Prefix Helpers
-----------------
+--------------
 
 .. autofunction:: nextcord.ext.commands.when_mentioned
 
@@ -62,7 +62,7 @@ Prefix Helpers
 .. _ext_commands_api_events:
 
 Event Reference
------------------
+---------------
 
 These events function similar to :ref:`the regular events <discord-api-events>`, except they
 are custom to the command extension module.
@@ -103,10 +103,10 @@ are custom to the command extension module.
 .. _ext_commands_api_command:
 
 Commands
-----------
+--------
 
 Decorators
-~~~~~~~~~~~~
+~~~~~~~~~~
 
 .. autofunction:: nextcord.ext.commands.command
     :decorator:
@@ -115,7 +115,7 @@ Decorators
     :decorator:
 
 Command
-~~~~~~~~~
+~~~~~~~
 
 .. attributetable:: nextcord.ext.commands.Command
 
@@ -134,7 +134,7 @@ Command
         :decorator:
 
 Group
-~~~~~~
+~~~~~
 
 .. attributetable:: nextcord.ext.commands.Group
 
@@ -159,7 +159,7 @@ Group
         :decorator:
 
 GroupMixin
-~~~~~~~~~~~
+~~~~~~~~~~
 
 .. attributetable:: nextcord.ext.commands.GroupMixin
 
@@ -176,10 +176,10 @@ GroupMixin
 .. _ext_commands_api_cogs:
 
 Cogs
-------
+----
 
 Cog
-~~~~
+~~~
 
 .. attributetable:: nextcord.ext.commands.Cog
 
@@ -187,7 +187,7 @@ Cog
     :members:
 
 CogMeta
-~~~~~~~~
+~~~~~~~
 
 .. attributetable:: nextcord.ext.commands.CogMeta
 
@@ -197,10 +197,10 @@ CogMeta
 .. _ext_commands_help_command:
 
 Help Commands
----------------
+-------------
 
 HelpCommand
-~~~~~~~~~~~~
+~~~~~~~~~~~
 
 .. attributetable:: nextcord.ext.commands.HelpCommand
 
@@ -208,7 +208,7 @@ HelpCommand
     :members:
 
 DefaultHelpCommand
-~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~
 
 .. attributetable:: nextcord.ext.commands.DefaultHelpCommand
 
@@ -217,7 +217,7 @@ DefaultHelpCommand
     :exclude-members: send_bot_help, send_cog_help, send_group_help, send_command_help, prepare_help_command
 
 MinimalHelpCommand
-~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~
 
 .. attributetable:: nextcord.ext.commands.MinimalHelpCommand
 
@@ -226,7 +226,7 @@ MinimalHelpCommand
     :exclude-members: send_bot_help, send_cog_help, send_group_help, send_command_help, prepare_help_command
 
 Paginator
-~~~~~~~~~~
+~~~~~~~~~
 
 .. attributetable:: nextcord.ext.commands.Paginator
 
@@ -234,7 +234,7 @@ Paginator
     :members:
 
 Enums
-------
+-----
 
 .. class:: BucketType
     :module: nextcord.ext.commands
@@ -269,7 +269,7 @@ Enums
 .. _ext_commands_api_checks:
 
 Checks
--------
+------
 
 .. autofunction:: nextcord.ext.commands.check(predicate)
     :decorator:
@@ -331,7 +331,7 @@ Checks
 .. _ext_commands_api_context:
 
 Cooldown
----------
+--------
 
 .. attributetable:: nextcord.ext.commands.Cooldown
 
@@ -339,7 +339,7 @@ Cooldown
     :members:
 
 Context
---------
+-------
 
 .. attributetable:: nextcord.ext.commands.Context
 
@@ -357,7 +357,7 @@ Context
 .. _ext_commands_api_converters:
 
 Converters
-------------
+----------
 
 .. autoclass:: nextcord.ext.commands.Converter
     :members:
@@ -427,7 +427,7 @@ Converters
 .. autofunction:: nextcord.ext.commands.run_converters
 
 Flag Converter
-~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~
 
 .. autoclass:: nextcord.ext.commands.FlagConverter
     :members:
@@ -440,12 +440,12 @@ Flag Converter
 .. _ext_commands_api_errors:
 
 Warnings
----------
+--------
 
 .. autoclass:: nextcord.ext.commands.MissingMessageContentIntentWarning
 
 Exceptions
------------
+----------
 
 .. autoexception:: nextcord.ext.commands.CommandError
     :members:
@@ -620,7 +620,7 @@ Exceptions
 
 
 Exception Hierarchy
-~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~
 
 .. exception_hierarchy::
 

--- a/docs/ext/commands/cogs.rst
+++ b/docs/ext/commands/cogs.rst
@@ -3,7 +3,7 @@
 .. _ext_commands_cogs:
 
 Cogs
-======
+====
 
 There comes a point in your bot's development when you want to organize a collection of commands, listeners, and some state into one class. Cogs allow you to do just that.
 
@@ -18,7 +18,7 @@ The gist:
 It should be noted that cogs are typically used alongside with :ref:`ext_commands_extensions`.
 
 Quick Example
----------------
+-------------
 
 This example cog defines a ``Greetings`` category for your commands, with a single :ref:`command <ext_commands_commands>` named ``hello`` as well as a listener to listen to an :ref:`Event <discord-api-events>`.
 
@@ -52,7 +52,7 @@ A couple of technical notes to take into consideration:
 - All commands must now take a ``self`` parameter to allow usage of instance attributes that can be used to maintain state.
 
 Cog Registration
--------------------
+----------------
 
 Once you have defined your cogs, you need to tell the bot to register the cogs to be used. We do this via the :meth:`~.commands.Bot.add_cog` method.
 
@@ -69,7 +69,7 @@ Note that we reference the cog by name, which we can override through :ref:`ext_
     bot.remove_cog('Greetings')
 
 Using Cogs
--------------
+----------
 
 Just as we remove a cog by its name, we can also retrieve it by its name as well. This allows us to use a cog as an inter-command communication protocol to share data. For example:
 
@@ -106,7 +106,7 @@ Just as we remove a cog by its name, we can also retrieve it by its name as well
 .. _ext_commands_cogs_special_methods:
 
 Special Methods
------------------
+---------------
 
 As cogs get more complicated and have more commands, there comes a point where we want to customise the behaviour of the entire cog or bot.
 
@@ -125,7 +125,7 @@ You can visit the reference to get more detail.
 .. _ext_commands_cogs_meta_options:
 
 Meta Options
---------------
+------------
 
 At the heart of a cog resides a metaclass, :class:`.commands.CogMeta`, which can take various options to customise some of the behaviour. To do this, we pass keyword arguments to the class definition line. For example, to change the cog name we can pass the ``name`` keyword argument as follows:
 
@@ -137,7 +137,7 @@ At the heart of a cog resides a metaclass, :class:`.commands.CogMeta`, which can
 To see more options that you can set, see the documentation of :class:`.commands.CogMeta`.
 
 Inspection
-------------
+----------
 
 Since cogs ultimately are classes, we have some tools to help us inspect certain properties of the cog.
 

--- a/docs/ext/commands/commands.rst
+++ b/docs/ext/commands/commands.rst
@@ -3,7 +3,7 @@
 .. _ext_commands_commands:
 
 Commands
-==========
+========
 
 One of the most appealing aspects of the command extension is how easy it is to define commands and
 how you can arbitrarily nest groups and commands to have a rich sub-command system.
@@ -62,7 +62,7 @@ the name to something other than the function would be as simple as doing this:
         pass
 
 Parameters
-------------
+----------
 
 Since we define commands by making Python functions, we also define the argument passing behaviour by the function
 parameters.
@@ -70,7 +70,7 @@ parameters.
 Certain parameter types do different things in the user side and most forms of parameter types are supported.
 
 Positional
-++++++++++++
+++++++++++
 
 The most basic form of parameter passing is the positional parameter. This is where we pass a parameter as-is:
 
@@ -102,7 +102,7 @@ Since positional arguments are just regular Python arguments, you can have as ma
         await ctx.send(f'You passed {arg1} and {arg2}')
 
 Variable
-++++++++++
+++++++++
 
 Sometimes you want users to pass in an undetermined number of parameters. The library supports this
 similar to how variable list parameters are done in Python:
@@ -134,7 +134,7 @@ Since the ``args`` variable is a :class:`py:tuple`,
 you can do anything you would usually do with one.
 
 Keyword-Only Arguments
-++++++++++++++++++++++++
+++++++++++++++++++++++
 
 When you want to handle parsing of the argument yourself or do not feel like you want to wrap multi-word user input into
 quotes, you can ask the library to give you the rest as a single argument. We do this by using a **keyword-only argument**,
@@ -164,7 +164,7 @@ toggled by the :attr:`.Command.rest_is_raw` argument in the decorator.
 .. _ext_commands_context:
 
 Invocation Context
--------------------
+------------------
 
 As seen earlier, every command must take at least a single parameter, called the :class:`~ext.commands.Context`.
 
@@ -180,7 +180,7 @@ The context implements the :class:`abc.Messageable` interface, so anything you c
 can do on the :class:`~ext.commands.Context`.
 
 Converters
-------------
+----------
 
 Adding bot arguments with function parameters is only the first step in defining your bot's command interface. To actually
 make use of the arguments, we usually want to convert the data into a target type. We call these
@@ -197,7 +197,7 @@ Converters come in a few flavours:
 .. _ext_commands_basic_converters:
 
 Basic Converters
-++++++++++++++++++
+++++++++++++++++
 
 At its core, a basic converter is a callable that takes in an argument and turns it into something else.
 
@@ -239,7 +239,7 @@ Unlike the other basic converters, the :class:`bool` converter is treated slight
 .. _ext_commands_adv_converters:
 
 Advanced Converters
-+++++++++++++++++++++
++++++++++++++++++++
 
 Sometimes a basic converter doesn't have enough information that we need. For example, sometimes we want to get some
 information from the :class:`Message` that called the command or we want to do some asynchronous processing.
@@ -297,7 +297,7 @@ If a converter fails to convert an argument to its designated target type, the :
 raised.
 
 Inline Advanced Converters
-+++++++++++++++++++++++++++++
+++++++++++++++++++++++++++
 
 If we don't want to inherit from :class:`~ext.commands.Converter`, we can still provide a converter that has the
 advanced functionalities of an advanced converter and save us from specifying two types.
@@ -355,7 +355,7 @@ This can get tedious, so an inline advanced converter is possible through a :fun
             await ctx.send("Hm you're not so new.")
 
 Discord Converters
-++++++++++++++++++++
+++++++++++++++++++
 
 Working with :ref:`discord_api_models` is a fairly common thing when defining commands, as a result the library makes
 working with them easy.
@@ -456,7 +456,7 @@ By providing the converter it allows us to use them as building blocks for anoth
 .. _ext_commands_special_converters:
 
 Special Converters
-++++++++++++++++++++
+++++++++++++++++++
 
 The command extension also has support for certain converters to allow for more advanced and intricate use cases that go
 beyond the generic linear parsing. These converters allow you to introduce some more relaxed and dynamic grammar to your
@@ -600,7 +600,7 @@ This command can be invoked any of the following ways:
 .. _ext_commands_flag_converter:
 
 FlagConverter
-++++++++++++++
++++++++++++++
 
 .. versionadded:: 2.0
 
@@ -758,7 +758,7 @@ given as a :class:`dict` rather than a :class:`list`.
 .. _ext_commands_error_handler:
 
 Error Handling
-----------------
+--------------
 
 When our commands fail to parse we will, by default, receive a noisy error in ``stderr`` of our console that tells us
 that an error has happened and has been silently ignored.
@@ -787,7 +787,7 @@ The first parameter of the error handler is the :class:`.Context` while the seco
 :exc:`~ext.commands.CommandError`. A list of errors is found in the :ref:`ext_commands_api_errors` page of the documentation.
 
 Checks
--------
+------
 
 There are cases when we don't want a user to use our commands. They don't have permissions to do so or maybe we blocked
 them from using our bot earlier. The commands extension comes with full support for these things in a concept called a
@@ -908,7 +908,7 @@ If you want a more robust error system, you can derive from the exception and ra
     Since having a ``guild_only`` decorator is pretty common, it comes built-in via :func:`~ext.commands.guild_only`.
 
 Global Checks
-++++++++++++++
++++++++++++++
 
 Sometimes we want to apply a check to **every** command, not just certain commands. The library supports this as well
 using the global check concept.

--- a/docs/ext/commands/extensions.rst
+++ b/docs/ext/commands/extensions.rst
@@ -3,12 +3,12 @@
 .. _ext_commands_extensions:
 
 Extensions
-=============
+==========
 
 There comes a time in the bot development when you want to extend the bot functionality at run-time and quickly unload and reload code (also called hot-reloading). The command framework comes with this ability built-in, with a concept called **extensions**.
 
 Primer
---------
+------
 
 An extension at its core is a python file with an entry point called ``setup``.
 
@@ -39,7 +39,7 @@ In this example we define a simple command, and when the extension is loaded thi
     Extension paths are ultimately similar to the import mechanism. What this means is that if there is a folder, then it must be dot-qualified. For example to load an extension in ``plugins/hello.py`` then we use the string ``plugins.hello``.
 
 Reloading
------------
+---------
 
 When you make a change to the extension and want to reload the references, the library comes with a function to do this for you, :meth:`.Bot.reload_extension`.
 
@@ -50,7 +50,7 @@ When you make a change to the extension and want to reload the references, the l
 Once the extension reloads, any changes that we did will be applied. This is useful if we want to add or remove functionality without restarting our bot. If an error occurred during the reloading process, the bot will pretend as if the reload never happened.
 
 Cleaning Up
--------------
+-----------
 
 Although rare, sometimes an extension needs to clean-up or know when it's being unloaded. For cases like these, there is another entry point named ``teardown`` which is similar to ``setup`` except called when the extension is unloaded.
 

--- a/docs/ext/commands/index.rst
+++ b/docs/ext/commands/index.rst
@@ -1,7 +1,7 @@
 .. _discord_ext_commands:
 
 ``nextcord.ext.commands`` -- Bot commands framework
-====================================================
+===================================================
 
 ``nextcord`` offers a lower level aspect on interacting with Discord. Often times, the library is used for the creation of
 bots. However this task can be daunting and confusing to get correctly the first time. Many times there comes a repetition in

--- a/docs/ext/tasks/index.rst
+++ b/docs/ext/tasks/index.rst
@@ -1,7 +1,7 @@
 .. _discord_ext_tasks:
 
 ``nextcord.ext.tasks`` -- asyncio.Task helpers
-====================================================
+==============================================
 
 .. versionadded:: 1.1.0
 
@@ -14,7 +14,7 @@ One of the most common operations when making a bot is having a loop run in the 
 The goal of this nextcord extension is to abstract all these worries away from you.
 
 Recipes
----------
+-------
 
 A simple background task in a :class:`~nextcord.ext.commands.Cog`:
 
@@ -133,7 +133,7 @@ Doing something during cancellation:
 .. _ext_tasks_api:
 
 API Reference
----------------
+-------------
 
 .. attributetable:: nextcord.ext.tasks.Loop
 

--- a/docs/whats_new.rst
+++ b/docs/whats_new.rst
@@ -858,7 +858,7 @@ v1.2.0
 This update mainly brings performance improvements and various nitro boosting attributes (referred to in the API as "premium guilds").
 
 New Features
-~~~~~~~~~~~~~~
+~~~~~~~~~~~~
 
 - Add :attr:`Guild.premium_tier` to query the guild's current nitro boost level.
 - Add :attr:`Guild.emoji_limit`, :attr:`Guild.bitrate_limit`, :attr:`Guild.filesize_limit` to query the new limits of a guild when taking into consideration boosting.
@@ -963,7 +963,7 @@ Bug Fixes
 - Tighten constraints of ``__eq__`` in :class:`Spotify` objects (:dpyissue:`2113`, :dpyissue:`2117`)
 
 ``discord.ext.commands``
-++++++++++++++++++++++++++
+++++++++++++++++++++++++
 
 - Fix lambda converters in a non-module context (e.g. ``eval``).
 - Use message creation time for reference time when computing cooldowns.

--- a/nextcord/abc.py
+++ b/nextcord/abc.py
@@ -115,7 +115,7 @@ class Snowflake(Protocol):
     :class:`.Object`.
 
     Attributes
-    -----------
+    ----------
     id: :class:`int`
         The model's unique ID.
     """
@@ -137,7 +137,7 @@ class User(Snowflake, Protocol):
     This ABC must also implement :class:`~nextcord.abc.Snowflake`.
 
     Attributes
-    -----------
+    ----------
     name: :class:`str`
         The user's username.
     discriminator: :class:`str`
@@ -178,7 +178,7 @@ class PrivateChannel(Snowflake, Protocol):
     This ABC must also implement :class:`~nextcord.abc.Snowflake`.
 
     Attributes
-    -----------
+    ----------
     me: :class:`~nextcord.ClientUser`
         The user presenting yourself.
     """
@@ -239,7 +239,7 @@ class GuildChannel:
     This ABC must also implement :class:`~nextcord.abc.Snowflake`.
 
     Attributes
-    -----------
+    ----------
     name: :class:`str`
         The channel name.
     guild: :class:`~nextcord.Guild`
@@ -461,13 +461,13 @@ class GuildChannel:
         """Returns the channel-specific overwrites for a member or a role.
 
         Parameters
-        -----------
+        ----------
         obj: Union[:class:`~nextcord.Role`, :class:`~nextcord.abc.User`]
             The role or user denoting
             whose overwrite to get.
 
         Returns
-        ---------
+        -------
         :class:`~nextcord.PermissionOverwrite`
             The permission overwrites for this object.
         """
@@ -497,7 +497,7 @@ class GuildChannel:
         overwrite as a :class:`~nextcord.PermissionOverwrite`.
 
         Returns
-        --------
+        -------
         Dict[Union[:class:`~nextcord.Role`, :class:`~nextcord.Member`], :class:`~nextcord.PermissionOverwrite`]
             The channel's permission overwrites.
         """
@@ -697,7 +697,7 @@ class GuildChannel:
         You must have :attr:`~nextcord.Permissions.manage_channels` permission to use this.
 
         Parameters
-        -----------
+        ----------
         reason: Optional[:class:`str`]
             The reason for deleting this channel.
             Shows up on the audit log.
@@ -777,7 +777,7 @@ class GuildChannel:
             await channel.set_permissions(member, overwrite=overwrite)
 
         Parameters
-        -----------
+        ----------
         target: Union[:class:`~nextcord.Member`, :class:`~nextcord.Role`]
             The member or role to overwrite permissions for.
         overwrite: Optional[:class:`~nextcord.PermissionOverwrite`]
@@ -867,7 +867,7 @@ class GuildChannel:
         .. versionadded:: 1.1
 
         Parameters
-        ------------
+        ----------
         name: Optional[:class:`str`]
             The name of the new channel. If not provided, defaults to this
             channel name.
@@ -882,7 +882,7 @@ class GuildChannel:
             Creating the channel failed.
 
         Returns
-        --------
+        -------
         :class:`.abc.GuildChannel`
             The channel that was created.
         """
@@ -954,7 +954,7 @@ class GuildChannel:
         .. versionadded:: 1.7
 
         Parameters
-        ------------
+        ----------
         beginning: :class:`bool`
             Whether to move the channel to the beginning of the
             channel list (or category if given).
@@ -1079,7 +1079,7 @@ class GuildChannel:
         do this.
 
         Parameters
-        ------------
+        ----------
         max_age: :class:`int`
             How long the invite should last in seconds. If it's 0 then the invite
             doesn't expire. Defaults to ``0``.
@@ -1119,7 +1119,7 @@ class GuildChannel:
             The channel that was passed is a category or an invalid channel.
 
         Returns
-        --------
+        -------
         :class:`~nextcord.Invite`
             The invite that was created.
         """
@@ -1145,7 +1145,7 @@ class GuildChannel:
         You must have :attr:`~nextcord.Permissions.manage_channels` to get this information.
 
         Raises
-        -------
+        ------
         ~nextcord.Forbidden
             You do not have proper permissions to get the information.
         ~nextcord.HTTPException
@@ -1292,7 +1292,7 @@ class Messageable:
         **Specifying both parameters will lead to an exception**.
 
         Parameters
-        ------------
+        ----------
         content: Optional[:class:`str`]
             The content of the message to send.
         tts: :class:`bool`
@@ -1357,7 +1357,7 @@ class Messageable:
             :class:`~nextcord.MessageReference` or :class:`~nextcord.PartialMessage`.
 
         Returns
-        ---------
+        -------
         :class:`~nextcord.Message`
             The message that was sent.
         """
@@ -1511,7 +1511,7 @@ class Messageable:
         Retrieves a single :class:`~nextcord.Message` from the destination.
 
         Parameters
-        ------------
+        ----------
         id: :class:`int`
             The message ID to look for.
 
@@ -1525,7 +1525,7 @@ class Messageable:
             Retrieving the message failed.
 
         Returns
-        --------
+        -------
         :class:`~nextcord.Message`
             The message asked for.
         """
@@ -1565,7 +1565,7 @@ class Messageable:
         All parameters are optional.
 
         Parameters
-        -----------
+        ----------
         limit: Optional[:class:`int`]
             The number of messages to retrieve.
             If ``None``, retrieves every message in the channel. Note, however,
@@ -1644,7 +1644,7 @@ class Connectable(Protocol):
         This requires :attr:`Intents.voice_states`.
 
         Parameters
-        -----------
+        ----------
         timeout: :class:`float`
             The timeout in seconds to wait for the voice endpoint.
         reconnect: :class:`bool`
@@ -1665,7 +1665,7 @@ class Connectable(Protocol):
             The opus library has not been loaded.
 
         Returns
-        --------
+        -------
         :class:`~nextcord.VoiceProtocol`
             A voice client that is fully connected to the voice server.
         """

--- a/nextcord/abc.py
+++ b/nextcord/abc.py
@@ -703,7 +703,7 @@ class GuildChannel:
             Shows up on the audit log.
 
         Raises
-        -------
+        ------
         ~nextcord.Forbidden
             You do not have proper permissions to delete the channel.
         ~nextcord.NotFound
@@ -758,7 +758,7 @@ class GuildChannel:
             This method *replaces* the old overwrites with the ones given.
 
         Examples
-        ----------
+        --------
 
         Setting allow and deny: ::
 
@@ -790,7 +790,7 @@ class GuildChannel:
             The reason for doing this action. Shows up on the audit log.
 
         Raises
-        -------
+        ------
         ~nextcord.Forbidden
             You do not have permissions to edit channel specific permissions.
         ~nextcord.HTTPException
@@ -875,7 +875,7 @@ class GuildChannel:
             The reason for cloning this channel. Shows up on the audit log.
 
         Raises
-        -------
+        ------
         ~nextcord.Forbidden
             You do not have the proper permissions to create this channel.
         ~nextcord.HTTPException
@@ -986,7 +986,7 @@ class GuildChannel:
             The reason for the move.
 
         Raises
-        -------
+        ------
         InvalidArgument
             An invalid position was given or a bad mix of arguments were passed.
         Forbidden
@@ -1111,7 +1111,7 @@ class GuildChannel:
             .. versionadded:: 2.0
 
         Raises
-        -------
+        ------
         ~nextcord.HTTPException
             Invite creation failed.
 
@@ -1344,7 +1344,7 @@ class Messageable:
             .. versionadded:: 2.0
 
         Raises
-        --------
+        ------
         ~nextcord.HTTPException
             Sending the message failed.
         ~nextcord.Forbidden
@@ -1516,7 +1516,7 @@ class Messageable:
             The message ID to look for.
 
         Raises
-        --------
+        ------
         ~nextcord.NotFound
             The specified message was not found.
         ~nextcord.Forbidden
@@ -1548,7 +1548,7 @@ class Messageable:
         You must have :attr:`~nextcord.Permissions.read_message_history` permissions to use this.
 
         Examples
-        ---------
+        --------
 
         Usage ::
 
@@ -1596,7 +1596,7 @@ class Messageable:
             The request to get message history failed.
 
         Yields
-        -------
+        ------
         :class:`~nextcord.Message`
             The message with the message data parsed.
         """
@@ -1656,7 +1656,7 @@ class Connectable(Protocol):
             Defaults to :class:`~nextcord.VoiceClient`.
 
         Raises
-        -------
+        ------
         asyncio.TimeoutError
             Could not connect to the voice channel in time.
         ~nextcord.ClientException

--- a/nextcord/activity.py
+++ b/nextcord/activity.py
@@ -153,7 +153,7 @@ class Activity(BaseActivity):
     - :class:`Streaming`
 
     Attributes
-    ------------
+    ----------
     application_id: Optional[:class:`int`]
         The application ID of the game.
     name: Optional[:class:`str`]
@@ -355,12 +355,12 @@ class Game(BaseActivity):
             Returns the game's name.
 
     Parameters
-    -----------
+    ----------
     name: :class:`str`
         The game's name.
 
     Attributes
-    -----------
+    ----------
     name: :class:`str`
         The game's name.
     """
@@ -458,7 +458,7 @@ class Streaming(BaseActivity):
             Returns the stream's name.
 
     Attributes
-    -----------
+    ----------
     platform: Optional[:class:`str`]
         Where the user is streaming from (ie. YouTube, Twitch).
 
@@ -752,7 +752,7 @@ class CustomActivity(BaseActivity):
     .. versionadded:: 1.3
 
     Attributes
-    -----------
+    ----------
     name: Optional[:class:`str`]
         The custom activity's name.
     emoji: Optional[:class:`PartialEmoji`]

--- a/nextcord/appinfo.py
+++ b/nextcord/appinfo.py
@@ -48,7 +48,7 @@ class AppInfo:
 
 
     Attributes
-    -------------
+    ----------
     id: :class:`int`
         The application ID.
     name: :class:`str`
@@ -146,7 +146,7 @@ class PartialAppInfo:
     .. versionadded:: 2.0
 
     Attributes
-    -------------
+    ----------
     id: :class:`int`
         The application ID.
     name: :class:`str`

--- a/nextcord/application_command.py
+++ b/nextcord/application_command.py
@@ -560,7 +560,7 @@ class ClientCog:
         This **must** be a coroutine.
 
         Parameters
-        -----------
+        ----------
         interaction: :class:`.Interaction`
             The invocation interaction.
         """
@@ -575,7 +575,7 @@ class ClientCog:
         This **must** be a coroutine.
 
         Parameters
-        -----------
+        ----------
         interaction: :class:`.Interaction`
             The invocation interaction.
         """
@@ -779,18 +779,18 @@ class CallbackMixin:
         inside the :attr:`~ApplicationCommand.checks` attribute, as well as all global and cog checks.
 
         Parameters
-        -----------
+        ----------
         interaction: :class:`.Interaction`
             The interaction of the command currently being invoked.
 
         Raises
-        -------
+        ------
         :class:`ApplicationError`
             Any application command error that was raised during a check call will be propagated
             by this function.
 
         Returns
-        --------
+        -------
         :class:`bool`
             A boolean indicating if the command can be invoked.
         """

--- a/nextcord/asset.py
+++ b/nextcord/asset.py
@@ -103,7 +103,7 @@ class AssetMixin:
             The asset was deleted.
 
         Returns
-        --------
+        -------
         :class:`int`
             The number of bytes written.
         """
@@ -134,7 +134,7 @@ class AssetMixin:
         .. versionadded:: 2.0
 
         Parameters
-        -----------
+        ----------
         filename: Optional[:class:`str`]
             The filename of the file. If not provided, then the filename from
             the asset's URL is used.
@@ -366,7 +366,7 @@ class Asset(AssetMixin):
         """Returns a new asset with the passed components replaced.
 
         Parameters
-        -----------
+        ----------
         size: :class:`int`
             The new size of the asset.
         format: :class:`str`
@@ -382,7 +382,7 @@ class Asset(AssetMixin):
             An invalid size or format was passed.
 
         Returns
-        --------
+        -------
         :class:`Asset`
             The newly updated asset.
         """
@@ -418,17 +418,17 @@ class Asset(AssetMixin):
         """Returns a new asset with the specified size.
 
         Parameters
-        ------------
+        ----------
         size: :class:`int`
             The new size of the asset.
 
         Raises
-        -------
+        ------
         InvalidArgument
             The asset had an invalid size.
 
         Returns
-        --------
+        -------
         :class:`Asset`
             The new updated asset.
         """
@@ -442,17 +442,17 @@ class Asset(AssetMixin):
         """Returns a new asset with the specified format.
 
         Parameters
-        ------------
+        ----------
         format: :class:`str`
             The new format of the asset.
 
         Raises
-        -------
+        ------
         InvalidArgument
             The asset had an invalid format.
 
         Returns
-        --------
+        -------
         :class:`Asset`
             The new updated asset.
         """
@@ -476,7 +476,7 @@ class Asset(AssetMixin):
         not animated. Otherwise, the asset is not changed.
 
         Parameters
-        ------------
+        ----------
         format: :class:`str`
             The new static format of the asset.
 
@@ -486,7 +486,7 @@ class Asset(AssetMixin):
             The asset had an invalid format.
 
         Returns
-        --------
+        -------
         :class:`Asset`
             The new updated asset.
         """

--- a/nextcord/asset.py
+++ b/nextcord/asset.py
@@ -377,7 +377,7 @@ class Asset(AssetMixin):
             Must be either 'webp', 'jpeg', 'jpg', or 'png'.
 
         Raises
-        -------
+        ------
         InvalidArgument
             An invalid size or format was passed.
 

--- a/nextcord/asset.py
+++ b/nextcord/asset.py
@@ -481,7 +481,7 @@ class Asset(AssetMixin):
             The new static format of the asset.
 
         Raises
-        -------
+        ------
         InvalidArgument
             The asset had an invalid format.
 

--- a/nextcord/audit_logs.py
+++ b/nextcord/audit_logs.py
@@ -433,7 +433,7 @@ class AuditLogEntry(Hashable):
         Audit log entries are now comparable and hashable.
 
     Attributes
-    -----------
+    ----------
     action: :class:`AuditLogAction`
         The action that was done.
     user: :class:`abc.User`

--- a/nextcord/channel.py
+++ b/nextcord/channel.py
@@ -122,7 +122,7 @@ class TextChannel(abc.Messageable, abc.GuildChannel, Hashable, PinsMixin):
             Returns the channel's name.
 
     Attributes
-    -----------
+    ----------
     name: :class:`str`
         The channel name.
     guild: :class:`Guild`
@@ -269,7 +269,7 @@ class TextChannel(abc.Messageable, abc.GuildChannel, Hashable, PinsMixin):
             attribute.
 
         Returns
-        ---------
+        -------
         Optional[:class:`Message`]
             The last message in this channel or ``None`` if not found.
         """
@@ -358,7 +358,7 @@ class TextChannel(abc.Messageable, abc.GuildChannel, Hashable, PinsMixin):
             Editing the channel failed.
 
         Returns
-        --------
+        -------
         Optional[:class:`.TextChannel`]
             The newly edited text channel. If the edit was only positional
             then ``None`` is returned instead.
@@ -396,7 +396,7 @@ class TextChannel(abc.Messageable, abc.GuildChannel, Hashable, PinsMixin):
         use this.
 
         Parameters
-        -----------
+        ----------
         messages: Iterable[:class:`abc.Snowflake`]
             An iterable of messages denoting which ones to bulk delete.
 
@@ -462,7 +462,7 @@ class TextChannel(abc.Messageable, abc.GuildChannel, Hashable, PinsMixin):
             await channel.send(f'Deleted {len(deleted)} message(s)')
 
         Parameters
-        -----------
+        ----------
         limit: Optional[:class:`int`]
             The number of messages to search through. This is not the number
             of messages that will be deleted, though it can be.
@@ -490,7 +490,7 @@ class TextChannel(abc.Messageable, abc.GuildChannel, Hashable, PinsMixin):
             Purging the messages failed.
 
         Returns
-        --------
+        -------
         List[:class:`.Message`]
             The list of messages that were deleted.
         """
@@ -555,7 +555,7 @@ class TextChannel(abc.Messageable, abc.GuildChannel, Hashable, PinsMixin):
             You don't have permissions to get the webhooks.
 
         Returns
-        --------
+        -------
         List[:class:`Webhook`]
             The webhooks for this channel.
         """
@@ -585,7 +585,7 @@ class TextChannel(abc.Messageable, abc.GuildChannel, Hashable, PinsMixin):
             The ``avatar`` parameter now accepts :class:`File`, :class:`Attachment`, and :class:`Asset`.
 
         Parameters
-        -------------
+        ----------
         name: :class:`str`
             The webhook's name.
         avatar: Optional[Union[:class:`bytes`, :class:`Asset`, :class:`Attachment`, :class:`File`]]
@@ -603,7 +603,7 @@ class TextChannel(abc.Messageable, abc.GuildChannel, Hashable, PinsMixin):
             You do not have permissions to create a webhook.
 
         Returns
-        --------
+        -------
         :class:`Webhook`
             The created webhook.
         """
@@ -631,7 +631,7 @@ class TextChannel(abc.Messageable, abc.GuildChannel, Hashable, PinsMixin):
         .. versionadded:: 1.3
 
         Parameters
-        -----------
+        ----------
         destination: :class:`TextChannel`
             The channel you would like to follow from.
         reason: Optional[:class:`str`]
@@ -647,7 +647,7 @@ class TextChannel(abc.Messageable, abc.GuildChannel, Hashable, PinsMixin):
             You do not have the permissions to create a webhook.
 
         Returns
-        --------
+        -------
         :class:`Webhook`
             The created webhook.
         """
@@ -674,12 +674,12 @@ class TextChannel(abc.Messageable, abc.GuildChannel, Hashable, PinsMixin):
         .. versionadded:: 1.6
 
         Parameters
-        ------------
+        ----------
         message_id: :class:`int`
             The message ID to create a partial message for.
 
         Returns
-        ---------
+        -------
         :class:`PartialMessage`
             The partial message.
         """
@@ -694,12 +694,12 @@ class TextChannel(abc.Messageable, abc.GuildChannel, Hashable, PinsMixin):
         .. versionadded:: 2.0
 
         Parameters
-        -----------
+        ----------
         thread_id: :class:`int`
             The ID to search for.
 
         Returns
-        --------
+        -------
         Optional[:class:`Thread`]
             The returned thread or ``None`` if not found.
         """
@@ -724,7 +724,7 @@ class TextChannel(abc.Messageable, abc.GuildChannel, Hashable, PinsMixin):
         .. versionadded:: 2.0
 
         Parameters
-        -----------
+        ----------
         name: :class:`str`
             The name of the thread.
         message: Optional[:class:`abc.Snowflake`]
@@ -749,7 +749,7 @@ class TextChannel(abc.Messageable, abc.GuildChannel, Hashable, PinsMixin):
             Starting the thread failed.
 
         Returns
-        --------
+        -------
         :class:`Thread`
             The created thread
         """
@@ -1353,7 +1353,7 @@ class VocalGuildChannel(abc.Connectable, abc.GuildChannel, Hashable):
             when the member cache is unavailable.
 
         Returns
-        --------
+        -------
         Mapping[:class:`int`, :class:`VoiceState`]
             The mapping of member ID to a voice state.
         """
@@ -1400,7 +1400,7 @@ class VoiceChannel(VocalGuildChannel, abc.Messageable):
             Returns the channel's name.
 
     Attributes
-    -----------
+    ----------
     name: :class:`str`
         The channel name.
     guild: :class:`Guild`
@@ -1497,7 +1497,7 @@ class VoiceChannel(VocalGuildChannel, abc.Messageable):
         .. versionadded:: 2.1
 
         Returns
-        ---------
+        -------
         Optional[:class:`Message`]
             The last message in this channel or ``None`` if not found.
         """
@@ -1588,7 +1588,7 @@ class VoiceChannel(VocalGuildChannel, abc.Messageable):
             Editing the channel failed.
 
         Returns
-        --------
+        -------
         Optional[:class:`.VoiceChannel`]
             The newly edited voice channel. If the edit was only positional
             then ``None`` is returned instead.
@@ -1618,7 +1618,7 @@ class VoiceChannel(VocalGuildChannel, abc.Messageable):
         .. versionadded:: 2.1
 
         Parameters
-        -----------
+        ----------
         messages: Iterable[:class:`abc.Snowflake`]
             An iterable of messages denoting which ones to bulk delete.
 
@@ -1686,7 +1686,7 @@ class VoiceChannel(VocalGuildChannel, abc.Messageable):
             await channel.send(f'Deleted {len(deleted)} message(s)')
 
         Parameters
-        -----------
+        ----------
         limit: Optional[:class:`int`]
             The number of messages to search through. This is not the number
             of messages that will be deleted, though it can be.
@@ -1707,14 +1707,14 @@ class VoiceChannel(VocalGuildChannel, abc.Messageable):
             fall back to single delete if messages are older than two weeks.
 
         Raises
-        -------
+        ------
         Forbidden
             You do not have proper permissions to do the actions required.
         HTTPException
             Purging the messages failed.
 
         Returns
-        --------
+        -------
         List[:class:`.Message`]
             The list of messages that were deleted.
         """
@@ -1791,7 +1791,7 @@ class StageChannel(VocalGuildChannel):
             Returns the channel's name.
 
     Attributes
-    -----------
+    ----------
     name: :class:`str`
         The channel name.
     guild: :class:`Guild`
@@ -1923,7 +1923,7 @@ class StageChannel(VocalGuildChannel):
         .. versionadded:: 2.0
 
         Parameters
-        -----------
+        ----------
         topic: :class:`str`
             The stage instance's topic.
         privacy_level: :class:`StagePrivacyLevel`
@@ -1941,7 +1941,7 @@ class StageChannel(VocalGuildChannel):
             Creating a stage instance failed.
 
         Returns
-        --------
+        -------
         :class:`StageInstance`
             The newly created stage instance.
         """
@@ -1965,14 +1965,14 @@ class StageChannel(VocalGuildChannel):
         .. versionadded:: 2.0
 
         Raises
-        -------
+        ------
         :exc:`.NotFound`
             The stage instance or channel could not be found.
         :exc:`.HTTPException`
             Getting the stage instance failed.
 
         Returns
-        --------
+        -------
         :class:`StageInstance`
             The stage instance.
         """
@@ -2049,7 +2049,7 @@ class StageChannel(VocalGuildChannel):
             Editing the channel failed.
 
         Returns
-        --------
+        -------
         Optional[:class:`.StageChannel`]
             The newly edited stage channel. If the edit was only positional
             then ``None`` is returned instead.
@@ -2085,7 +2085,7 @@ class CategoryChannel(abc.GuildChannel, Hashable):
             Returns the category's name.
 
     Attributes
-    -----------
+    ----------
     name: :class:`str`
         The category name.
     guild: :class:`Guild`
@@ -2210,7 +2210,7 @@ class CategoryChannel(abc.GuildChannel, Hashable):
             Editing the category failed.
 
         Returns
-        --------
+        -------
         Optional[:class:`.CategoryChannel`]
             The newly edited category channel. If the edit was only positional
             then ``None`` is returned instead.
@@ -2418,13 +2418,13 @@ class DMChannel(abc.Messageable, abc.PrivateChannel, Hashable, PinsMixin):
         - :attr:`~Permissions.manage_messages`: You cannot delete others messages in a DM.
 
         Parameters
-        -----------
+        ----------
         obj: :class:`User`
             The user to check permissions for. This parameter is ignored
             but kept for compatibility with other ``permissions_for`` methods.
 
         Returns
-        --------
+        -------
         :class:`Permissions`
             The resolved permissions.
         """
@@ -2444,12 +2444,12 @@ class DMChannel(abc.Messageable, abc.PrivateChannel, Hashable, PinsMixin):
         .. versionadded:: 1.6
 
         Parameters
-        ------------
+        ----------
         message_id: :class:`int`
             The message ID to create a partial message for.
 
         Returns
-        ---------
+        -------
         :class:`PartialMessage`
             The partial message.
         """
@@ -2567,12 +2567,12 @@ class GroupChannel(abc.Messageable, abc.PrivateChannel, Hashable, PinsMixin):
         This also checks the kick_members permission if the user is the owner.
 
         Parameters
-        -----------
+        ----------
         obj: :class:`~abc.Snowflake`
             The user to check permissions for.
 
         Returns
-        --------
+        -------
         :class:`Permissions`
             The resolved permissions for the user.
         """
@@ -2629,7 +2629,7 @@ class PartialMessageable(abc.Messageable, Hashable):
             Returns the partial messageable's hash.
 
     Attributes
-    -----------
+    ----------
     id: :class:`int`
         The channel ID associated with this partial messageable.
     type: Optional[:class:`ChannelType`]
@@ -2652,12 +2652,12 @@ class PartialMessageable(abc.Messageable, Hashable):
         doing an unnecessary API call.
 
         Parameters
-        ------------
+        ----------
         message_id: :class:`int`
             The message ID to create a partial message for.
 
         Returns
-        ---------
+        -------
         :class:`PartialMessage`
             The partial message.
         """

--- a/nextcord/channel.py
+++ b/nextcord/channel.py
@@ -550,7 +550,7 @@ class TextChannel(abc.Messageable, abc.GuildChannel, Hashable, PinsMixin):
         Requires :attr:`~.Permissions.manage_webhooks` permissions.
 
         Raises
-        -------
+        ------
         Forbidden
             You don't have permissions to get the webhooks.
 

--- a/nextcord/channel.py
+++ b/nextcord/channel.py
@@ -451,7 +451,7 @@ class TextChannel(abc.Messageable, abc.GuildChannel, Hashable, PinsMixin):
         also needed to retrieve message history.
 
         Examples
-        ---------
+        --------
 
         Deleting bot's messages ::
 
@@ -483,7 +483,7 @@ class TextChannel(abc.Messageable, abc.GuildChannel, Hashable, PinsMixin):
             fall back to single delete if messages are older than two weeks.
 
         Raises
-        -------
+        ------
         Forbidden
             You do not have proper permissions to do the actions required.
         HTTPException
@@ -596,7 +596,7 @@ class TextChannel(abc.Messageable, abc.GuildChannel, Hashable, PinsMixin):
             The reason for creating this webhook. Shows up in the audit logs.
 
         Raises
-        -------
+        ------
         HTTPException
             Creating the webhook failed.
         Forbidden
@@ -640,7 +640,7 @@ class TextChannel(abc.Messageable, abc.GuildChannel, Hashable, PinsMixin):
             .. versionadded:: 1.4
 
         Raises
-        -------
+        ------
         HTTPException
             Following the channel failed.
         Forbidden
@@ -742,7 +742,7 @@ class TextChannel(abc.Messageable, abc.GuildChannel, Hashable, PinsMixin):
             The reason for creating a new thread. Shows up on the audit log.
 
         Raises
-        -------
+        ------
         Forbidden
             You do not have permissions to create a thread.
         HTTPException
@@ -1675,7 +1675,7 @@ class VoiceChannel(VocalGuildChannel, abc.Messageable):
         .. versionadded:: 2.1
 
         Examples
-        ---------
+        --------
 
         Deleting bot's messages ::
 
@@ -2596,7 +2596,7 @@ class GroupChannel(abc.Messageable, abc.PrivateChannel, Hashable, PinsMixin):
         If you are the only one in the group, this deletes it as well.
 
         Raises
-        -------
+        ------
         HTTPException
             Leaving the group failed.
         """

--- a/nextcord/client.py
+++ b/nextcord/client.py
@@ -679,7 +679,7 @@ class Client:
             invalid sharding payloads or bad tokens).
 
         Raises
-        -------
+        ------
         :exc:`.GatewayNotFound`
             If the gateway to connect to Discord is not found. Usually if this
             is thrown then there is a Discord API outage.
@@ -798,7 +798,7 @@ class Client:
         A shorthand coroutine for :meth:`login` + :meth:`connect`.
 
         Raises
-        -------
+        ------
         TypeError
             An unexpected keyword argument was received.
         """

--- a/nextcord/client.py
+++ b/nextcord/client.py
@@ -159,7 +159,7 @@ class Client:
     A number of options can be passed to the :class:`Client`.
 
     Parameters
-    -----------
+    ----------
     max_messages: Optional[:class:`int`]
         The maximum number of messages to store in the internal message cache.
         This defaults to ``1000``. Passing in ``None`` disables the message cache.
@@ -267,7 +267,7 @@ class Client:
 
 
     Attributes
-    -----------
+    ----------
     ws
         The websocket gateway the client is currently connected to. Could be ``None``.
     loop: :class:`asyncio.AbstractEventLoop`
@@ -618,7 +618,7 @@ class Client:
         .. versionadded:: 1.4
 
         Parameters
-        ------------
+        ----------
         shard_id: :class:`int`
             The shard ID that requested being IDENTIFY'd
         initial: :class:`bool`
@@ -637,7 +637,7 @@ class Client:
 
 
         Parameters
-        -----------
+        ----------
         token: :class:`str`
             The authentication token. Do not prefix this token with
             anything as the library will do it for you.
@@ -671,7 +671,7 @@ class Client:
         is not resumed until the WebSocket connection is terminated.
 
         Parameters
-        -----------
+        ----------
         reconnect: :class:`bool`
             If we should attempt reconnecting, either due to internet
             failure or a specific failure on Discord's part. Certain
@@ -944,12 +944,12 @@ class Client:
         """Returns a channel or thread with the given ID.
 
         Parameters
-        -----------
+        ----------
         id: :class:`int`
             The ID to search for.
 
         Returns
-        --------
+        -------
         Optional[Union[:class:`.abc.GuildChannel`, :class:`.Thread`, :class:`.abc.PrivateChannel`]]
             The returned channel or ``None`` if not found.
         """
@@ -966,14 +966,14 @@ class Client:
         .. versionadded:: 2.0
 
         Parameters
-        -----------
+        ----------
         id: :class:`int`
             The channel ID to create a partial messageable for.
         type: Optional[:class:`.ChannelType`]
             The underlying channel type for the partial messageable.
 
         Returns
-        --------
+        -------
         :class:`.PartialMessageable`
             The partial messageable
         """
@@ -985,12 +985,12 @@ class Client:
         .. versionadded:: 2.0
 
         Parameters
-        -----------
+        ----------
         id: :class:`int`
             The ID to search for.
 
         Returns
-        --------
+        -------
         Optional[:class:`.StageInstance`]
             The returns stage instance of ``None`` if not found.
         """
@@ -1005,12 +1005,12 @@ class Client:
         """Returns a guild with the given ID.
 
         Parameters
-        -----------
+        ----------
         id: :class:`int`
             The ID to search for.
 
         Returns
-        --------
+        -------
         Optional[:class:`.Guild`]
             The guild or ``None`` if not found.
         """
@@ -1020,12 +1020,12 @@ class Client:
         """Returns a user with the given ID.
 
         Parameters
-        -----------
+        ----------
         id: :class:`int`
             The ID to search for.
 
         Returns
-        --------
+        -------
         Optional[:class:`~nextcord.User`]
             The user or ``None`` if not found.
         """
@@ -1035,12 +1035,12 @@ class Client:
         """Returns an emoji with the given ID.
 
         Parameters
-        -----------
+        ----------
         id: :class:`int`
             The ID to search for.
 
         Returns
-        --------
+        -------
         Optional[:class:`.Emoji`]
             The custom emoji or ``None`` if not found.
         """
@@ -1057,7 +1057,7 @@ class Client:
             or :meth:`.fetch_premium_sticker_packs`.
 
         Returns
-        --------
+        -------
         Optional[:class:`.GuildSticker`]
             The sticker or ``None`` if not found.
         """
@@ -1069,12 +1069,12 @@ class Client:
         .. versionadded:: 2.0
 
         Parameters
-        -----------
+        ----------
         id: :class:`int`
             The scheduled event's ID to search for.
 
         Returns
-        --------
+        -------
         Optional[:class:`.ScheduledEvent`]
             The scheduled event or ``None`` if not found.
         """
@@ -1158,7 +1158,7 @@ class Client:
         This function returns the **first event that meets the requirements**.
 
         Examples
-        ---------
+        --------
 
         Waiting for a user reply: ::
 
@@ -1194,7 +1194,7 @@ class Client:
 
 
         Parameters
-        ------------
+        ----------
         event: :class:`str`
             The event name, similar to the :ref:`event reference <discord-api-events>`,
             but without the ``on_`` prefix, to wait for.
@@ -1206,12 +1206,12 @@ class Client:
             :exc:`asyncio.TimeoutError`.
 
         Raises
-        -------
+        ------
         asyncio.TimeoutError
             If a timeout is provided and it was reached.
 
         Returns
-        --------
+        -------
         Any
             Returns no arguments, a single argument, or a :class:`tuple` of multiple
             arguments that mirrors the parameters passed in the
@@ -1246,7 +1246,7 @@ class Client:
         The events must be a :ref:`coroutine <coroutine>`, if not, :exc:`TypeError` is raised.
 
         Example
-        ---------
+        -------
 
         .. code-block:: python3
 
@@ -1255,7 +1255,7 @@ class Client:
                 print('Ready!')
 
         Raises
-        --------
+        ------
         TypeError
             The coroutine passed is not actually a coroutine.
         """
@@ -1278,7 +1278,7 @@ class Client:
         Changes the client's presence.
 
         Example
-        ---------
+        -------
 
         .. code-block:: python3
 
@@ -1346,7 +1346,7 @@ class Client:
             This method is an API call. For general usage, consider :attr:`guilds` instead.
 
         Examples
-        ---------
+        --------
 
         Usage ::
 
@@ -1361,7 +1361,7 @@ class Client:
         All parameters are optional.
 
         Parameters
-        -----------
+        ----------
         limit: Optional[:class:`int`]
             The number of guilds to retrieve.
             If ``None``, it retrieves every guild you have access to. Note, however,
@@ -1386,7 +1386,7 @@ class Client:
             Getting the guilds failed.
 
         Yields
-        --------
+        ------
         :class:`.Guild`
             The guild with the guild data parsed.
         """
@@ -1398,19 +1398,19 @@ class Client:
         Gets a :class:`.Template` from a nextcord.new URL or code.
 
         Parameters
-        -----------
+        ----------
         code: Union[:class:`.Template`, :class:`str`]
             The Discord Template Code or URL (must be a nextcord.new URL).
 
         Raises
-        -------
+        ------
         :exc:`.NotFound`
             The template is invalid.
         :exc:`.HTTPException`
             Getting the template failed.
 
         Returns
-        --------
+        -------
         :class:`.Template`
             The template from the URL/code.
         """
@@ -1433,7 +1433,7 @@ class Client:
             This method is an API call. For general usage, consider :meth:`get_guild` instead.
 
         Parameters
-        -----------
+        ----------
         guild_id: :class:`int`
             The guild's ID to fetch from.
 
@@ -1452,7 +1452,7 @@ class Client:
             Getting the guild failed.
 
         Returns
-        --------
+        -------
         :class:`.Guild`
             The guild from the ID.
         """
@@ -1520,19 +1520,19 @@ class Client:
         .. versionadded:: 2.0
 
         Parameters
-        -----------
+        ----------
         channel_id: :class:`int`
             The stage channel ID.
 
         Raises
-        -------
+        ------
         :exc:`.NotFound`
             The stage instance or channel could not be found.
         :exc:`.HTTPException`
             Getting the stage instance failed.
 
         Returns
-        --------
+        -------
         :class:`.StageInstance`
             The stage instance from the stage channel ID.
         """
@@ -1556,7 +1556,7 @@ class Client:
             :class:`.PartialInviteChannel` respectively.
 
         Parameters
-        -----------
+        ----------
         url: Union[:class:`.Invite`, :class:`str`]
             The Discord invite ID or URL (must be a discord.gg URL).
         with_counts: :class:`bool`
@@ -1570,14 +1570,14 @@ class Client:
             .. versionadded:: 2.0
 
         Raises
-        -------
+        ------
         :exc:`.NotFound`
             The invite has expired or is invalid.
         :exc:`.HTTPException`
             Getting the invite failed.
 
         Returns
-        --------
+        -------
         :class:`.Invite`
             The invite from the URL/ID.
         """
@@ -1602,7 +1602,7 @@ class Client:
             The invite to revoke.
 
         Raises
-        -------
+        ------
         :exc:`.Forbidden`
             You do not have permissions to revoke invites.
         :exc:`.NotFound`
@@ -1626,19 +1626,19 @@ class Client:
             The guild must have the widget enabled to get this information.
 
         Parameters
-        -----------
+        ----------
         guild_id: :class:`int`
             The ID of the guild.
 
         Raises
-        -------
+        ------
         :exc:`.Forbidden`
             The widget for this guild is disabled.
         :exc:`.HTTPException`
             Retrieving the widget failed.
 
         Returns
-        --------
+        -------
         :class:`.Widget`
             The guild's widget.
         """
@@ -1652,12 +1652,12 @@ class Client:
         Retrieves the bot's application information.
 
         Raises
-        -------
+        ------
         :exc:`.HTTPException`
             Retrieving the information failed somehow.
 
         Returns
-        --------
+        -------
         :class:`.AppInfo`
             The bot's application information.
         """
@@ -1678,19 +1678,19 @@ class Client:
             This method is an API call. If you have :attr:`nextcord.Intents.members` and member cache enabled, consider :meth:`get_user` instead.
 
         Parameters
-        -----------
+        ----------
         user_id: :class:`int`
             The user's ID to fetch from.
 
         Raises
-        -------
+        ------
         :exc:`.NotFound`
             A user with this ID does not exist.
         :exc:`.HTTPException`
             Fetching the user failed.
 
         Returns
-        --------
+        -------
         :class:`~nextcord.User`
             The user you requested.
         """
@@ -1711,7 +1711,7 @@ class Client:
         .. versionadded:: 1.2
 
         Raises
-        -------
+        ------
         :exc:`.InvalidData`
             An unknown channel type was received from Discord.
         :exc:`.HTTPException`
@@ -1722,7 +1722,7 @@ class Client:
             You do not have permission to fetch this channel.
 
         Returns
-        --------
+        -------
         Union[:class:`.abc.GuildChannel`, :class:`.abc.PrivateChannel`, :class:`.Thread`]
             The channel from the ID.
         """
@@ -1750,7 +1750,7 @@ class Client:
         Retrieves a :class:`.Webhook` with the specified ID.
 
         Raises
-        --------
+        ------
         :exc:`.HTTPException`
             Retrieving the webhook failed.
         :exc:`.NotFound`
@@ -1759,7 +1759,7 @@ class Client:
             You do not have permission to fetch this webhook.
 
         Returns
-        ---------
+        -------
         :class:`.Webhook`
             The webhook you requested.
         """
@@ -1774,14 +1774,14 @@ class Client:
         .. versionadded:: 2.0
 
         Raises
-        --------
+        ------
         :exc:`.HTTPException`
             Retrieving the sticker failed.
         :exc:`.NotFound`
             Invalid sticker ID.
 
         Returns
-        --------
+        -------
         Union[:class:`.StandardSticker`, :class:`.GuildSticker`]
             The sticker you requested.
         """
@@ -1797,12 +1797,12 @@ class Client:
         .. versionadded:: 2.0
 
         Raises
-        -------
+        ------
         :exc:`.HTTPException`
             Retrieving the sticker packs failed.
 
         Returns
-        ---------
+        -------
         List[:class:`.StickerPack`]
             All available premium sticker packs.
         """
@@ -1820,7 +1820,7 @@ class Client:
         .. versionadded:: 2.0
 
         Parameters
-        -----------
+        ----------
         user: :class:`~nextcord.abc.Snowflake`
             The user to create a DM with.
 
@@ -1846,7 +1846,7 @@ class Client:
         .. versionadded:: 2.0
 
         Parameters
-        ------------
+        ----------
         view: :class:`nextcord.ui.View`
             The view to register for dispatching.
         message_id: Optional[:class:`int`]
@@ -1855,7 +1855,7 @@ class Client:
             then message update events are not propagated for the view.
 
         Raises
-        -------
+        ------
         TypeError
             A view was not passed.
         ValueError
@@ -1881,7 +1881,7 @@ class Client:
         depend on particular criteria.
 
         Parameters
-        ------------
+        ----------
         modal: :class:`nextcord.ui.Modal`
             The view to register for dispatching.
         user_id: Optional[:class:`int`]
@@ -1889,7 +1889,7 @@ class Client:
             the modal calls based on the users.
 
         Raises
-        -------
+        ------
         TypeError
             A modal was not passed.
         ValueError

--- a/nextcord/colour.py
+++ b/nextcord/colour.py
@@ -63,7 +63,7 @@ class Colour:
              Returns the raw colour value.
 
     Attributes
-    ------------
+    ----------
     value: :class:`int`
         The raw integer colour value.
     """
@@ -146,7 +146,7 @@ class Colour:
         .. versionadded:: 1.6
 
         Parameters
-        ------------
+        ----------
         seed: Optional[Union[:class:`int`, :class:`str`, :class:`float`, :class:`bytes`, :class:`bytearray`]]
             The seed to initialize the RNG with. If ``None`` is passed the default RNG is used.
 

--- a/nextcord/components.py
+++ b/nextcord/components.py
@@ -68,7 +68,7 @@ class Component:
     .. versionadded:: 2.0
 
     Attributes
-    ------------
+    ----------
     type: :class:`ComponentType`
         The type of component.
     """
@@ -108,7 +108,7 @@ class ActionRow(Component):
     .. versionadded:: 2.0
 
     Attributes
-    ------------
+    ----------
     type: :class:`ComponentType`
         The type of component.
     children: List[:class:`Component`]
@@ -143,7 +143,7 @@ class Button(Component):
     .. versionadded:: 2.0
 
     Attributes
-    -----------
+    ----------
     style: :class:`.ButtonStyle`
         The style of the button.
     custom_id: Optional[:class:`str`]
@@ -216,7 +216,7 @@ class SelectMenu(Component):
     .. versionadded:: 2.0
 
     Attributes
-    ------------
+    ----------
     custom_id: Optional[:class:`str`]
         The ID of the select menu that gets received during an interaction.
     placeholder: Optional[:class:`str`]
@@ -279,7 +279,7 @@ class SelectOption:
     .. versionadded:: 2.0
 
     Attributes
-    -----------
+    ----------
     label: :class:`str`
         The label of the option. This is displayed to users.
         Can only be up to 100 characters.

--- a/nextcord/embeds.py
+++ b/nextcord/embeds.py
@@ -118,7 +118,7 @@ class Embed:
             This also means that you can no longer use ``len()`` on an empty field.
 
     Attributes
-    -----------
+    ----------
     title: :class:`str`
         The title of the embed.
         This can be set during initialisation.
@@ -211,7 +211,7 @@ class Embed:
         __ DiscordDocs_
 
         Parameters
-        -----------
+        ----------
         data: :class:`dict`
             The dictionary to convert into an embed.
         """
@@ -350,7 +350,7 @@ class Embed:
         chaining.
 
         Parameters
-        -----------
+        ----------
         text: Optional[:class:`str`]
             The footer text.
         icon_url: Optional[:class:`str`]
@@ -406,7 +406,7 @@ class Embed:
             Passing ``None`` removes the image.
 
         Parameters
-        -----------
+        ----------
         url: Optional[:class:`str`]
             The source URL for the image. Only HTTP(S) is supported.
         """
@@ -448,7 +448,7 @@ class Embed:
             Passing ``None`` removes the thumbnail.
 
         Parameters
-        -----------
+        ----------
         url: :class:`str`
             The source URL for the thumbnail. Only HTTP(S) is supported.
         """
@@ -512,7 +512,7 @@ class Embed:
         chaining.
 
         Parameters
-        -----------
+        ----------
         name: Optional[:class:`str`]
             The name of the author.
         url: Optional[:class:`str`]
@@ -565,7 +565,7 @@ class Embed:
         chaining.
 
         Parameters
-        -----------
+        ----------
         name: :class:`str`
             The name of the field.
         value: :class:`str`
@@ -596,7 +596,7 @@ class Embed:
         .. versionadded:: 1.2
 
         Parameters
-        -----------
+        ----------
         index: :class:`int`
             The index of where to insert the field.
         name: :class:`str`
@@ -648,7 +648,7 @@ class Embed:
             shift to fill the gap just like a regular list.
 
         Parameters
-        -----------
+        ----------
         index: :class:`int`
             The index of the field to remove.
         """
@@ -668,7 +668,7 @@ class Embed:
         chaining.
 
         Parameters
-        -----------
+        ----------
         index: :class:`int`
             The index of the field to modify.
         name: :class:`str`
@@ -679,7 +679,7 @@ class Embed:
             Whether the field should be displayed inline.
 
         Raises
-        -------
+        ------
         IndexError
             An invalid index was provided.
         """

--- a/nextcord/emoji.py
+++ b/nextcord/emoji.py
@@ -73,7 +73,7 @@ class Emoji(_EmojiTag, AssetMixin):
             Returns the emoji rendered for discord.
 
     Attributes
-    -----------
+    ----------
     name: :class:`str`
         The name of the emoji.
     id: :class:`int`
@@ -198,12 +198,12 @@ class Emoji(_EmojiTag, AssetMixin):
         do this.
 
         Parameters
-        -----------
+        ----------
         reason: Optional[:class:`str`]
             The reason for deleting this emoji. Shows up on the audit log.
 
         Raises
-        -------
+        ------
         Forbidden
             You are not allowed to delete emojis.
         HTTPException
@@ -226,7 +226,7 @@ class Emoji(_EmojiTag, AssetMixin):
             The newly updated emoji is returned.
 
         Parameters
-        -----------
+        ----------
         name: :class:`str`
             The new emoji name.
         roles: Optional[List[:class:`~nextcord.abc.Snowflake`]]
@@ -235,14 +235,14 @@ class Emoji(_EmojiTag, AssetMixin):
             The reason for editing this emoji. Shows up on the audit log.
 
         Raises
-        -------
+        ------
         Forbidden
             You are not allowed to edit emojis.
         HTTPException
             An error occurred editing the emoji.
 
         Returns
-        --------
+        -------
         :class:`Emoji`
             The newly updated emoji.
         """

--- a/nextcord/errors.py
+++ b/nextcord/errors.py
@@ -114,7 +114,7 @@ class HTTPException(DiscordException):
     """Exception that's raised when an HTTP request operation fails.
 
     Attributes
-    ------------
+    ----------
     response: :class:`aiohttp.ClientResponse`
         The response of the failed HTTP request. This is an
         instance of :class:`aiohttp.ClientResponse`. In some cases
@@ -217,7 +217,7 @@ class ConnectionClosed(ClientException):
     closed for reasons that could not be handled internally.
 
     Attributes
-    -----------
+    ----------
     code: :class:`int`
         The close code of the websocket.
     reason: :class:`str`
@@ -253,7 +253,7 @@ class PrivilegedIntentsRequired(ClientException):
     - :attr:`Intents.presences`
 
     Attributes
-    -----------
+    ----------
     shard_id: Optional[:class:`int`]
         The shard ID that got closed if applicable.
     """
@@ -278,7 +278,7 @@ class InteractionResponded(ClientException):
     .. versionadded:: 2.0
 
     Attributes
-    -----------
+    ----------
     interaction: :class:`Interaction`
         The interaction that's already been responded to.
     """
@@ -313,7 +313,7 @@ class ApplicationInvokeError(ApplicationError):
     This inherits from :exc:`ApplicationError`
 
     Attributes
-    -----------
+    ----------
     original: :exc:`Exception`
         The original exception that was raised. You can also get this via
         the ``__cause__`` attribute.

--- a/nextcord/ext/application_checks/core.py
+++ b/nextcord/ext/application_checks/core.py
@@ -179,7 +179,7 @@ def check(predicate: "ApplicationCheck") -> AC:
             await interaction.response.send_message('Only you!')
 
     Parameters
-    -----------
+    ----------
     predicate: Callable[[:class:`~.Interaction`], :class:`bool`]
         The predicate to check if the command should be invoked.
     """
@@ -203,7 +203,7 @@ def check_any(*checks: "ApplicationCheck") -> AC:
         The ``predicate`` attribute for this function **is** a coroutine.
 
     Parameters
-    ------------
+    ----------
     \*checks: Callable[[:class:`~.Interaction`], :class:`bool`]
         An argument list of checks that have been decorated with
         the :func:`check` decorator.
@@ -282,7 +282,7 @@ def has_role(item: Union[int, str]) -> AC:
     Both inherit from :exc:`.ApplicationCheckFailure`.
 
     Parameters
-    -----------
+    ----------
     item: Union[:class:`int`, :class:`str`]
         The name or ID of the role to check.
 
@@ -325,7 +325,7 @@ def has_any_role(*items: Union[int, str]) -> AC:
     Both inherit from :exc:`.ApplicationCheckFailure`.
 
     Parameters
-    -----------
+    ----------
     items: List[Union[:class:`str`, :class:`int`]]
         An argument list of names or IDs to check that the member has roles wise.
 
@@ -366,7 +366,7 @@ def bot_has_role(item: Union[int, str]) -> AC:
     Both inherit from :exc:`.ApplicationCheckFailure`.
 
     Parameters
-    -----------
+    ----------
     item: Union[:class:`int`, :class:`str`]
         The name or ID of the role to check.
 
@@ -407,7 +407,7 @@ def bot_has_any_role(*items: Union[str, int]) -> AC:
     Both inherit from :exc:`.ApplicationCheckFailure`.
 
     Parameters
-    -----------
+    ----------
     *items: Union[:class:`str`, :class:`int`]
         An argument list of names or IDs to check that the bot has roles wise.
 
@@ -454,7 +454,7 @@ def has_permissions(**perms: bool) -> AC:
     exception, :exc:`.ApplicationNoPrivateMessage`.
 
     Parameters
-    ------------
+    ----------
     perms: :class:`bool`
         An argument list of permissions to check for.
 
@@ -533,7 +533,7 @@ def has_guild_permissions(**perms: bool) -> AC:
     exception, :exc:`.ApplicationNoPrivateMessage`.
 
     Parameters
-    -----------
+    ----------
     perms: :class:`bool`
         An argument list of guild permissions to check for.
 

--- a/nextcord/ext/application_checks/core.py
+++ b/nextcord/ext/application_checks/core.py
@@ -150,7 +150,7 @@ def check(predicate: "ApplicationCheck") -> AC:
         even if the original function was not a coroutine.
 
     Examples
-    ---------
+    --------
 
     Creating a basic check to see if the command invoker is you.
 
@@ -209,13 +209,13 @@ def check_any(*checks: "ApplicationCheck") -> AC:
         the :func:`check` decorator.
 
     Raises
-    -------
+    ------
     TypeError
         A check passed has not been decorated with the :func:`check`
         decorator.
 
     Examples
-    ---------
+    --------
 
     Creating a basic check to see if it's the bot owner or
     the server owner:
@@ -287,7 +287,7 @@ def has_role(item: Union[int, str]) -> AC:
         The name or ID of the role to check.
 
     Example
-    --------
+    -------
 
     .. code-block:: python3
 
@@ -330,7 +330,7 @@ def has_any_role(*items: Union[int, str]) -> AC:
         An argument list of names or IDs to check that the member has roles wise.
 
     Example
-    --------
+    -------
 
     .. code-block:: python3
 
@@ -371,7 +371,7 @@ def bot_has_role(item: Union[int, str]) -> AC:
         The name or ID of the role to check.
 
     Example
-    --------
+    -------
 
     .. code-block:: python3
 
@@ -412,7 +412,7 @@ def bot_has_any_role(*items: Union[str, int]) -> AC:
         An argument list of names or IDs to check that the bot has roles wise.
 
     Example
-    --------
+    -------
 
     .. code-block:: python3
 
@@ -459,7 +459,7 @@ def has_permissions(**perms: bool) -> AC:
         An argument list of permissions to check for.
 
     Example
-    ---------
+    -------
 
     .. code-block:: python3
 
@@ -538,7 +538,7 @@ def has_guild_permissions(**perms: bool) -> AC:
         An argument list of guild permissions to check for.
 
     Example
-    --------
+    -------
 
     .. code-block:: python3
 
@@ -600,7 +600,7 @@ def dm_only() -> AC:
     that is inherited from :exc:`.ApplicationCheckFailure`.
 
     Example
-    --------
+    -------
 
     .. code-block:: python3
 
@@ -627,7 +627,7 @@ def guild_only() -> AC:
     that is inherited from :exc:`.ApplicationCheckFailure`.
 
     Example
-    --------
+    -------
 
     .. code-block:: python3
 
@@ -658,7 +658,7 @@ def is_owner() -> AC:
     raise :exc:`.ApplicationCheckForBotOnly`.
 
     Example
-    --------
+    -------
 
     .. code-block:: python3
 
@@ -688,7 +688,7 @@ def is_nsfw() -> AC:
     that is derived from :exc:`.ApplicationCheckFailure`.
 
     Example
-    --------
+    -------
 
     .. code-block:: python3
 
@@ -716,7 +716,7 @@ def application_command_before_invoke(coro) -> AC:
     do not have to be within the same cog.
 
     Example
-    ---------
+    -------
 
     .. code-block:: python3
 

--- a/nextcord/ext/application_checks/errors.py
+++ b/nextcord/ext/application_checks/errors.py
@@ -52,7 +52,7 @@ class ApplicationCheckAnyFailure(ApplicationCheckFailure):
     This inherits from :exc:`~.ApplicationCheckFailure`.
 
     Attributes
-    ------------
+    ----------
     errors: List[:class:`~.ApplicationCheckFailure`]
         A list of errors that were caught during execution.
     checks: List[Callable[[:class:`~.Interaction`], :class:`bool`]]
@@ -88,7 +88,7 @@ class ApplicationMissingRole(ApplicationCheckFailure):
     .. versionadded:: 1.1
 
     Attributes
-    -----------
+    ----------
     missing_role: Union[:class:`str`, :class:`int`]
         The required role that is missing.
         This is the parameter passed to :func:`~.application_checks.has_role`.
@@ -107,7 +107,7 @@ class ApplicationMissingAnyRole(ApplicationCheckFailure):
     This inherits from :exc:`~.ApplicationCheckFailure`
 
     Attributes
-    -----------
+    ----------
     missing_roles: List[Union[:class:`str`, :class:`int`]]
         The roles that the invoker is missing.
         These are the parameters passed to :func:`has_any_role`.
@@ -135,7 +135,7 @@ class ApplicationBotMissingRole(ApplicationCheckFailure):
     .. versionadded:: 1.1
 
     Attributes
-    -----------
+    ----------
     missing_role: Union[:class:`str`, :class:`int`]
         The required role that is missing.
         This is the parameter passed to :func:`has_role`.
@@ -156,7 +156,7 @@ class ApplicationBotMissingAnyRole(ApplicationCheckFailure):
     .. versionadded:: 1.1
 
     Attributes
-    -----------
+    ----------
     missing_roles: List[Union[:class:`str`, :class:`int`]]
         The roles that the bot's member is missing.
         These are the parameters passed to :func:`has_any_role`.
@@ -184,7 +184,7 @@ class ApplicationMissingPermissions(ApplicationCheckFailure):
     This inherits from :exc:`~.ApplicationCheckFailure`
 
     Attributes
-    -----------
+    ----------
     missing_permissions: List[:class:`str`]
         The required permissions that are missing.
     """
@@ -212,7 +212,7 @@ class ApplicationBotMissingPermissions(ApplicationCheckFailure):
     This inherits from :exc:`~.ApplicationCheckFailure`
 
     Attributes
-    -----------
+    ----------
     missing_permissions: List[:class:`str`]
         The required permissions that are missing.
     """
@@ -259,7 +259,7 @@ class ApplicationNSFWChannelRequired(ApplicationCheckFailure):
     This inherits from :exc:`~.ApplicationCheckFailure`.
 
     Parameters
-    -----------
+    ----------
     channel: Optional[Union[:class:`.abc.GuildChannel`, :class:`.Thread`, :class:`PartialMessageable`]]
         The channel that does not have NSFW enabled.
     """

--- a/nextcord/ext/commands/bot.py
+++ b/nextcord/ext/commands/bot.py
@@ -107,7 +107,7 @@ def when_mentioned_or(*prefixes: str) -> Callable[[Union[Bot, AutoShardedBot], M
     These are meant to be passed into the :attr:`.Bot.command_prefix` attribute.
 
     Example
-    --------
+    -------
 
     .. code-block:: python3
 
@@ -127,7 +127,7 @@ def when_mentioned_or(*prefixes: str) -> Callable[[Union[Bot, AutoShardedBot], M
 
 
     See Also
-    ----------
+    --------
     :func:`.when_mentioned`
     """
 
@@ -304,7 +304,7 @@ class BotBase(GroupMixin):
         :exc:`.CommandError`.
 
         Example
-        ---------
+        -------
 
         .. code-block:: python3
 
@@ -384,7 +384,7 @@ class BotBase(GroupMixin):
         :exc:`.CommandError`.
 
         Example
-        ---------
+        -------
 
         .. code-block:: python3
 
@@ -423,7 +423,7 @@ class BotBase(GroupMixin):
             The user to check for.
 
         Returns
-        --------
+        -------
         :class:`bool`
             Whether the user is the owner.
         """
@@ -464,7 +464,7 @@ class BotBase(GroupMixin):
             The coroutine to register as the pre-invoke hook.
 
         Raises
-        -------
+        ------
         TypeError
             The coroutine passed is not actually a coroutine.
         """
@@ -497,7 +497,7 @@ class BotBase(GroupMixin):
             The coroutine to register as the post-invoke hook.
 
         Raises
-        -------
+        ------
         TypeError
             The coroutine passed is not actually a coroutine.
         """
@@ -520,7 +520,7 @@ class BotBase(GroupMixin):
             The name of the event to listen for. Defaults to ``func.__name__``.
 
         Example
-        --------
+        -------
 
         .. code-block:: python3
 
@@ -569,7 +569,7 @@ class BotBase(GroupMixin):
         The functions being listened to must be a :ref:`coroutine <coroutine>`.
 
         Example
-        --------
+        -------
 
         .. code-block:: python3
 
@@ -586,7 +586,7 @@ class BotBase(GroupMixin):
         Would print one and two in an unspecified order.
 
         Raises
-        -------
+        ------
         TypeError
             The function being listened to is not a coroutine.
         """
@@ -620,7 +620,7 @@ class BotBase(GroupMixin):
             .. versionadded:: 2.0
 
         Raises
-        -------
+        ------
         TypeError
             The cog does not inherit from :class:`.Cog`.
         CommandError
@@ -664,7 +664,7 @@ class BotBase(GroupMixin):
             argument in class creation or the class name if unspecified.
 
         Returns
-        --------
+        -------
         Optional[:class:`Cog`]
             The cog that was requested. If not found, returns ``None``.
         """
@@ -861,7 +861,7 @@ class BotBase(GroupMixin):
             .. versionadded:: 2.0.0
 
         Raises
-        --------
+        ------
         ExtensionNotFound
             The extension could not be imported.
             This is also raised if the name of the extension could not
@@ -912,7 +912,7 @@ class BotBase(GroupMixin):
             .. versionadded:: 1.7
 
         Raises
-        -------
+        ------
         ExtensionNotFound
             The name of the extension could not
             be resolved using the provided ``package`` parameter.
@@ -950,7 +950,7 @@ class BotBase(GroupMixin):
             .. versionadded:: 1.7
 
         Raises
-        -------
+        ------
         ExtensionNotLoaded
             The extension was not loaded.
         ExtensionNotFound
@@ -1256,7 +1256,7 @@ class BotBase(GroupMixin):
             The message context to get the prefix of.
 
         Returns
-        --------
+        -------
         Union[List[:class:`str`], :class:`str`]
             A list of prefixes or a single prefix that the bot is
             listening for.
@@ -1308,7 +1308,7 @@ class BotBase(GroupMixin):
             interface.
 
         Returns
-        --------
+        -------
         :class:`.Context`
             The invocation context. The type of this can change via the
             ``cls`` parameter.
@@ -1468,7 +1468,7 @@ class BotBase(GroupMixin):
         :exc:`.ApplicationError`.
 
         Example
-        ---------
+        -------
 
         .. code-block:: python3
 
@@ -1500,7 +1500,7 @@ class BotBase(GroupMixin):
             The coroutine to register as the pre-invoke hook.
 
         Raises
-        -------
+        ------
         TypeError
             The coroutine passed is not actually a coroutine.
         """
@@ -1533,7 +1533,7 @@ class BotBase(GroupMixin):
             The coroutine to register as the post-invoke hook.
 
         Raises
-        -------
+        ------
         TypeError
             The coroutine passed is not actually a coroutine.
         """

--- a/nextcord/ext/commands/bot.py
+++ b/nextcord/ext/commands/bot.py
@@ -324,7 +324,7 @@ class BotBase(GroupMixin):
         and :meth:`.check_once`.
 
         Parameters
-        -----------
+        ----------
         func
             The function that was used as a global check.
         call_once: :class:`bool`
@@ -344,7 +344,7 @@ class BotBase(GroupMixin):
         if the function is not in the global checks.
 
         Parameters
-        -----------
+        ----------
         func
             The function to remove from the global checks.
         call_once: :class:`bool`
@@ -418,7 +418,7 @@ class BotBase(GroupMixin):
             :attr:`owner_ids` is not set.
 
         Parameters
-        -----------
+        ----------
         user: :class:`.abc.User`
             The user to check for.
 
@@ -459,7 +459,7 @@ class BotBase(GroupMixin):
             then the hooks are not called.
 
         Parameters
-        -----------
+        ----------
         coro: :ref:`coroutine <coroutine>`
             The coroutine to register as the pre-invoke hook.
 
@@ -492,7 +492,7 @@ class BotBase(GroupMixin):
             This makes it ideal for clean-up scenarios.
 
         Parameters
-        -----------
+        ----------
         coro: :ref:`coroutine <coroutine>`
             The coroutine to register as the post-invoke hook.
 
@@ -513,7 +513,7 @@ class BotBase(GroupMixin):
         """The non decorator alternative to :meth:`.listen`.
 
         Parameters
-        -----------
+        ----------
         func: :ref:`coroutine <coroutine>`
             The function to call.
         name: :class:`str`
@@ -545,7 +545,7 @@ class BotBase(GroupMixin):
         """Removes a listener from the pool of listeners.
 
         Parameters
-        -----------
+        ----------
         func
             The function that was used as a listener to remove.
         name: :class:`str`
@@ -610,7 +610,7 @@ class BotBase(GroupMixin):
             is already loaded.
 
         Parameters
-        -----------
+        ----------
         cog: :class:`.Cog`
             The cog to register to the bot.
         override: :class:`bool`
@@ -657,7 +657,7 @@ class BotBase(GroupMixin):
         If the cog is not found, ``None`` is returned instead.
 
         Parameters
-        -----------
+        ----------
         name: :class:`str`
             The name of the cog you are requesting.
             This is equivalent to the name passed via keyword
@@ -679,7 +679,7 @@ class BotBase(GroupMixin):
         If no cog is found then this method has no effect.
 
         Parameters
-        -----------
+        ----------
         name: :class:`str`
             The name of the cog to remove.
 
@@ -825,7 +825,7 @@ class BotBase(GroupMixin):
         point must have a single argument, the ``bot``.
 
         Parameters
-        ------------
+        ----------
         name: :class:`str`
             The extension name to load. It must be dot separated like
             regular Python imports if accessing a sub-module. e.g.
@@ -899,7 +899,7 @@ class BotBase(GroupMixin):
         :meth:`~.Bot.load_extension`.
 
         Parameters
-        ------------
+        ----------
         name: :class:`str`
             The extension name to unload. It must be dot separated like
             regular Python imports if accessing a sub-module. e.g.
@@ -937,7 +937,7 @@ class BotBase(GroupMixin):
         the bot will roll-back to the prior working state.
 
         Parameters
-        ------------
+        ----------
         name: :class:`str`
             The extension name to reload. It must be dot separated like
             regular Python imports if accessing a sub-module. e.g.
@@ -1251,7 +1251,7 @@ class BotBase(GroupMixin):
         with the message as a context.
 
         Parameters
-        -----------
+        ----------
         message: :class:`nextcord.Message`
             The message context to get the prefix of.
 
@@ -1298,7 +1298,7 @@ class BotBase(GroupMixin):
         invoked under :meth:`~.Bot.invoke`.
 
         Parameters
-        -----------
+        ----------
         message: :class:`nextcord.Message`
             The message to get the invocation context from.
         cls
@@ -1371,7 +1371,7 @@ class BotBase(GroupMixin):
         handles all the internal event dispatch mechanisms.
 
         Parameters
-        -----------
+        ----------
         ctx: :class:`.Context`
             The invocation context to invoke.
         """
@@ -1408,7 +1408,7 @@ class BotBase(GroupMixin):
         call :meth:`~.Bot.get_context` or :meth:`~.Bot.invoke` if so.
 
         Parameters
-        -----------
+        ----------
         message: :class:`nextcord.Message`
             The message to process commands for.
         """
@@ -1428,7 +1428,7 @@ class BotBase(GroupMixin):
         and :meth:`.check_once`.
 
         Parameters
-        -----------
+        ----------
         func: Callable[[:class:`Interaction`], MaybeCoro[bool]]]
             The function that was used as a global application check.
         """
@@ -1442,7 +1442,7 @@ class BotBase(GroupMixin):
         if the function is not in the global checks.
 
         Parameters
-        -----------
+        ----------
         func: Callable[[:class:`Interaction`], MaybeCoro[bool]]]
             The function to remove from the global application checks.
         """
@@ -1495,7 +1495,7 @@ class BotBase(GroupMixin):
             are not called.
 
         Parameters
-        -----------
+        ----------
         coro: :ref:`coroutine <coroutine>`
             The coroutine to register as the pre-invoke hook.
 
@@ -1528,7 +1528,7 @@ class BotBase(GroupMixin):
             This makes it ideal for clean-up scenarios.
 
         Parameters
-        -----------
+        ----------
         coro: :ref:`coroutine`
             The coroutine to register as the post-invoke hook.
 
@@ -1555,7 +1555,7 @@ class Bot(BotBase, nextcord.Client):
     to manage commands.
 
     Attributes
-    -----------
+    ----------
     command_prefix
         The command prefix is what the message content must contain initially
         to have a command invoked. This prefix could either be a string to

--- a/nextcord/ext/commands/cog.py
+++ b/nextcord/ext/commands/cog.py
@@ -241,7 +241,7 @@ class Cog(ClientCog, metaclass=CogMeta):
     def get_commands(self) -> List[Command]:
         r"""
         Returns
-        --------
+        -------
         List[:class:`.Command`]
             A :class:`list` of :class:`.Command`\s that are
             defined inside this cog.
@@ -286,7 +286,7 @@ class Cog(ClientCog, metaclass=CogMeta):
         """Returns a :class:`list` of (name, function) listener pairs that are defined in this cog.
 
         Returns
-        --------
+        -------
         List[Tuple[:class:`str`, :ref:`coroutine <coroutine>`]]
             The listeners defined in this cog.
         """
@@ -305,7 +305,7 @@ class Cog(ClientCog, metaclass=CogMeta):
             defaults to the function's name.
 
         Raises
-        --------
+        ------
         TypeError
             The function is not a coroutine function or a string was not passed as
             the name.

--- a/nextcord/ext/commands/cog.py
+++ b/nextcord/ext/commands/cog.py
@@ -95,7 +95,7 @@ class CogMeta(type):
                 pass
 
     Attributes
-    -----------
+    ----------
     name: :class:`str`
         The cog name. By default, it is the name of the class with no modification.
     description: :class:`str`
@@ -299,7 +299,7 @@ class Cog(ClientCog, metaclass=CogMeta):
         This is the cog equivalent of :meth:`.Bot.listen`.
 
         Parameters
-        ------------
+        ----------
         name: :class:`str`
             The name of the event being listened to. If not provided, it
             defaults to the function's name.
@@ -395,7 +395,7 @@ class Cog(ClientCog, metaclass=CogMeta):
         This **must** be a coroutine.
 
         Parameters
-        -----------
+        ----------
         ctx: :class:`.Context`
             The invocation context where the error happened.
         error: :class:`CommandError`
@@ -412,7 +412,7 @@ class Cog(ClientCog, metaclass=CogMeta):
         This **must** be a coroutine.
 
         Parameters
-        -----------
+        ----------
         ctx: :class:`.Context`
             The invocation context.
         """
@@ -427,7 +427,7 @@ class Cog(ClientCog, metaclass=CogMeta):
         This **must** be a coroutine.
 
         Parameters
-        -----------
+        ----------
         ctx: :class:`.Context`
             The invocation context.
         """

--- a/nextcord/ext/commands/context.py
+++ b/nextcord/ext/commands/context.py
@@ -177,7 +177,7 @@ class Context(nextcord.abc.Messageable, Generic[BotT]):
             The keyword arguments to use.
 
         Raises
-        -------
+        ------
         TypeError
             The command argument to invoke is missing.
         """
@@ -209,7 +209,7 @@ class Context(nextcord.abc.Messageable, Generic[BotT]):
             The default is to start where we left off.
 
         Raises
-        -------
+        ------
         ValueError
             The context to reinvoke is not valid.
         """
@@ -337,7 +337,7 @@ class Context(nextcord.abc.Messageable, Generic[BotT]):
             The entity to show help for.
 
         Returns
-        --------
+        -------
         Any
             The result of the help command, if any.
         """

--- a/nextcord/ext/commands/context.py
+++ b/nextcord/ext/commands/context.py
@@ -72,7 +72,7 @@ class Context(nextcord.abc.Messageable, Generic[BotT]):
     This class implements the :class:`~nextcord.abc.Messageable` ABC.
 
     Attributes
-    -----------
+    ----------
     message: :class:`.Message`
         The message that triggered the command being executed.
     bot: :class:`.Bot`
@@ -168,7 +168,7 @@ class Context(nextcord.abc.Messageable, Generic[BotT]):
             using this function.
 
         Parameters
-        -----------
+        ----------
         command: :class:`.Command`
             The command that is going to be called.
         \*args
@@ -200,7 +200,7 @@ class Context(nextcord.abc.Messageable, Generic[BotT]):
             fail again.
 
         Parameters
-        ------------
+        ----------
         call_hooks: :class:`bool`
             Whether to call the before and after invoke hooks.
         restart: :class:`bool`
@@ -332,7 +332,7 @@ class Context(nextcord.abc.Messageable, Generic[BotT]):
             this returns :class:`None` on bad input or no help command.
 
         Parameters
-        ------------
+        ----------
         entity: Optional[Union[:class:`Command`, :class:`Cog`, :class:`str`]]
             The entity to show help for.
 

--- a/nextcord/ext/commands/converter.py
+++ b/nextcord/ext/commands/converter.py
@@ -125,7 +125,7 @@ class Converter(Protocol[T_co]):
         properly propagate to the error handlers.
 
         Parameters
-        -----------
+        ----------
         ctx: :class:`.Context`
             The invocation context that the argument is being used in.
         argument: :class:`str`
@@ -951,7 +951,7 @@ class clean_content(Converter[str]):
     This behaves similarly to :attr:`~nextcord.Message.clean_content`.
 
     Attributes
-    ------------
+    ----------
     fix_channel_mentions: :class:`bool`
         Whether to clean channel mentions.
     use_nicknames: :class:`bool`
@@ -1190,7 +1190,7 @@ async def run_converters(ctx: Context, converter, argument: str, param: inspect.
     .. versionadded:: 2.0
 
     Parameters
-    ------------
+    ----------
     ctx: :class:`Context`
         The invocation context to run the converters under.
     converter: Any

--- a/nextcord/ext/commands/converter.py
+++ b/nextcord/ext/commands/converter.py
@@ -132,7 +132,7 @@ class Converter(Protocol[T_co]):
             The argument that is being converted.
 
         Raises
-        -------
+        ------
         :exc:`.CommandError`
             A generic exception occurred when converting the argument.
         :exc:`.BadArgument`
@@ -1201,12 +1201,12 @@ async def run_converters(ctx: Context, converter, argument: str, param: inspect.
         The parameter being converted. This is mainly for error reporting.
 
     Raises
-    -------
+    ------
     CommandError
         The converter failed to convert.
 
     Returns
-    --------
+    -------
     Any
         The resulting conversion.
     """

--- a/nextcord/ext/commands/cooldowns.py
+++ b/nextcord/ext/commands/cooldowns.py
@@ -84,7 +84,7 @@ class Cooldown:
     """Represents a cooldown for a command.
 
     Attributes
-    -----------
+    ----------
     rate: :class:`int`
         The total number of tokens available per :attr:`per` seconds.
     per: :class:`float`
@@ -104,7 +104,7 @@ class Cooldown:
         """Returns the number of available tokens before rate limiting is applied.
 
         Parameters
-        ------------
+        ----------
         current: Optional[:class:`float`]
             The time in seconds since Unix epoch to calculate tokens at.
             If not supplied then :func:`time.time()` is used.
@@ -127,7 +127,7 @@ class Cooldown:
         """Returns the time in seconds until the cooldown will be reset.
 
         Parameters
-        -------------
+        ----------
         current: Optional[:class:`float`]
             The current time in seconds since Unix epoch.
             If not supplied, then :func:`time.time()` is used.
@@ -149,7 +149,7 @@ class Cooldown:
         """Updates the cooldown rate limit.
 
         Parameters
-        -------------
+        ----------
         current: Optional[:class:`float`]
             The time in seconds since Unix epoch to update the rate limit at.
             If not supplied, then :func:`time.time()` is used.

--- a/nextcord/ext/commands/cooldowns.py
+++ b/nextcord/ext/commands/cooldowns.py
@@ -110,7 +110,7 @@ class Cooldown:
             If not supplied then :func:`time.time()` is used.
 
         Returns
-        --------
+        -------
         :class:`int`
             The number of tokens available before the cooldown is to be applied.
         """
@@ -184,7 +184,7 @@ class Cooldown:
         """Creates a copy of this cooldown.
 
         Returns
-        --------
+        -------
         :class:`Cooldown`
             A new instance of this cooldown.
         """

--- a/nextcord/ext/commands/core.py
+++ b/nextcord/ext/commands/core.py
@@ -536,7 +536,7 @@ class Command(_BaseCommand, Generic[CogT, P, T]):
         """Creates a copy of this command.
 
         Returns
-        --------
+        -------
         :class:`Command`
             A new instance of this command.
         """
@@ -888,7 +888,7 @@ class Command(_BaseCommand, Generic[CogT, P, T]):
             The invocation context to use when checking the commands cooldown status.
 
         Returns
-        --------
+        -------
         :class:`bool`
             A boolean indicating if the command is on cooldown.
         """
@@ -923,7 +923,7 @@ class Command(_BaseCommand, Generic[CogT, P, T]):
             The invocation context to retrieve the cooldown from.
 
         Returns
-        --------
+        -------
         :class:`float`
             The amount of time left on this command's cooldown in seconds.
             If this is ``0.0`` then the command isn't on cooldown.
@@ -977,7 +977,7 @@ class Command(_BaseCommand, Generic[CogT, P, T]):
             The coroutine to register as the local error handler.
 
         Raises
-        -------
+        ------
         TypeError
             The coroutine passed is not actually a coroutine.
         """
@@ -1012,7 +1012,7 @@ class Command(_BaseCommand, Generic[CogT, P, T]):
             The coroutine to register as the pre-invoke hook.
 
         Raises
-        -------
+        ------
         TypeError
             The coroutine passed is not actually a coroutine.
         """
@@ -1039,7 +1039,7 @@ class Command(_BaseCommand, Generic[CogT, P, T]):
             The coroutine to register as the post-invoke hook.
 
         Raises
-        -------
+        ------
         TypeError
             The coroutine passed is not actually a coroutine.
         """
@@ -1148,13 +1148,13 @@ class Command(_BaseCommand, Generic[CogT, P, T]):
             The ctx of the command currently being invoked.
 
         Raises
-        -------
+        ------
         :class:`CommandError`
             Any command error that was raised during a check call will be propagated
             by this function.
 
         Returns
-        --------
+        -------
         :class:`bool`
             A boolean indicating if the command can be invoked.
         """
@@ -1234,7 +1234,7 @@ class GroupMixin(Generic[CogT]):
             The command to add.
 
         Raises
-        -------
+        ------
         :exc:`.CommandRegistrationError`
             If the command or its alias is already registered by different command.
         TypeError
@@ -1269,7 +1269,7 @@ class GroupMixin(Generic[CogT]):
             The name of the command to remove.
 
         Returns
-        --------
+        -------
         Optional[:class:`.Command`]
             The command that was removed. If the name is not valid then
             ``None`` is returned instead.
@@ -1326,7 +1326,7 @@ class GroupMixin(Generic[CogT]):
             The name of the command to get.
 
         Returns
-        --------
+        -------
         Optional[:class:`Command`]
             The command that was requested. If not found, returns ``None``.
         """
@@ -1389,7 +1389,7 @@ class GroupMixin(Generic[CogT]):
         the internal command list via :meth:`~.GroupMixin.add_command`.
 
         Returns
-        --------
+        -------
         Callable[..., :class:`Command`]
             A decorator that converts the provided method into a Command, adds it to the bot, then returns it.
         """
@@ -1442,7 +1442,7 @@ class GroupMixin(Generic[CogT]):
         the internal command list via :meth:`~.GroupMixin.add_command`.
 
         Returns
-        --------
+        -------
         Callable[..., :class:`Group`]
             A decorator that converts the provided method into a Group, adds it to the bot, then returns it.
         """
@@ -1488,7 +1488,7 @@ class Group(GroupMixin[CogT], Command[CogT, P, T]):
         """Creates a copy of this :class:`Group`.
 
         Returns
-        --------
+        -------
         :class:`Group`
             A new instance of this group.
         """
@@ -1642,7 +1642,7 @@ def command(
         by ``cls``.
 
     Raises
-    -------
+    ------
     TypeError
         If the function is not a coroutine or is already a command.
     """
@@ -1760,7 +1760,7 @@ def check(predicate: Check) -> Callable[[T], T]:
         The ``predicate`` attribute was added.
 
     Examples
-    ---------
+    --------
 
     Creating a basic check to see if the command invoker is you.
 
@@ -1838,13 +1838,13 @@ def check_any(*checks: Check) -> Callable[[T], T]:
         the :func:`check` decorator.
 
     Raises
-    -------
+    ------
     TypeError
         A check passed has not been decorated with the :func:`check`
         decorator.
 
     Examples
-    ---------
+    --------
 
     Creating a basic check to see if it's the bot owner or
     the server owner:

--- a/nextcord/ext/commands/core.py
+++ b/nextcord/ext/commands/core.py
@@ -1952,7 +1952,7 @@ def has_any_role(*items: Union[int, str]) -> Callable[[T], T]:
         An argument list of names or IDs to check that the member has roles wise.
 
     Example
-    --------
+    -------
 
     .. code-block:: python3
 
@@ -2057,7 +2057,7 @@ def has_permissions(**perms: bool) -> Callable[[T], T]:
         An argument list of permissions to check for.
 
     Example
-    ---------
+    -------
 
     .. code-block:: python3
 
@@ -2374,7 +2374,7 @@ def before_invoke(coro) -> Callable[[T], T]:
     .. versionadded:: 1.4
 
     Example
-    ---------
+    -------
 
     .. code-block:: python3
 

--- a/nextcord/ext/commands/core.py
+++ b/nextcord/ext/commands/core.py
@@ -209,7 +209,7 @@ class Command(_BaseCommand, Generic[CogT, P, T]):
     decorator or functional interface.
 
     Attributes
-    -----------
+    ----------
     name: :class:`str`
         The name of the command.
     callback: :ref:`coroutine <coroutine>`
@@ -462,7 +462,7 @@ class Command(_BaseCommand, Generic[CogT, P, T]):
         .. versionadded:: 1.3
 
         Parameters
-        -----------
+        ----------
         func
             The function that will be used as a check.
         """
@@ -478,7 +478,7 @@ class Command(_BaseCommand, Generic[CogT, P, T]):
         .. versionadded:: 1.3
 
         Parameters
-        -----------
+        ----------
         func
             The function to remove from the checks.
         """
@@ -883,7 +883,7 @@ class Command(_BaseCommand, Generic[CogT, P, T]):
         """Checks whether the command is currently on cooldown.
 
         Parameters
-        -----------
+        ----------
         ctx: :class:`.Context`
             The invocation context to use when checking the commands cooldown status.
 
@@ -904,7 +904,7 @@ class Command(_BaseCommand, Generic[CogT, P, T]):
         """Resets the cooldown on this command.
 
         Parameters
-        -----------
+        ----------
         ctx: :class:`.Context`
             The invocation context to reset the cooldown under.
         """
@@ -918,7 +918,7 @@ class Command(_BaseCommand, Generic[CogT, P, T]):
         .. versionadded:: 1.4
 
         Parameters
-        -----------
+        ----------
         ctx: :class:`.Context`
             The invocation context to retrieve the cooldown from.
 
@@ -972,7 +972,7 @@ class Command(_BaseCommand, Generic[CogT, P, T]):
         invoked afterwards as the catch-all.
 
         Parameters
-        -----------
+        ----------
         coro: :ref:`coroutine <coroutine>`
             The coroutine to register as the local error handler.
 
@@ -1007,7 +1007,7 @@ class Command(_BaseCommand, Generic[CogT, P, T]):
         See :meth:`.Bot.before_invoke` for more info.
 
         Parameters
-        -----------
+        ----------
         coro: :ref:`coroutine <coroutine>`
             The coroutine to register as the pre-invoke hook.
 
@@ -1034,7 +1034,7 @@ class Command(_BaseCommand, Generic[CogT, P, T]):
         See :meth:`.Bot.after_invoke` for more info.
 
         Parameters
-        -----------
+        ----------
         coro: :ref:`coroutine <coroutine>`
             The coroutine to register as the post-invoke hook.
 
@@ -1143,7 +1143,7 @@ class Command(_BaseCommand, Generic[CogT, P, T]):
             Checks whether the command is disabled or not
 
         Parameters
-        -----------
+        ----------
         ctx: :class:`.Context`
             The ctx of the command currently being invoked.
 
@@ -1194,7 +1194,7 @@ class GroupMixin(Generic[CogT]):
     similar to :class:`.Group` and are allowed to register commands.
 
     Attributes
-    -----------
+    ----------
     all_commands: :class:`dict`
         A mapping of command name to :class:`.Command`
         objects.
@@ -1229,7 +1229,7 @@ class GroupMixin(Generic[CogT]):
              Raise :exc:`.CommandRegistrationError` instead of generic :exc:`.ClientException`
 
         Parameters
-        -----------
+        ----------
         command: :class:`Command`
             The command to add.
 
@@ -1264,7 +1264,7 @@ class GroupMixin(Generic[CogT]):
         This could also be used as a way to remove aliases.
 
         Parameters
-        -----------
+        ----------
         name: :class:`str`
             The name of the command to remove.
 
@@ -1321,7 +1321,7 @@ class GroupMixin(Generic[CogT]):
         subcommand is not found then ``None`` is returned just as usual.
 
         Parameters
-        -----------
+        ----------
         name: :class:`str`
             The name of the command to get.
 
@@ -1464,7 +1464,7 @@ class Group(GroupMixin[CogT], Command[CogT, P, T]):
     valid in :class:`.Command` are valid in here as well.
 
     Attributes
-    -----------
+    ----------
     invoke_without_command: :class:`bool`
         Indicates if the group callback should begin parsing and
         invocation only if no subcommand was found. Useful for
@@ -1630,7 +1630,7 @@ def command(
     decorator.
 
     Parameters
-    -----------
+    ----------
     name: :class:`str`
         The name to create the command with. By default this uses the
         function name unchanged.
@@ -1789,7 +1789,7 @@ def check(predicate: Check) -> Callable[[T], T]:
             await ctx.send('Only you!')
 
     Parameters
-    -----------
+    ----------
     predicate: Callable[[:class:`Context`], :class:`bool`]
         The predicate to check if the command should be invoked.
     """
@@ -1832,7 +1832,7 @@ def check_any(*checks: Check) -> Callable[[T], T]:
     .. versionadded:: 1.3
 
     Parameters
-    ------------
+    ----------
     \*checks: Callable[[:class:`Context`], :class:`bool`]
         An argument list of checks that have been decorated with
         the :func:`check` decorator.
@@ -1909,7 +1909,7 @@ def has_role(item: Union[int, str]) -> Callable[[T], T]:
         instead of generic :exc:`.CheckFailure`
 
     Parameters
-    -----------
+    ----------
     item: Union[:class:`int`, :class:`str`]
         The name or ID of the role to check.
     """
@@ -1947,7 +1947,7 @@ def has_any_role(*items: Union[int, str]) -> Callable[[T], T]:
         instead of generic :exc:`.CheckFailure`
 
     Parameters
-    -----------
+    ----------
     items: List[Union[:class:`str`, :class:`int`]]
         An argument list of names or IDs to check that the member has roles wise.
 
@@ -2052,7 +2052,7 @@ def has_permissions(**perms: bool) -> Callable[[T], T]:
     that is inherited from :exc:`.CheckFailure`.
 
     Parameters
-    ------------
+    ----------
     perms
         An argument list of permissions to check for.
 
@@ -2262,7 +2262,7 @@ def cooldown(
     A command can only have a single cooldown.
 
     Parameters
-    ------------
+    ----------
     rate: :class:`int`
         The number of times a command can be used before triggering a cooldown.
     per: :class:`float`
@@ -2308,7 +2308,7 @@ def dynamic_cooldown(
     .. versionadded:: 2.0
 
     Parameters
-    ------------
+    ----------
     cooldown: Callable[[:class:`.nextcord.Message`], Optional[:class:`.Cooldown`]]
         A function that takes a message and returns a cooldown that will
         apply to this invocation or ``None`` if the cooldown should be bypassed.
@@ -2341,7 +2341,7 @@ def max_concurrency(
     .. versionadded:: 1.3
 
     Parameters
-    -------------
+    ----------
     number: :class:`int`
         The maximum number of invocations of this command that can be running at the same time.
     per: :class:`.BucketType`

--- a/nextcord/ext/commands/errors.py
+++ b/nextcord/ext/commands/errors.py
@@ -165,7 +165,7 @@ class CommandNotFound(CommandError):
         Added :attr:`command_name` as a parameter.
 
     Attributes
-    -----------
+    ----------
     command_name: :class:`str`
         The command that was not found.
     """
@@ -182,7 +182,7 @@ class MissingRequiredArgument(UserInputError):
     This inherits from :exc:`UserInputError`
 
     Attributes
-    -----------
+    ----------
     param: :class:`inspect.Parameter`
         The argument that is missing.
     """
@@ -229,7 +229,7 @@ class CheckAnyFailure(CheckFailure):
     .. versionadded:: 1.3
 
     Attributes
-    ------------
+    ----------
     errors: List[:class:`CheckFailure`]
         A list of errors that were caught during execution.
     checks: List[Callable[[:class:`Context`], :class:`bool`]]
@@ -282,7 +282,7 @@ class ObjectNotFound(BadArgument):
     .. versionadded:: 2.0
 
     Attributes
-    -----------
+    ----------
     argument: :class:`str`
         The argument supplied by the caller that was not matched
     """
@@ -301,7 +301,7 @@ class MemberNotFound(BadArgument):
     .. versionadded:: 1.5
 
     Attributes
-    -----------
+    ----------
     argument: :class:`str`
         The member supplied by the caller that was not found
     """
@@ -319,7 +319,7 @@ class GuildNotFound(BadArgument):
     .. versionadded:: 1.7
 
     Attributes
-    -----------
+    ----------
     argument: :class:`str`
         The guild supplied by the called that was not found
     """
@@ -338,7 +338,7 @@ class UserNotFound(BadArgument):
     .. versionadded:: 1.5
 
     Attributes
-    -----------
+    ----------
     argument: :class:`str`
         The user supplied by the caller that was not found
     """
@@ -356,7 +356,7 @@ class MessageNotFound(BadArgument):
     .. versionadded:: 1.5
 
     Attributes
-    -----------
+    ----------
     argument: :class:`str`
         The message supplied by the caller that was not found
     """
@@ -375,7 +375,7 @@ class ChannelNotReadable(BadArgument):
     .. versionadded:: 1.5
 
     Attributes
-    -----------
+    ----------
     argument: Union[:class:`.abc.GuildChannel`, :class:`.Thread`]
         The channel supplied by the caller that was not readable
     """
@@ -393,7 +393,7 @@ class ChannelNotFound(BadArgument):
     .. versionadded:: 1.5
 
     Attributes
-    -----------
+    ----------
     argument: :class:`str`
         The channel supplied by the caller that was not found
     """
@@ -411,7 +411,7 @@ class ThreadNotFound(BadArgument):
     .. versionadded:: 2.0
 
     Attributes
-    -----------
+    ----------
     argument: :class:`str`
         The thread supplied by the caller that was not found
     """
@@ -429,7 +429,7 @@ class BadColourArgument(BadArgument):
     .. versionadded:: 1.5
 
     Attributes
-    -----------
+    ----------
     argument: :class:`str`
         The colour supplied by the caller that was not valid
     """
@@ -450,7 +450,7 @@ class RoleNotFound(BadArgument):
     .. versionadded:: 1.5
 
     Attributes
-    -----------
+    ----------
     argument: :class:`str`
         The role supplied by the caller that was not found
     """
@@ -481,7 +481,7 @@ class EmojiNotFound(BadArgument):
     .. versionadded:: 1.5
 
     Attributes
-    -----------
+    ----------
     argument: :class:`str`
         The emoji supplied by the caller that was not found
     """
@@ -500,7 +500,7 @@ class PartialEmojiConversionFailure(BadArgument):
     .. versionadded:: 1.5
 
     Attributes
-    -----------
+    ----------
     argument: :class:`str`
         The emoji supplied by the caller that did not match the regex
     """
@@ -518,7 +518,7 @@ class GuildStickerNotFound(BadArgument):
     .. versionadded:: 2.0
 
     Attributes
-    -----------
+    ----------
     argument: :class:`str`
         The sticker supplied by the caller that was not found
     """
@@ -554,7 +554,7 @@ class BadBoolArgument(BadArgument):
     .. versionadded:: 1.5
 
     Attributes
-    -----------
+    ----------
     argument: :class:`str`
         The boolean argument supplied by the caller that is not in the predefined list
     """
@@ -579,7 +579,7 @@ class CommandInvokeError(CommandError):
     This inherits from :exc:`CommandError`
 
     Attributes
-    -----------
+    ----------
     original: :exc:`Exception`
         The original exception that was raised. You can also get this via
         the ``__cause__`` attribute.
@@ -596,7 +596,7 @@ class CommandOnCooldown(CommandError):
     This inherits from :exc:`CommandError`
 
     Attributes
-    -----------
+    ----------
     cooldown: :class:`.Cooldown`
         A class with attributes ``rate`` and ``per`` similar to the
         :func:`.cooldown` decorator.
@@ -619,7 +619,7 @@ class MaxConcurrencyReached(CommandError):
     This inherits from :exc:`CommandError`.
 
     Attributes
-    ------------
+    ----------
     number: :class:`int`
         The maximum number of concurrent invokers allowed.
     per: :class:`.BucketType`
@@ -646,7 +646,7 @@ class MissingRole(CheckFailure):
     .. versionadded:: 1.1
 
     Attributes
-    -----------
+    ----------
     missing_role: Union[:class:`str`, :class:`int`]
         The required role that is missing.
         This is the parameter passed to :func:`~.commands.has_role`.
@@ -666,7 +666,7 @@ class BotMissingRole(CheckFailure):
     .. versionadded:: 1.1
 
     Attributes
-    -----------
+    ----------
     missing_role: Union[:class:`str`, :class:`int`]
         The required role that is missing.
         This is the parameter passed to :func:`~.commands.has_role`.
@@ -687,7 +687,7 @@ class MissingAnyRole(CheckFailure):
     .. versionadded:: 1.1
 
     Attributes
-    -----------
+    ----------
     missing_roles: List[Union[:class:`str`, :class:`int`]]
         The roles that the invoker is missing.
         These are the parameters passed to :func:`~.commands.has_any_role`.
@@ -716,7 +716,7 @@ class BotMissingAnyRole(CheckFailure):
     .. versionadded:: 1.1
 
     Attributes
-    -----------
+    ----------
     missing_roles: List[Union[:class:`str`, :class:`int`]]
         The roles that the bot's member is missing.
         These are the parameters passed to :func:`~.commands.has_any_role`.
@@ -745,7 +745,7 @@ class NSFWChannelRequired(CheckFailure):
     .. versionadded:: 1.1
 
     Parameters
-    -----------
+    ----------
     channel: Union[:class:`.abc.GuildChannel`, :class:`.Thread`]
         The channel that does not have NSFW enabled.
     """
@@ -762,7 +762,7 @@ class MissingPermissions(CheckFailure):
     This inherits from :exc:`CheckFailure`
 
     Attributes
-    -----------
+    ----------
     missing_permissions: List[:class:`str`]
         The required permissions that are missing.
     """
@@ -790,7 +790,7 @@ class BotMissingPermissions(CheckFailure):
     This inherits from :exc:`CheckFailure`
 
     Attributes
-    -----------
+    ----------
     missing_permissions: List[:class:`str`]
         The required permissions that are missing.
     """
@@ -818,7 +818,7 @@ class BadUnionArgument(UserInputError):
     This inherits from :exc:`UserInputError`
 
     Attributes
-    -----------
+    ----------
     param: :class:`inspect.Parameter`
         The parameter that failed being converted.
     converters: Tuple[Type, ``...``]
@@ -860,7 +860,7 @@ class BadLiteralArgument(UserInputError):
     .. versionadded:: 2.0
 
     Attributes
-    -----------
+    ----------
     param: :class:`inspect.Parameter`
         The parameter that failed being converted.
     literals: Tuple[Any, ``...``]
@@ -903,7 +903,7 @@ class UnexpectedQuoteError(ArgumentParsingError):
     This inherits from :exc:`ArgumentParsingError`.
 
     Attributes
-    ------------
+    ----------
     quote: :class:`str`
         The quote mark that was found inside the non-quoted string.
     """
@@ -920,7 +920,7 @@ class InvalidEndOfQuotedStringError(ArgumentParsingError):
     This inherits from :exc:`ArgumentParsingError`.
 
     Attributes
-    -----------
+    ----------
     char: :class:`str`
         The character found instead of the expected string.
     """
@@ -936,7 +936,7 @@ class ExpectedClosingQuoteError(ArgumentParsingError):
     This inherits from :exc:`ArgumentParsingError`.
 
     Attributes
-    -----------
+    ----------
     close_quote: :class:`str`
         The quote character expected.
     """
@@ -952,7 +952,7 @@ class ExtensionError(DiscordException):
     This inherits from :exc:`~nextcord.DiscordException`.
 
     Attributes
-    ------------
+    ----------
     name: :class:`str`
         The extension that had an error.
     """
@@ -1014,7 +1014,7 @@ class ExtensionFailed(ExtensionError):
     This inherits from :exc:`ExtensionError`
 
     Attributes
-    -----------
+    ----------
     name: :class:`str`
         The extension that had the error.
     original: :exc:`Exception`
@@ -1037,7 +1037,7 @@ class ExtensionNotFound(ExtensionError):
         Made the ``original`` attribute always None.
 
     Attributes
-    -----------
+    ----------
     name: :class:`str`
         The extension that had the error.
     """
@@ -1089,7 +1089,7 @@ class TooManyFlags(FlagError):
     .. versionadded:: 2.0
 
     Attributes
-    ------------
+    ----------
     flag: :class:`~nextcord.ext.commands.Flag`
         The flag that received too many values.
     values: List[:class:`str`]
@@ -1112,7 +1112,7 @@ class BadFlagArgument(FlagError):
     .. versionadded:: 2.0
 
     Attributes
-    -----------
+    ----------
     flag: :class:`~nextcord.ext.commands.Flag`
         The flag that failed to convert.
     """
@@ -1135,7 +1135,7 @@ class MissingRequiredFlag(FlagError):
     .. versionadded:: 2.0
 
     Attributes
-    -----------
+    ----------
     flag: :class:`~nextcord.ext.commands.Flag`
         The required flag that was not found.
     """
@@ -1153,7 +1153,7 @@ class MissingFlagArgument(FlagError):
     .. versionadded:: 2.0
 
     Attributes
-    -----------
+    ----------
     flag: :class:`~nextcord.ext.commands.Flag`
         The flag that did not get a value.
     """

--- a/nextcord/ext/commands/flags.py
+++ b/nextcord/ext/commands/flags.py
@@ -76,7 +76,7 @@ class Flag:
     do so. These cannot be constructed manually.
 
     Attributes
-    ------------
+    ----------
     name: :class:`str`
         The name of the flag.
     aliases: List[:class:`str`]
@@ -124,7 +124,7 @@ def flag(
     class attributes.
 
     Parameters
-    ------------
+    ----------
     name: :class:`str`
         The flag name. If not given, defaults to the attribute name.
     aliases: List[:class:`str`]
@@ -473,7 +473,7 @@ class FlagConverter(metaclass=FlagsMeta):
     .. versionadded:: 2.0
 
     Parameters
-    -----------
+    ----------
     case_insensitive: :class:`bool`
         A class parameter to toggle case insensitivity of the flag parsing.
         If ``True`` then flags are parsed in a case insensitive manner.

--- a/nextcord/ext/commands/flags.py
+++ b/nextcord/ext/commands/flags.py
@@ -586,14 +586,14 @@ class FlagConverter(metaclass=FlagsMeta):
             The argument to convert from.
 
         Raises
-        --------
+        ------
         FlagError
             A flag related parsing error.
         CommandError
             A command related error.
 
         Returns
-        --------
+        -------
         :class:`FlagConverter`
             The flag converter instance with all flags parsed.
         """

--- a/nextcord/ext/commands/help.py
+++ b/nextcord/ext/commands/help.py
@@ -394,7 +394,7 @@ class HelpCommand:
         then it returns the internal command name of the help command.
 
         Returns
-        ---------
+        -------
         :class:`str`
             The command name that triggered this invocation.
         """
@@ -413,7 +413,7 @@ class HelpCommand:
             The command to get the signature of.
 
         Returns
-        --------
+        -------
         :class:`str`
             The signature for the command.
         """
@@ -466,7 +466,7 @@ class HelpCommand:
         To unbind the cog from the help command, you can set it to ``None``.
 
         Returns
-        --------
+        -------
         Optional[:class:`Cog`]
             The cog that is currently set for the help command.
         """
@@ -496,7 +496,7 @@ class HelpCommand:
             had mentions removed to prevent abuse.
 
         Returns
-        ---------
+        -------
         :class:`str`
             The string to use when a command has not been found.
         """
@@ -524,7 +524,7 @@ class HelpCommand:
             had mentions removed to prevent abuse.
 
         Returns
-        ---------
+        -------
         :class:`str`
             The string to use when the command did not have the subcommand requested.
         """
@@ -554,7 +554,7 @@ class HelpCommand:
             passed as ``True`` then this will default as the command name.
 
         Returns
-        ---------
+        -------
         List[:class:`Command`]
             A list of commands that passed the filter.
         """
@@ -601,7 +601,7 @@ class HelpCommand:
             A sequence of commands to check for the largest size.
 
         Returns
-        --------
+        -------
         :class:`int`
             The maximum width of the commands.
         """

--- a/nextcord/ext/commands/help.py
+++ b/nextcord/ext/commands/help.py
@@ -79,7 +79,7 @@ class Paginator:
             Returns the total number of characters in the paginator.
 
     Attributes
-    -----------
+    ----------
     prefix: :class:`str`
         The prefix inserted to every page. e.g. three backticks.
     suffix: :class:`str`
@@ -127,7 +127,7 @@ class Paginator:
         is raised.
 
         Parameters
-        -----------
+        ----------
         line: :class:`str`
             The line to add.
         empty: :class:`bool`
@@ -276,7 +276,7 @@ class HelpCommand:
         the same between command invocations would not work as expected.
 
     Attributes
-    ------------
+    ----------
     context: Optional[:class:`Context`]
         The context that invoked this help formatter. This is generally set after
         the help command assigned, :func:`command_callback`\, has been called.
@@ -408,7 +408,7 @@ class HelpCommand:
         """Retrieves the signature portion of the help page.
 
         Parameters
-        ------------
+        ----------
         command: :class:`Command`
             The command to get the signature of.
 
@@ -490,7 +490,7 @@ class HelpCommand:
         Defaults to ``No command called {0} found.``
 
         Parameters
-        ------------
+        ----------
         string: :class:`str`
             The string that contains the invalid command. Note that this has
             had mentions removed to prevent abuse.
@@ -516,7 +516,7 @@ class HelpCommand:
             - If the ``command`` parameter has subcommands but not one named ``string``.
 
         Parameters
-        ------------
+        ----------
         command: :class:`Command`
             The command that did not have the subcommand requested.
         string: :class:`str`
@@ -543,7 +543,7 @@ class HelpCommand:
         attributes.
 
         Parameters
-        ------------
+        ----------
         commands: Iterable[:class:`Command`]
             An iterable of commands that are getting filtered.
         sort: :class:`bool`
@@ -596,7 +596,7 @@ class HelpCommand:
         """Returns the largest name length of the specified command list.
 
         Parameters
-        ------------
+        ----------
         commands: Sequence[:class:`Command`]
             A sequence of commands to check for the largest size.
 
@@ -639,7 +639,7 @@ class HelpCommand:
             You can access the invocation context with :attr:`HelpCommand.context`.
 
         Parameters
-        ------------
+        ----------
         error: :class:`str`
             The error message to display to the user. Note that this has
             had mentions removed to prevent abuse.
@@ -660,7 +660,7 @@ class HelpCommand:
         error handlers.
 
         Parameters
-        ------------
+        ----------
         ctx: :class:`Context`
             The invocation context.
         error: :class:`CommandError`
@@ -689,7 +689,7 @@ class HelpCommand:
             you will have to call :meth:`filter_commands` yourself.
 
         Parameters
-        ------------
+        ----------
         mapping: Mapping[Optional[:class:`Cog`], List[:class:`Command`]]
             A mapping of cogs to commands that have been requested by the user for help.
             The key of the mapping is the :class:`~.commands.Cog` that the command belongs to, or
@@ -719,7 +719,7 @@ class HelpCommand:
             :meth:`filter_commands` yourself.
 
         Parameters
-        -----------
+        ----------
         cog: :class:`Cog`
             The cog that was requested for help.
         """
@@ -747,7 +747,7 @@ class HelpCommand:
             filtering you will have to call :meth:`filter_commands` yourself.
 
         Parameters
-        -----------
+        ----------
         group: :class:`Group`
             The group that was requested for help.
         """
@@ -785,7 +785,7 @@ class HelpCommand:
             these to help you get started to get the output that you want.
 
         Parameters
-        -----------
+        ----------
         command: :class:`Command`
             The command that was requested for help.
         """
@@ -807,7 +807,7 @@ class HelpCommand:
             the usual rules that happen inside apply here as well.
 
         Parameters
-        -----------
+        ----------
         ctx: :class:`Context`
             The invocation context.
         command: Optional[:class:`str`]
@@ -886,7 +886,7 @@ class DefaultHelpCommand(HelpCommand):
     It extends it with the following attributes.
 
     Attributes
-    ------------
+    ----------
     width: :class:`int`
         The maximum number of characters that fit in a line.
         Defaults to 80.
@@ -953,7 +953,7 @@ class DefaultHelpCommand(HelpCommand):
         to fit into the :attr:`width`.
 
         Parameters
-        -----------
+        ----------
         commands: Sequence[:class:`Command`]
             A list of commands to indent for output.
         heading: :class:`str`
@@ -988,7 +988,7 @@ class DefaultHelpCommand(HelpCommand):
         """A utility function to format the non-indented block of commands and groups.
 
         Parameters
-        ------------
+        ----------
         command: :class:`Command`
             The command to format.
         """
@@ -1092,7 +1092,7 @@ class MinimalHelpCommand(HelpCommand):
     This inherits from :class:`HelpCommand`.
 
     Attributes
-    ------------
+    ----------
     sort_commands: :class:`bool`
         Whether to sort the commands in the output alphabetically. Defaults to ``True``.
     commands_heading: :class:`str`
@@ -1180,7 +1180,7 @@ class MinimalHelpCommand(HelpCommand):
         by commands separated by an EN SPACE (U+2002) in the next line.
 
         Parameters
-        -----------
+        ----------
         commands: Sequence[:class:`Command`]
             A list of commands that belong to the heading.
         heading: :class:`str`
@@ -1201,7 +1201,7 @@ class MinimalHelpCommand(HelpCommand):
         optionally followed by an En dash and the command's :attr:`Command.short_doc`.
 
         Parameters
-        -----------
+        ----------
         command: :class:`Command`
             The command to show information of.
         """
@@ -1221,7 +1221,7 @@ class MinimalHelpCommand(HelpCommand):
         This is not called if there are no aliases to format.
 
         Parameters
-        -----------
+        ----------
         aliases: Sequence[:class:`str`]
             A list of aliases to format.
         """
@@ -1231,7 +1231,7 @@ class MinimalHelpCommand(HelpCommand):
         """A utility function to format commands and groups.
 
         Parameters
-        ------------
+        ----------
         command: :class:`Command`
             The command to format.
         """

--- a/nextcord/ext/slash_utils/__init__.py
+++ b/nextcord/ext/slash_utils/__init__.py
@@ -1,6 +1,6 @@
 """
 nextcord.ext.dpy
-~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~
 An extension module to replicate parts of Discord.py.
 :copyright: (c) 2022-present tag-epic
 :license: MIT, see LICENSE for more details.

--- a/nextcord/ext/tasks/__init__.py
+++ b/nextcord/ext/tasks/__init__.py
@@ -277,7 +277,7 @@ class Loop(Generic[LF]):
         .. versionadded:: 1.6
 
         Parameters
-        ------------
+        ----------
         \*args
             The arguments to use.
         \*\*kwargs
@@ -293,7 +293,7 @@ class Loop(Generic[LF]):
         r"""Starts the internal task in the event loop.
 
         Parameters
-        ------------
+        ----------
         \*args
             The arguments to use.
         \*\*kwargs
@@ -360,7 +360,7 @@ class Loop(Generic[LF]):
             returned like :meth:`start`.
 
         Parameters
-        ------------
+        ----------
         \*args
             The arguments to use.
         \*\*kwargs
@@ -386,7 +386,7 @@ class Loop(Generic[LF]):
         raises its own set of exceptions.
 
         Parameters
-        ------------
+        ----------
         \*exceptions: Type[:class:`BaseException`]
             An argument list of exception classes to handle.
 
@@ -417,7 +417,7 @@ class Loop(Generic[LF]):
         r"""Removes exception types from being handled during the reconnect logic.
 
         Parameters
-        ------------
+        ----------
         \*exceptions: Type[:class:`BaseException`]
             An argument list of exception classes to handle.
 
@@ -471,7 +471,7 @@ class Loop(Generic[LF]):
         The coroutine must take no arguments (except ``self`` in a class context).
 
         Parameters
-        ------------
+        ----------
         coro: :ref:`coroutine <coroutine>`
             The coroutine to register before the loop runs.
 
@@ -499,7 +499,7 @@ class Loop(Generic[LF]):
             whether :meth:`is_being_cancelled` is ``True`` or not.
 
         Parameters
-        ------------
+        ----------
         coro: :ref:`coroutine <coroutine>`
             The coroutine to register after the loop finishes.
 
@@ -526,7 +526,7 @@ class Loop(Generic[LF]):
         .. versionadded:: 1.4
 
         Parameters
-        ------------
+        ----------
         coro: :ref:`coroutine <coroutine>`
             The coroutine to register in the event of an unhandled exception.
 
@@ -627,7 +627,7 @@ class Loop(Generic[LF]):
         .. versionadded:: 1.2
 
         Parameters
-        ------------
+        ----------
         seconds: :class:`float`
             The number of seconds between every iteration.
         minutes: :class:`float`
@@ -698,7 +698,7 @@ def loop(
     optional reconnect logic. The decorator returns a :class:`Loop`.
 
     Parameters
-    ------------
+    ----------
     seconds: :class:`float`
         The number of seconds between every iteration.
     minutes: :class:`float`

--- a/nextcord/ext/tasks/__init__.py
+++ b/nextcord/ext/tasks/__init__.py
@@ -300,12 +300,12 @@ class Loop(Generic[LF]):
             The keyword arguments to use.
 
         Raises
-        --------
+        ------
         RuntimeError
             A task has already been launched and is running.
 
         Returns
-        ---------
+        -------
         :class:`asyncio.Task`
             The task that has been created.
         """
@@ -391,7 +391,7 @@ class Loop(Generic[LF]):
             An argument list of exception classes to handle.
 
         Raises
-        --------
+        ------
         TypeError
             An exception passed is either not a class or not inherited from :class:`BaseException`.
         """
@@ -422,7 +422,7 @@ class Loop(Generic[LF]):
             An argument list of exception classes to handle.
 
         Returns
-        ---------
+        -------
         :class:`bool`
             Whether all exceptions were successfully removed.
         """
@@ -476,7 +476,7 @@ class Loop(Generic[LF]):
             The coroutine to register before the loop runs.
 
         Raises
-        -------
+        ------
         TypeError
             The function was not a coroutine.
         """
@@ -504,7 +504,7 @@ class Loop(Generic[LF]):
             The coroutine to register after the loop finishes.
 
         Raises
-        -------
+        ------
         TypeError
             The function was not a coroutine.
         """
@@ -531,7 +531,7 @@ class Loop(Generic[LF]):
             The coroutine to register in the event of an unhandled exception.
 
         Raises
-        -------
+        ------
         TypeError
             The function was not a coroutine.
         """
@@ -646,7 +646,7 @@ class Loop(Generic[LF]):
                 Duplicate times will be ignored, and only run once.
 
         Raises
-        -------
+        ------
         ValueError
             An invalid value was given.
         TypeError
@@ -735,7 +735,7 @@ def loop(
         defaults to :func:`asyncio.get_event_loop`.
 
     Raises
-    --------
+    ------
     ValueError
         An invalid value was given.
     TypeError

--- a/nextcord/file.py
+++ b/nextcord/file.py
@@ -41,7 +41,7 @@ class File:
         multiple :meth:`abc.Messageable.send`\s.
 
     Parameters
-    -----------
+    ----------
 
     fp: Union[str, bytes, os.PathLike, io.BufferedIOBase]
         A file-like object opened in binary mode and read mode
@@ -73,7 +73,7 @@ class File:
         .. versionadded:: 2.2
 
     Attributes
-    -----------
+    ----------
     fp: Union[:class:`io.BufferedReader`, :class:`io.BufferedIOBase`]
         A file-like object opened in binary mode and read mode.
         This will be a :class:`io.BufferedIOBase` if an

--- a/nextcord/flags.py
+++ b/nextcord/flags.py
@@ -188,7 +188,7 @@ class SystemChannelFlags(BaseFlags):
                to be, for example, constructed as a dict or a list of pairs.
 
     Attributes
-    -----------
+    ----------
     value: :class:`int`
         The raw value. This value is a bit array field of a 53-bit integer
         representing the currently available flags. You should query
@@ -310,7 +310,7 @@ class MessageFlags(BaseFlags):
     .. versionadded:: 1.3
 
     Attributes
-    -----------
+    ----------
     value: :class:`int`
         The raw value. This value is a bit array field of a 53-bit integer
         representing the currently available flags. You should query
@@ -388,7 +388,7 @@ class PublicUserFlags(BaseFlags):
     .. versionadded:: 1.4
 
     Attributes
-    -----------
+    ----------
     value: :class:`int`
         The raw value. This value is a bit array field of a 53-bit integer
         representing the currently available flags. You should query
@@ -525,7 +525,7 @@ class Intents(BaseFlags):
                to be, for example, constructed as a dict or a list of pairs.
 
     Attributes
-    -----------
+    ----------
     value: :class:`int`
         The raw value. You should query flags via the properties
         rather than using this raw value.
@@ -1065,7 +1065,7 @@ class MemberCacheFlags(BaseFlags):
                to be, for example, constructed as a dict or a list of pairs.
 
     Attributes
-    -----------
+    ----------
     value: :class:`int`
         The raw value. You should query flags via the properties
         rather than using this raw value.
@@ -1128,7 +1128,7 @@ class MemberCacheFlags(BaseFlags):
         the currently selected :class:`Intents`.
 
         Parameters
-        ------------
+        ----------
         intents: :class:`Intents`
             The intents to select from.
 
@@ -1182,7 +1182,7 @@ class ApplicationFlags(BaseFlags):
     .. versionadded:: 2.0
 
     Attributes
-    -----------
+    ----------
     value: :class:`int`
         The raw value. You should query flags via the properties
         rather than using this raw value.

--- a/nextcord/flags.py
+++ b/nextcord/flags.py
@@ -1133,7 +1133,7 @@ class MemberCacheFlags(BaseFlags):
             The intents to select from.
 
         Returns
-        ---------
+        -------
         :class:`MemberCacheFlags`
             The resulting member cache flags.
         """

--- a/nextcord/gateway.py
+++ b/nextcord/gateway.py
@@ -241,7 +241,7 @@ class DiscordWebSocket:
     """Implements a WebSocket for Discord's gateway.
 
     Attributes
-    -----------
+    ----------
     DISPATCH
         Receive only. Denotes an event to be sent to Discord, such as READY.
     HEARTBEAT
@@ -393,7 +393,7 @@ class DiscordWebSocket:
         """Waits for a DISPATCH'd event that meets the predicate.
 
         Parameters
-        -----------
+        ----------
         event: :class:`str`
             The event name in all upper case to wait for.
         predicate
@@ -404,7 +404,7 @@ class DiscordWebSocket:
             the result to the future. If ``None``, returns the data.
 
         Returns
-        --------
+        -------
         asyncio.Future
             A future to wait for.
         """
@@ -728,7 +728,7 @@ class DiscordVoiceWebSocket:
     """Implements the websocket protocol for handling voice connections.
 
     Attributes
-    -----------
+    ----------
     IDENTIFY
         Send only. Starts a new voice session.
     SELECT_PROTOCOL

--- a/nextcord/guild.py
+++ b/nextcord/guild.py
@@ -668,7 +668,7 @@ class Guild(Hashable):
         ``None``.
 
         Returns
-        --------
+        -------
         List[Tuple[Optional[:class:`CategoryChannel`], List[:class:`abc.GuildChannel`]]]:
             The categories and their associated channels.
         """
@@ -711,7 +711,7 @@ class Guild(Hashable):
             The ID to search for.
 
         Returns
-        --------
+        -------
         Optional[Union[:class:`Thread`, :class:`.abc.GuildChannel`]]
             The returned channel or thread or ``None`` if not found.
         """
@@ -730,7 +730,7 @@ class Guild(Hashable):
             The ID to search for.
 
         Returns
-        --------
+        -------
         Optional[:class:`.abc.GuildChannel`]
             The returned channel or ``None`` if not found.
         """
@@ -747,7 +747,7 @@ class Guild(Hashable):
             The ID to search for.
 
         Returns
-        --------
+        -------
         Optional[:class:`Thread`]
             The returned thread or ``None`` if not found.
         """
@@ -858,7 +858,7 @@ class Guild(Hashable):
             The ID to search for.
 
         Returns
-        --------
+        -------
         Optional[:class:`Member`]
             The member or ``None`` if not found.
         """
@@ -887,7 +887,7 @@ class Guild(Hashable):
             The ID to search for.
 
         Returns
-        --------
+        -------
         Optional[:class:`Role`]
             The role or ``None`` if not found.
         """
@@ -943,7 +943,7 @@ class Guild(Hashable):
             The ID to search for.
 
         Returns
-        --------
+        -------
         Optional[:class:`StageInstance`]
             The stage instance or ``None`` if not found.
         """
@@ -1045,7 +1045,7 @@ class Guild(Hashable):
             The name of the member to lookup with an optional discriminator.
 
         Returns
-        --------
+        -------
         Optional[:class:`Member`]
             The member in this guild with the associated name. If not found
             then ``None`` is returned.
@@ -1141,7 +1141,7 @@ class Guild(Hashable):
             will be required to update the position of the channel in the channel list.
 
         Examples
-        ----------
+        --------
 
         Creating a basic channel:
 
@@ -1663,7 +1663,7 @@ class Guild(Hashable):
             guild and request an ownership transfer.
 
         Returns
-        --------
+        -------
         :class:`Guild`
             The newly updated guild. Note that this has the same limitations as
             mentioned in :meth:`Client.fetch_guild` and may not have full data.
@@ -1916,7 +1916,7 @@ class Guild(Hashable):
             Fetching the member failed.
 
         Returns
-        --------
+        -------
         :class:`Member`
             The member from the member ID.
         """
@@ -2013,7 +2013,7 @@ class Guild(Hashable):
             Due to a breaking change in Discord's API, this now returns an :class:`~nextcord.AsyncIterator` instead of a :class:`list`.
 
         Examples
-        ---------
+        --------
 
         Usage ::
 
@@ -3199,7 +3199,7 @@ class Guild(Hashable):
             The presences intent is not enabled.
 
         Returns
-        --------
+        -------
         List[:class:`Member`]
             The list of members that have matched the query.
         """

--- a/nextcord/guild.py
+++ b/nextcord/guild.py
@@ -706,7 +706,7 @@ class Guild(Hashable):
         .. versionadded:: 2.0
 
         Parameters
-        -----------
+        ----------
         channel_id: :class:`int`
             The ID to search for.
 
@@ -725,7 +725,7 @@ class Guild(Hashable):
             This does *not* search for threads.
 
         Parameters
-        -----------
+        ----------
         channel_id: :class:`int`
             The ID to search for.
 
@@ -742,7 +742,7 @@ class Guild(Hashable):
         .. versionadded:: 2.0
 
         Parameters
-        -----------
+        ----------
         thread_id: :class:`int`
             The ID to search for.
 
@@ -853,7 +853,7 @@ class Guild(Hashable):
         """Returns a member with the given ID.
 
         Parameters
-        -----------
+        ----------
         user_id: :class:`int`
             The ID to search for.
 
@@ -882,7 +882,7 @@ class Guild(Hashable):
         """Returns a role with the given ID.
 
         Parameters
-        -----------
+        ----------
         role_id: :class:`int`
             The ID to search for.
 
@@ -938,7 +938,7 @@ class Guild(Hashable):
         .. versionadded:: 2.0
 
         Parameters
-        -----------
+        ----------
         stage_instance_id: :class:`int`
             The ID to search for.
 
@@ -1040,7 +1040,7 @@ class Guild(Hashable):
         If no member is found, ``None`` is returned.
 
         Parameters
-        -----------
+        ----------
         name: :class:`str`
             The name of the member to lookup with an optional discriminator.
 
@@ -1161,7 +1161,7 @@ class Guild(Hashable):
             channel = await guild.create_text_channel('secret', overwrites=overwrites)
 
         Parameters
-        -----------
+        ----------
         name: :class:`str`
             The channel's name.
         overwrites: Dict[Union[:class:`Role`, :class:`Member`], :class:`PermissionOverwrite`]
@@ -1186,7 +1186,7 @@ class Guild(Hashable):
             The reason for creating this channel. Shows up on the audit log.
 
         Raises
-        -------
+        ------
         Forbidden
             You do not have the proper permissions to create this channel.
         HTTPException
@@ -1246,7 +1246,7 @@ class Guild(Hashable):
         This is similar to :meth:`create_text_channel` except makes a :class:`VoiceChannel` instead.
 
         Parameters
-        -----------
+        ----------
         name: :class:`str`
             The channel's name.
         overwrites: Dict[Union[:class:`Role`, :class:`Member`], :class:`PermissionOverwrite`]
@@ -1338,7 +1338,7 @@ class Guild(Hashable):
         .. versionadded:: 1.7
 
         Parameters
-        -----------
+        ----------
         name: :class:`str`
             The channel's name.
         topic: :class:`str`
@@ -1523,7 +1523,7 @@ class Guild(Hashable):
             via :meth:`delete`.
 
         Raises
-        --------
+        ------
         HTTPException
             Leaving the guild failed.
         """
@@ -1536,7 +1536,7 @@ class Guild(Hashable):
         guild.
 
         Raises
-        --------
+        ------
         HTTPException
             Deleting the guild failed.
         Forbidden
@@ -1652,7 +1652,7 @@ class Guild(Hashable):
             The reason for editing this guild. Shows up on the audit log.
 
         Raises
-        -------
+        ------
         Forbidden
             You do not have permissions to edit the guild.
         HTTPException
@@ -1786,7 +1786,7 @@ class Guild(Hashable):
         .. versionadded:: 1.2
 
         Raises
-        -------
+        ------
         InvalidData
             An unknown channel type was received from Discord.
         HTTPException
@@ -1824,7 +1824,7 @@ class Guild(Hashable):
             The request to get the active threads failed.
 
         Returns
-        --------
+        -------
         List[:class:`Thread`]
             The active threads
         """
@@ -1904,12 +1904,12 @@ class Guild(Hashable):
             This method is an API call. If you have :attr:`Intents.members` and member cache enabled, consider :meth:`get_member` instead.
 
         Parameters
-        -----------
+        ----------
         member_id: :class:`int`
             The member's ID to fetch from.
 
         Raises
-        -------
+        ------
         Forbidden
             You do not have access to the guild.
         HTTPException
@@ -1932,7 +1932,7 @@ class Guild(Hashable):
         to get this information.
 
         Parameters
-        -----------
+        ----------
         user: :class:`abc.Snowflake`
             The user to get ban information from.
 
@@ -1965,7 +1965,7 @@ class Guild(Hashable):
         .. versionadded:: 2.0
 
         Raises
-        -------
+        ------
         :exc:`.InvalidData`
             An unknown channel type was received from Discord
             or the guild the channel belongs to is not the same
@@ -1978,7 +1978,7 @@ class Guild(Hashable):
             You do not have permission to fetch this channel.
 
         Returns
-        --------
+        -------
         Union[:class:`.abc.GuildChannel`, :class:`.Thread`]
             The channel from the ID.
         """
@@ -2030,7 +2030,7 @@ class Guild(Hashable):
         All parameters are optional.
 
         Parameters
-        -----------
+        ----------
         limit: Optional[:class:`int`]
             The number of bans to retrieve.
             If ``None``, it retrieves every ban in the guild. Note, however,
@@ -2049,7 +2049,7 @@ class Guild(Hashable):
             An error occurred while fetching the bans.
 
         Yields
-        -------
+        ------
         :class:`~nextcord.BanEntry`
             The ban with the ban data parsed.
         """
@@ -2083,7 +2083,7 @@ class Guild(Hashable):
             The ``roles`` keyword-only parameter was added.
 
         Parameters
-        -----------
+        ----------
         days: :class:`int`
             The number of days before counting as inactive.
         reason: Optional[:class:`str`]
@@ -2098,7 +2098,7 @@ class Guild(Hashable):
             has a role that is not specified, they'll be excluded.
 
         Raises
-        -------
+        ------
         Forbidden
             You do not have permissions to prune members.
         HTTPException
@@ -2107,7 +2107,7 @@ class Guild(Hashable):
             An integer was not passed for ``days``.
 
         Returns
-        ---------
+        -------
         Optional[:class:`int`]
             The number of members pruned. If ``compute_prune_count`` is ``False``
             then this returns ``None``.
@@ -2138,12 +2138,12 @@ class Guild(Hashable):
         .. versionadded:: 1.7
 
         Raises
-        -------
+        ------
         Forbidden
             You don't have permissions to get the templates.
 
         Returns
-        --------
+        -------
         List[:class:`Template`]
             The templates for this guild.
         """
@@ -2160,12 +2160,12 @@ class Guild(Hashable):
         Requires :attr:`~.Permissions.manage_webhooks` permissions.
 
         Raises
-        -------
+        ------
         Forbidden
             You don't have permissions to get the webhooks.
 
         Returns
-        --------
+        -------
         List[:class:`Webhook`]
             The webhooks for this guild.
         """
@@ -2185,7 +2185,7 @@ class Guild(Hashable):
         from the guild had it been called.
 
         Parameters
-        -----------
+        ----------
         days: :class:`int`
             The number of days before counting as inactive.
         roles: List[:class:`abc.Snowflake`]
@@ -2195,7 +2195,7 @@ class Guild(Hashable):
             .. versionadded:: 1.7
 
         Raises
-        -------
+        ------
         Forbidden
             You do not have permissions to prune members.
         HTTPException
@@ -2204,7 +2204,7 @@ class Guild(Hashable):
             An integer was not passed for ``days``.
 
         Returns
-        ---------
+        -------
         :class:`int`
             The number of members estimated to be pruned.
         """
@@ -2231,7 +2231,7 @@ class Guild(Hashable):
         this information.
 
         Raises
-        -------
+        ------
         Forbidden
             You do not have proper permissions to get the information.
         HTTPException
@@ -2268,7 +2268,7 @@ class Guild(Hashable):
         .. versionadded:: 1.7
 
         Parameters
-        -----------
+        ----------
         name: :class:`str`
             The name of the template.
         description: :class:`str`
@@ -2296,14 +2296,14 @@ class Guild(Hashable):
         .. versionadded:: 1.4
 
         Parameters
-        -----------
+        ----------
         type: :class:`str`
             The integration type (e.g. Twitch).
         id: :class:`int`
             The integration ID.
 
         Raises
-        -------
+        ------
         Forbidden
             You do not have permission to create the integration.
         HTTPException
@@ -2322,14 +2322,14 @@ class Guild(Hashable):
         .. versionadded:: 1.4
 
         Raises
-        -------
+        ------
         Forbidden
             You do not have permission to create the integration.
         HTTPException
             Fetching the integrations failed.
 
         Returns
-        --------
+        -------
         List[:class:`Integration`]
             The list of integrations that are attached to the guild.
         """
@@ -2357,12 +2357,12 @@ class Guild(Hashable):
             This method is an API call. For general usage, consider :attr:`stickers` instead.
 
         Raises
-        ---------
+        ------
         HTTPException
             An error occurred fetching the stickers.
 
         Returns
-        --------
+        -------
         List[:class:`GuildSticker`]
             The retrieved stickers.
         """
@@ -2382,19 +2382,19 @@ class Guild(Hashable):
             For general usage, consider iterating over :attr:`stickers` instead.
 
         Parameters
-        -------------
+        ----------
         sticker_id: :class:`int`
             The sticker's ID.
 
         Raises
-        ---------
+        ------
         NotFound
             The sticker requested could not be found.
         HTTPException
             An error occurred fetching the sticker.
 
         Returns
-        --------
+        -------
         :class:`GuildSticker`
             The retrieved sticker.
         """
@@ -2420,7 +2420,7 @@ class Guild(Hashable):
         .. versionadded:: 2.0
 
         Parameters
-        -----------
+        ----------
         name: :class:`str`
             The sticker name. Must be at least 2 characters.
         description: Optional[:class:`str`]
@@ -2433,14 +2433,14 @@ class Guild(Hashable):
             The reason for creating this sticker. Shows up on the audit log.
 
         Raises
-        -------
+        ------
         Forbidden
             You are not allowed to create stickers.
         HTTPException
             An error occurred creating a sticker.
 
         Returns
-        --------
+        -------
         :class:`GuildSticker`
             The created sticker.
         """
@@ -2473,14 +2473,14 @@ class Guild(Hashable):
         .. versionadded:: 2.0
 
         Parameters
-        -----------
+        ----------
         sticker: :class:`abc.Snowflake`
             The sticker you are deleting.
         reason: Optional[:class:`str`]
             The reason for deleting this sticker. Shows up on the audit log.
 
         Raises
-        -------
+        ------
         Forbidden
             You are not allowed to delete stickers.
         HTTPException
@@ -2498,12 +2498,12 @@ class Guild(Hashable):
             This method is an API call. For general usage, consider :attr:`emojis` instead.
 
         Raises
-        ---------
+        ------
         HTTPException
             An error occurred fetching the emojis.
 
         Returns
-        --------
+        -------
         List[:class:`Emoji`]
             The retrieved emojis.
         """
@@ -2521,19 +2521,19 @@ class Guild(Hashable):
             For general usage, consider iterating over :attr:`emojis` instead.
 
         Parameters
-        -------------
+        ----------
         emoji_id: :class:`int`
             The emoji's ID.
 
         Raises
-        ---------
+        ------
         NotFound
             The emoji requested could not be found.
         HTTPException
             An error occurred fetching the emoji.
 
         Returns
-        --------
+        -------
         :class:`Emoji`
             The retrieved emoji.
         """
@@ -2562,7 +2562,7 @@ class Guild(Hashable):
             The ``image`` parameter now accepts :class:`File`, :class:`Attachment`, and :class:`Asset`.
 
         Parameters
-        -----------
+        ----------
         name: :class:`str`
             The emoji name. Must be at least 2 characters.
         image: Union[:class:`bytes`, :class:`Asset`, :class:`Attachment`, :class:`File`]
@@ -2574,14 +2574,14 @@ class Guild(Hashable):
             The reason for creating this emoji. Shows up on the audit log.
 
         Raises
-        -------
+        ------
         Forbidden
             You are not allowed to create emojis.
         HTTPException
             An error occurred creating an emoji.
 
         Returns
-        --------
+        -------
         :class:`Emoji`
             The created emoji.
         """
@@ -2607,14 +2607,14 @@ class Guild(Hashable):
         do this.
 
         Parameters
-        -----------
+        ----------
         emoji: :class:`abc.Snowflake`
             The emoji you are deleting.
         reason: Optional[:class:`str`]
             The reason for deleting this emoji. Shows up on the audit log.
 
         Raises
-        -------
+        ------
         Forbidden
             You are not allowed to delete emojis.
         HTTPException
@@ -2639,7 +2639,7 @@ class Guild(Hashable):
             role cache. Defaults to ``False``.
 
         Raises
-        -------
+        ------
         HTTPException
             Retrieving the roles failed.
 
@@ -2713,7 +2713,7 @@ class Guild(Hashable):
             The ``icon`` parameter now accepts :class:`File`, :class:`Attachment`, and :class:`Asset`.
 
         Parameters
-        -----------
+        ----------
         name: :class:`str`
             The role name. Defaults to 'new role'.
         permissions: :class:`Permissions`
@@ -2733,7 +2733,7 @@ class Guild(Hashable):
             The reason for creating this role. Shows up on the audit log.
 
         Raises
-        -------
+        ------
         Forbidden
             You do not have permissions to create the role.
         HTTPException
@@ -2742,7 +2742,7 @@ class Guild(Hashable):
             An invalid keyword argument was given.
 
         Returns
-        --------
+        -------
         :class:`Role`
             The newly created role.
         """
@@ -2803,7 +2803,7 @@ class Guild(Hashable):
             await guild.edit_role_positions(positions=positions)
 
         Parameters
-        -----------
+        ----------
         positions
             A :class:`dict` of :class:`Role` to :class:`int` to change the positions
             of each given role.
@@ -2811,7 +2811,7 @@ class Guild(Hashable):
             The reason for editing the role positions. Shows up on the audit log.
 
         Raises
-        -------
+        ------
         Forbidden
             You do not have permissions to move the roles.
         HTTPException
@@ -2820,7 +2820,7 @@ class Guild(Hashable):
             An invalid keyword argument was given.
 
         Returns
-        --------
+        -------
         List[:class:`Role`]
             A list of all the roles in the guild.
         """
@@ -2854,14 +2854,14 @@ class Guild(Hashable):
         do this.
 
         Parameters
-        -----------
+        ----------
         user: :class:`abc.Snowflake`
             The user to kick from their guild.
         reason: Optional[:class:`str`]
             The reason the user got kicked.
 
         Raises
-        -------
+        ------
         Forbidden
             You do not have the proper permissions to kick.
         HTTPException
@@ -2886,7 +2886,7 @@ class Guild(Hashable):
         do this.
 
         Parameters
-        -----------
+        ----------
         user: :class:`abc.Snowflake`
             The user to ban from their guild.
         delete_message_days: :class:`int`
@@ -2896,7 +2896,7 @@ class Guild(Hashable):
             The reason the user got banned.
 
         Raises
-        -------
+        ------
         Forbidden
             You do not have the proper permissions to ban.
         HTTPException
@@ -2915,14 +2915,14 @@ class Guild(Hashable):
         do this.
 
         Parameters
-        -----------
+        ----------
         user: :class:`abc.Snowflake`
             The user to unban.
         reason: Optional[:class:`str`]
             The reason for doing this action. Shows up on the audit log.
 
         Raises
-        -------
+        ------
         Forbidden
             You do not have the proper permissions to unban.
         HTTPException
@@ -2941,14 +2941,14 @@ class Guild(Hashable):
         this as well.
 
         Raises
-        -------
+        ------
         Forbidden
             You do not have the proper permissions to get this.
         HTTPException
             Retrieving the vanity invite failed.
 
         Returns
-        --------
+        -------
         Optional[:class:`Invite`]
             The special vanity invite. If ``None`` then the guild does not
             have a vanity invite set.
@@ -2987,7 +2987,7 @@ class Guild(Hashable):
         You must have the :attr:`~Permissions.view_audit_log` permission to use this.
 
         Examples
-        ----------
+        --------
 
         Getting the first 100 entries: ::
 
@@ -3005,7 +3005,7 @@ class Guild(Hashable):
             await channel.send(f'I made {len(entries)} moderation actions.')
 
         Parameters
-        -----------
+        ----------
         limit: :class:`int`
             The number of entries to retrieve. If ``None`` retrieve all entries.
         before: Optional[Union[:class:`abc.Snowflake`, :class:`datetime.datetime`]]
@@ -3025,14 +3025,14 @@ class Guild(Hashable):
             The action to filter with.
 
         Raises
-        -------
+        ------
         Forbidden
             You are not allowed to fetch audit logs
         HTTPException
             An error occurred while fetching the audit logs.
 
         Yields
-        --------
+        ------
         :class:`AuditLogEntry`
             The audit log entry.
         """
@@ -3064,14 +3064,14 @@ class Guild(Hashable):
             The guild must have the widget enabled to get this information.
 
         Raises
-        -------
+        ------
         Forbidden
             The widget for this guild is disabled.
         HTTPException
             Retrieving the widget failed.
 
         Returns
-        --------
+        -------
         :class:`Widget`
             The guild's widget.
         """
@@ -3092,14 +3092,14 @@ class Guild(Hashable):
         .. versionadded:: 2.0
 
         Parameters
-        -----------
+        ----------
         enabled: :class:`bool`
             Whether to enable the widget for the guild.
         channel: Optional[:class:`~nextcord.abc.Snowflake`]
             The new widget channel. ``None`` removes the widget channel.
 
         Raises
-        -------
+        ------
         Forbidden
             You do not have permission to edit the widget.
         HTTPException
@@ -3124,17 +3124,17 @@ class Guild(Hashable):
         .. versionadded:: 1.5
 
         Parameters
-        -----------
+        ----------
         cache: :class:`bool`
             Whether to cache the members as well.
 
         Raises
-        -------
+        ------
         ClientException
             The members intent is not enabled.
 
         Returns
-        --------
+        -------
         Optional[List[:class:`Member`]]
              Returns a list of all the members in the guild.
         """
@@ -3168,7 +3168,7 @@ class Guild(Hashable):
         .. versionadded:: 1.3
 
         Parameters
-        -----------
+        ----------
         query: Optional[:class:`str`]
             The string that the username's start with.
         limit: :class:`int`
@@ -3190,7 +3190,7 @@ class Guild(Hashable):
 
 
         Raises
-        -------
+        ------
         asyncio.TimeoutError
             The query timed out waiting for the members.
         ValueError
@@ -3239,7 +3239,7 @@ class Guild(Hashable):
         .. versionadded:: 1.4
 
         Parameters
-        -----------
+        ----------
         channel: Optional[:class:`VoiceChannel`]
             Channel the client wants to join. Use ``None`` to disconnect.
         self_mute: :class:`bool`

--- a/nextcord/integrations.py
+++ b/nextcord/integrations.py
@@ -59,7 +59,7 @@ class IntegrationAccount:
     .. versionadded:: 1.4
 
     Attributes
-    -----------
+    ----------
     id: :class:`str`
         The account ID.
     name: :class:`str`
@@ -82,7 +82,7 @@ class Integration:
     .. versionadded:: 1.4
 
     Attributes
-    -----------
+    ----------
     id: :class:`int`
         The integration ID.
     name: :class:`str`
@@ -137,14 +137,14 @@ class Integration:
         do this.
 
         Parameters
-        -----------
+        ----------
         reason: :class:`str`
             The reason the integration was deleted. Shows up on the audit log.
 
             .. versionadded:: 2.0
 
         Raises
-        -------
+        ------
         Forbidden
             You do not have permission to delete the integration.
         HTTPException
@@ -233,7 +233,7 @@ class StreamIntegration(Integration):
         do this.
 
         Parameters
-        -----------
+        ----------
         expire_behaviour: :class:`ExpireBehaviour`
             The behaviour when an integration subscription lapses. Aliased to ``expire_behavior`` as well.
         expire_grace_period: :class:`int`
@@ -242,7 +242,7 @@ class StreamIntegration(Integration):
             Where emoticons should be synced for this integration (currently twitch only).
 
         Raises
-        -------
+        ------
         Forbidden
             You do not have permission to edit the integration.
         HTTPException
@@ -276,7 +276,7 @@ class StreamIntegration(Integration):
         do this.
 
         Raises
-        -------
+        ------
         Forbidden
             You do not have permission to sync the integration.
         HTTPException

--- a/nextcord/interactions.py
+++ b/nextcord/interactions.py
@@ -146,7 +146,7 @@ class Interaction(Hashable, Generic[ClientT]):
         :class:`Interaction` is now hashable.
 
     Attributes
-    -----------
+    ----------
     id: :class:`int`
         The interaction's ID.
     type: :class:`InteractionType`
@@ -352,14 +352,14 @@ class Interaction(Hashable, Generic[ClientT]):
         Repeated calls to this will return a cached value.
 
         Raises
-        -------
+        ------
         HTTPException
             Fetching the original response message failed.
         ClientException
             The channel for the message could not be resolved.
 
         Returns
-        --------
+        -------
         InteractionMessage
             The original interaction response message.
         """
@@ -406,7 +406,7 @@ class Interaction(Hashable, Generic[ClientT]):
         the message sent was ephemeral.
 
         Parameters
-        ------------
+        ----------
         content: Optional[:class:`str`]
             The content to edit the message with or ``None`` to clear it.
         embeds: List[:class:`Embed`]
@@ -431,7 +431,7 @@ class Interaction(Hashable, Generic[ClientT]):
             the view is removed.
 
         Raises
-        -------
+        ------
         HTTPException
             Editing the message failed.
         Forbidden
@@ -442,7 +442,7 @@ class Interaction(Hashable, Generic[ClientT]):
             The length of ``embeds`` was invalid.
 
         Returns
-        --------
+        -------
         :class:`InteractionMessage`
             The newly edited message.
         """
@@ -484,13 +484,13 @@ class Interaction(Hashable, Generic[ClientT]):
         you do not want to fetch the message and save an HTTP request.
 
         Parameters
-        -----------
+        ----------
         delay: Optional[:class:`float`]
             If provided, the number of seconds to wait before deleting the message.
             The waiting is done in the background and deletion failures are ignored.
 
         Raises
-        -------
+        ------
         HTTPException
             Deleting the message failed.
         Forbidden
@@ -539,7 +539,7 @@ class Interaction(Hashable, Generic[ClientT]):
         via :attr:`Interaction.followup` using :class:`Webhook.send` instead.
 
         Raises
-        --------
+        ------
         HTTPException
             Sending the message failed.
         NotFound
@@ -663,7 +663,7 @@ class InteractionResponse:
         and a secondary action will be done later.
 
         Parameters
-        -----------
+        ----------
         ephemeral: :class:`bool`
             Indicates whether the deferred message will eventually be ephemeral.
             This only applies for interactions of type :attr:`InteractionType.application_command` or when ``with_message`` is True
@@ -675,7 +675,7 @@ class InteractionResponse:
             .. versionadded:: 2.0
 
         Raises
-        -------
+        ------
         HTTPException
             Deferring the interaction failed.
         InteractionResponded
@@ -711,7 +711,7 @@ class InteractionResponse:
         This should rarely be used.
 
         Raises
-        -------
+        ------
         HTTPException
             Ponging the interaction failed.
         InteractionResponded
@@ -746,7 +746,7 @@ class InteractionResponse:
             name-value pair, where the display name and the value Discord sends back are the same.
 
         Raises
-        -------
+        ------
         HTTPException
             Sending the message failed.
         InteractionResponded
@@ -790,7 +790,7 @@ class InteractionResponse:
         Responds to this interaction by sending a message.
 
         Parameters
-        -----------
+        ----------
         content: Optional[:class:`str`]
             The content of the message to send.
         embeds: List[:class:`Embed`]
@@ -821,7 +821,7 @@ class InteractionResponse:
             See :meth:`.abc.Messageable.send` for more information.
 
         Raises
-        -------
+        ------
         HTTPException
             Sending the message failed.
         NotFound
@@ -838,7 +838,7 @@ class InteractionResponse:
             This interaction has already been responded to before.
 
         Returns
-        --------
+        -------
         :class:`PartialInteractionMessage`
             An object supporting only the :meth:`~PartialInteractionMessage.edit` and :meth:`~PartialInteractionMessage.delete`
             operations. To fetch the :class:`InteractionMessage` you may use :meth:`PartialInteractionMessage.fetch`
@@ -931,7 +931,7 @@ class InteractionResponse:
             be displayed on the user's screen.
 
         Raises
-        -------
+        ------
         HTTPException
             Sending the modal failed.
         InteractionResponded
@@ -972,7 +972,7 @@ class InteractionResponse:
         component or modal submit interaction originated from.
 
         Parameters
-        -----------
+        ----------
         content: Optional[:class:`str`]
             The new content to replace the message with. ``None`` removes the content.
         embeds: List[:class:`Embed`]
@@ -998,7 +998,7 @@ class InteractionResponse:
 
 
         Raises
-        -------
+        ------
         HTTPException
             Editing the message failed.
         InvalidArgument
@@ -1009,7 +1009,7 @@ class InteractionResponse:
             This interaction has already been responded to before.
 
         Returns
-        --------
+        -------
         Optional[:class:`Message`]
             The message that was edited, or None if the :attr:`Interaction.message` is not found
             (this may happen if the interaction occurred in a :class:`Thread`).
@@ -1132,7 +1132,7 @@ class _InteractionMessageMixin:
         Edits the message.
 
         Parameters
-        ------------
+        ----------
         content: Optional[:class:`str`]
             The content to edit the message with or ``None`` to clear it.
         embeds: List[:class:`Embed`]
@@ -1161,7 +1161,7 @@ class _InteractionMessageMixin:
             then it is silently ignored.
 
         Raises
-        -------
+        ------
         HTTPException
             Editing the message failed.
         Forbidden
@@ -1172,7 +1172,7 @@ class _InteractionMessageMixin:
             The length of ``embeds`` was invalid.
 
         Returns
-        ---------
+        -------
         :class:`InteractionMessage`
             The newly edited message.
         """
@@ -1198,7 +1198,7 @@ class _InteractionMessageMixin:
         Deletes the message.
 
         Parameters
-        -----------
+        ----------
         delay: Optional[:class:`float`]
             If provided, the number of seconds to wait before deleting the message.
             The waiting is done in the background and deletion failures are ignored.
@@ -1263,14 +1263,14 @@ class PartialInteractionMessage(_InteractionMessageMixin):
         Repeated calls to this will return a cached value.
 
         Raises
-        -------
+        ------
         HTTPException
             Fetching the original response message failed.
         ClientException
             The channel for the message could not be resolved.
 
         Returns
-        --------
+        -------
         InteractionMessage
             The original interaction response message.
         """

--- a/nextcord/interactions.py
+++ b/nextcord/interactions.py
@@ -94,7 +94,7 @@ class InteractionAttached(dict):
     This is used to store information about an :class:`Interaction`. This is useful if you want to save some data from a :meth:`ApplicationCommand.application_command_before_invoke` to use later in the callback.
 
     Example
-    ---------
+    -------
 
     .. code-block:: python3
 

--- a/nextcord/invite.py
+++ b/nextcord/invite.py
@@ -83,7 +83,7 @@ class PartialInviteChannel:
             Returns the partial channel's name.
 
     Attributes
-    -----------
+    ----------
     name: :class:`str`
         The partial channel's name.
     id: :class:`int`
@@ -141,7 +141,7 @@ class PartialInviteGuild:
             Returns the partial guild's name.
 
     Attributes
-    -----------
+    ----------
     name: :class:`str`
         The partial guild's name.
     id: :class:`int`
@@ -267,7 +267,7 @@ class Invite(Hashable):
     If it's not in the table above then it is available by all methods.
 
     Attributes
-    -----------
+    ----------
     max_age: :class:`int`
         How long before the invite expires in seconds.
         A value of ``0`` indicates that it doesn't expire.
@@ -491,12 +491,12 @@ class Invite(Hashable):
         You must have the :attr:`~Permissions.manage_channels` permission to do this.
 
         Parameters
-        -----------
+        ----------
         reason: Optional[:class:`str`]
             The reason for deleting this invite. Shows up on the audit log.
 
         Raises
-        -------
+        ------
         Forbidden
             You do not have permissions to revoke invites.
         NotFound

--- a/nextcord/iterators.py
+++ b/nextcord/iterators.py
@@ -256,7 +256,7 @@ class HistoryIterator(_AsyncIterator["Message"]):
     messages endpoint.
 
     Parameters
-    -----------
+    ----------
     messageable: :class:`abc.Messageable`
         Messageable class to retrieve message history from.
     limit: :class:`int`
@@ -414,7 +414,7 @@ class BanIterator(_AsyncIterator["BanEntry"]):
     bans endpoint.
 
     Parameters
-    -----------
+    ----------
     guild: :class:`~nextcord.Guild`
         The guild to get bans from.
     limit: Optional[:class:`int`]
@@ -623,7 +623,7 @@ class GuildIterator(_AsyncIterator["Guild"]):
     guilds endpoint.
 
     Parameters
-    -----------
+    ----------
     bot: :class:`nextcord.Client`
         The client to retrieve the guilds from.
     limit: :class:`int`

--- a/nextcord/member.py
+++ b/nextcord/member.py
@@ -73,7 +73,7 @@ class VoiceState:
     """Represents a Discord user's voice state.
 
     Attributes
-    ------------
+    ----------
     deaf: :class:`bool`
         Indicates if the user is currently deafened by the guild.
     mute: :class:`bool`
@@ -570,7 +570,7 @@ class Member(abc.Messageable, _UserTag):
         """Checks if the member is mentioned in the specified message.
 
         Parameters
-        -----------
+        ----------
         message: :class:`Message`
             The message to check if you're mentioned in.
 
@@ -689,7 +689,7 @@ class Member(abc.Messageable, _UserTag):
         .. versionadded:: 2.0
 
         Parameters
-        -----------
+        ----------
         timeout: Optional[Union[:class:`~datetime.datetime`, :class:`~datetime.timedelta`]]
             The time until the member should not be timed out.
             Set this to None to disable their timeout.
@@ -741,7 +741,7 @@ class Member(abc.Messageable, _UserTag):
             The newly member is now optionally returned, if applicable.
 
         Parameters
-        -----------
+        ----------
         nick: Optional[:class:`str`]
             The member's new nickname. Use ``None`` to remove the nickname.
         mute: :class:`bool`
@@ -767,14 +767,14 @@ class Member(abc.Messageable, _UserTag):
             .. versionadded:: 2.0
 
         Raises
-        -------
+        ------
         Forbidden
             You do not have the proper permissions to the action requested.
         HTTPException
             The operation failed.
 
         Returns
-        --------
+        -------
         Optional[:class:`.Member`]
             The newly updated member, if applicable. This is only returned
             when certain fields are updated.
@@ -859,7 +859,7 @@ class Member(abc.Messageable, _UserTag):
         .. versionadded:: 1.7
 
         Raises
-        -------
+        ------
         Forbidden
             You do not have the proper permissions to the action requested.
         HTTPException
@@ -892,7 +892,7 @@ class Member(abc.Messageable, _UserTag):
             Can now pass ``None`` to kick a member from voice.
 
         Parameters
-        -----------
+        ----------
         channel: Optional[:class:`VoiceChannel`]
             The new voice channel to move the member to.
             Pass ``None`` to kick them from voice.
@@ -912,7 +912,7 @@ class Member(abc.Messageable, _UserTag):
         This raises the same exceptions as :meth:`edit`.
 
         Parameters
-        -----------
+        ----------
         reason: Optional[:class:`str`]
             The reason for doing this action. Shows up on the audit log.
         """
@@ -930,7 +930,7 @@ class Member(abc.Messageable, _UserTag):
         of roles than the highest role of the member.
 
         Parameters
-        -----------
+        ----------
         \*roles: :class:`abc.Snowflake`
             An argument list of :class:`abc.Snowflake` representing a :class:`Role`
             to give to the member.
@@ -942,7 +942,7 @@ class Member(abc.Messageable, _UserTag):
             state of the cache.
 
         Raises
-        -------
+        ------
         Forbidden
             You do not have permissions to add these roles.
         HTTPException
@@ -973,7 +973,7 @@ class Member(abc.Messageable, _UserTag):
         of roles than the highest role of the member.
 
         Parameters
-        -----------
+        ----------
         \*roles: :class:`abc.Snowflake`
             An argument list of :class:`abc.Snowflake` representing a :class:`Role`
             to remove from the member.
@@ -985,7 +985,7 @@ class Member(abc.Messageable, _UserTag):
             state of the cache.
 
         Raises
-        -------
+        ------
         Forbidden
             You do not have permissions to remove these roles.
         HTTPException
@@ -1016,12 +1016,12 @@ class Member(abc.Messageable, _UserTag):
         .. versionadded:: 2.0
 
         Parameters
-        -----------
+        ----------
         role_id: :class:`int`
             The ID to search for.
 
         Returns
-        --------
+        -------
         Optional[:class:`Role`]
             The role or ``None`` if not found in the member's roles.
         """

--- a/nextcord/mentions.py
+++ b/nextcord/mentions.py
@@ -57,7 +57,7 @@ class AllowedMentions:
     via :meth:`abc.Messageable.send` for more fine-grained control.
 
     Attributes
-    ------------
+    ----------
     everyone: :class:`bool`
         Whether to allow everyone and here mentions. Defaults to ``True``.
     users: Union[:class:`bool`, List[:class:`abc.Snowflake`]]

--- a/nextcord/message.py
+++ b/nextcord/message.py
@@ -141,7 +141,7 @@ class Attachment(Hashable):
         Attachment can now be casted to :class:`str` and is hashable.
 
     Attributes
-    ------------
+    ----------
     id: :class:`int`
         The attachment ID.
     size: :class:`int`
@@ -216,7 +216,7 @@ class Attachment(Hashable):
         Saves this attachment into a file-like object.
 
         Parameters
-        -----------
+        ----------
         fp: Union[:class:`io.BufferedIOBase`, :class:`os.PathLike`, :class:`str`]
             The file-like object to save this attachment to or the filename
             to use. If a filename is passed then a file is created with that
@@ -233,14 +233,14 @@ class Attachment(Hashable):
             on some types of attachments.
 
         Raises
-        --------
+        ------
         HTTPException
             Saving the attachment failed.
         NotFound
             The attachment was deleted.
 
         Returns
-        --------
+        -------
         :class:`int`
             The number of bytes written.
         """
@@ -262,7 +262,7 @@ class Attachment(Hashable):
         .. versionadded:: 1.1
 
         Parameters
-        -----------
+        ----------
         use_cached: :class:`bool`
             Whether to use :attr:`proxy_url` rather than :attr:`url` when downloading
             the attachment. This will allow attachments to be saved after deletion
@@ -306,7 +306,7 @@ class Attachment(Hashable):
         .. versionadded:: 1.3
 
         Parameters
-        -----------
+        ----------
         filename: Optional[:class:`str`]
             The filename to use for the file. If not specified then the filename
             of the attachment is used instead.
@@ -429,7 +429,7 @@ class MessageReference:
         This class can now be constructed by users.
 
     Attributes
-    -----------
+    ----------
     message_id: Optional[:class:`int`]
         The id of the message referenced.
     channel_id: :class:`int`
@@ -581,7 +581,7 @@ class MessageInteraction(Hashable):
             Returns the message interaction's hash.
 
     Attributes
-    -----------
+    ----------
     data: Dict[:class:`str`, Any]
         The raw data from the interaction.
     id: :class:`int`
@@ -646,7 +646,7 @@ class Message(Hashable):
             Returns the message's hash.
 
     Attributes
-    -----------
+    ----------
     tts: :class:`bool`
         Specifies if the message was done with text-to-speech.
         This can only be accurately received in :func:`on_message` due to
@@ -1303,7 +1303,7 @@ class Message(Hashable):
             Added the new ``delay`` keyword-only parameter.
 
         Parameters
-        -----------
+        ----------
         delay: Optional[:class:`float`]
             If provided, the number of seconds to wait in the background
             before deleting the message. If the deletion fails then it is silently ignored.
@@ -1413,7 +1413,7 @@ class Message(Hashable):
             The ``suppress`` keyword-only parameter was added.
 
         Parameters
-        -----------
+        ----------
         content: Optional[:class:`str`]
             The new content to replace the message with.
             Could be ``None`` to remove the content.
@@ -1459,7 +1459,7 @@ class Message(Hashable):
             .. versionadded:: 2.0
 
         Raises
-        -------
+        ------
         HTTPException
             Editing the message failed.
         Forbidden
@@ -1469,7 +1469,7 @@ class Message(Hashable):
             You specified both ``embed`` and ``embeds`` or ``file`` and ``files``.
 
         Returns
-        --------
+        -------
         :class:`Message`
             The edited message.
         """
@@ -1548,7 +1548,7 @@ class Message(Hashable):
         permission is also needed.
 
         Raises
-        -------
+        ------
         Forbidden
             You do not have the proper permissions to publish this message.
         HTTPException
@@ -1566,14 +1566,14 @@ class Message(Hashable):
         this in a non-private channel context.
 
         Parameters
-        -----------
+        ----------
         reason: Optional[:class:`str`]
             The reason for pinning the message. Shows up on the audit log.
 
             .. versionadded:: 1.4
 
         Raises
-        -------
+        ------
         Forbidden
             You do not have permissions to pin the message.
         NotFound
@@ -1595,14 +1595,14 @@ class Message(Hashable):
         this in a non-private channel context.
 
         Parameters
-        -----------
+        ----------
         reason: Optional[:class:`str`]
             The reason for unpinning the message. Shows up on the audit log.
 
             .. versionadded:: 1.4
 
         Raises
-        -------
+        ------
         Forbidden
             You do not have permissions to unpin the message.
         NotFound
@@ -1626,12 +1626,12 @@ class Message(Hashable):
         emoji, the :attr:`~Permissions.add_reactions` permission is required.
 
         Parameters
-        ------------
+        ----------
         emoji: Union[:class:`Emoji`, :class:`Reaction`, :class:`PartialEmoji`, :class:`str`]
             The emoji to react with.
 
         Raises
-        --------
+        ------
         HTTPException
             Adding the reaction failed.
         Forbidden
@@ -1661,14 +1661,14 @@ class Message(Hashable):
         the :class:`abc.Snowflake` abc.
 
         Parameters
-        ------------
+        ----------
         emoji: Union[:class:`Emoji`, :class:`Reaction`, :class:`PartialEmoji`, :class:`str`]
             The emoji to remove.
         member: :class:`abc.Snowflake`
             The member for which to remove the reaction.
 
         Raises
-        --------
+        ------
         HTTPException
             Removing the reaction failed.
         Forbidden
@@ -1698,12 +1698,12 @@ class Message(Hashable):
         .. versionadded:: 1.3
 
         Parameters
-        -----------
+        ----------
         emoji: Union[:class:`Emoji`, :class:`Reaction`, :class:`PartialEmoji`, :class:`str`]
             The emoji to clear.
 
         Raises
-        --------
+        ------
         HTTPException
             Clearing the reaction failed.
         Forbidden
@@ -1725,7 +1725,7 @@ class Message(Hashable):
         You need the :attr:`~Permissions.manage_messages` permission to use this.
 
         Raises
-        --------
+        ------
         HTTPException
             Removing the reactions failed.
         Forbidden
@@ -1748,7 +1748,7 @@ class Message(Hashable):
         .. versionadded:: 2.0
 
         Parameters
-        -----------
+        ----------
         name: :class:`str`
             The name of the thread.
         auto_archive_duration: :class:`int`
@@ -1756,7 +1756,7 @@ class Message(Hashable):
             If not provided, the channel's default auto archive duration is used.
 
         Raises
-        -------
+        ------
         Forbidden
             You do not have permissions to create a thread.
         HTTPException
@@ -1765,7 +1765,7 @@ class Message(Hashable):
             This message does not have guild info attached.
 
         Returns
-        --------
+        -------
         :class:`.Thread`
             The created thread.
         """
@@ -1792,7 +1792,7 @@ class Message(Hashable):
         .. versionadded:: 1.6
 
         Raises
-        --------
+        ------
         ~nextcord.HTTPException
             Sending the message failed.
         ~nextcord.Forbidden
@@ -1802,7 +1802,7 @@ class Message(Hashable):
             you specified both ``file`` and ``files``.
 
         Returns
-        ---------
+        -------
         :class:`.Message`
             The message that was sent.
         """
@@ -1872,7 +1872,7 @@ class PartialMessage(Hashable):
             Returns the partial message's hash.
 
     Attributes
-    -----------
+    ----------
     channel: Union[:class:`TextChannel`, :class:`Thread`, :class:`DMChannel`]
         The channel associated with this partial message.
     id: :class:`int`
@@ -1937,7 +1937,7 @@ class PartialMessage(Hashable):
         Fetches the partial message to a full :class:`Message`.
 
         Raises
-        --------
+        ------
         NotFound
             The message was not found.
         Forbidden
@@ -1946,7 +1946,7 @@ class PartialMessage(Hashable):
             Retrieving the message failed.
 
         Returns
-        --------
+        -------
         :class:`Message`
             The full message.
         """
@@ -1965,7 +1965,7 @@ class PartialMessage(Hashable):
             :class:`nextcord.Message` is returned instead of ``None`` if an edit took place.
 
         Parameters
-        -----------
+        ----------
         content: Optional[:class:`str`]
             The new content to replace the message with.
             Could be ``None`` to remove the content.
@@ -2000,7 +2000,7 @@ class PartialMessage(Hashable):
             .. versionadded:: 2.0
 
         Raises
-        -------
+        ------
         NotFound
             The message was not found.
         HTTPException
@@ -2012,7 +2012,7 @@ class PartialMessage(Hashable):
             You specified both ``embed`` and ``embeds``.
 
         Returns
-        ---------
+        -------
         Optional[:class:`Message`]
             The message that was edited.
         """

--- a/nextcord/message.py
+++ b/nextcord/message.py
@@ -1823,7 +1823,7 @@ class Message(Hashable):
             .. versionadded:: 1.7
 
         Returns
-        ---------
+        -------
         :class:`~nextcord.MessageReference`
             The reference to this message.
         """

--- a/nextcord/mixins.py
+++ b/nextcord/mixins.py
@@ -77,12 +77,12 @@ class PinsMixin:
             :attr:`.Message.reactions` data.
 
         Raises
-        -------
+        ------
         ~nextcord.HTTPException
             Retrieving the pinned messages failed.
 
         Returns
-        --------
+        -------
         List[:class:`~nextcord.Message`]
             The messages that are currently pinned.
         """

--- a/nextcord/object.py
+++ b/nextcord/object.py
@@ -66,7 +66,7 @@ class Object(Hashable):
             Returns the object's hash.
 
     Attributes
-    -----------
+    ----------
     id: :class:`int`
         The ID of the object.
     """

--- a/nextcord/partial_emoji.py
+++ b/nextcord/partial_emoji.py
@@ -79,7 +79,7 @@ class PartialEmoji(_EmojiTag, AssetMixin):
             Returns the emoji rendered for discord.
 
     Attributes
-    -----------
+    ----------
     name: Optional[:class:`str`]
         The custom emoji name, if applicable, or the unicode codepoint
         of the non-custom emoji. This can be ``None`` if the emoji
@@ -129,12 +129,12 @@ class PartialEmoji(_EmojiTag, AssetMixin):
         .. versionadded:: 2.0
 
         Parameters
-        ------------
+        ----------
         value: :class:`str`
             The string representation of an emoji.
 
         Returns
-        --------
+        -------
         :class:`PartialEmoji`
             The partial emoji from this string.
         """

--- a/nextcord/permissions.py
+++ b/nextcord/permissions.py
@@ -106,7 +106,7 @@ class Permissions(BaseFlags):
                Note that aliases are not shown.
 
     Attributes
-    -----------
+    ----------
     value: :class:`int`
         The raw value. This value is a bit array field of a 53-bit integer
         representing the currently available permissions. You should query
@@ -275,7 +275,7 @@ class Permissions(BaseFlags):
         listed. Extraneous key/value pairs will be silently ignored.
 
         Parameters
-        ------------
+        ----------
         \*\*kwargs
             A list of key/value pairs to bulk update permissions with.
         """
@@ -651,7 +651,7 @@ class PermissionOverwrite:
            Note that aliases are not shown.
 
     Parameters
-    -----------
+    ----------
     \*\*kwargs
         Set the value of permissions by their name.
     """
@@ -779,7 +779,7 @@ class PermissionOverwrite:
         listed. Extraneous key/value pairs will be silently ignored.
 
         Parameters
-        ------------
+        ----------
         \*\*kwargs
             A list of key/value pairs to bulk update with.
         """

--- a/nextcord/player.py
+++ b/nextcord/player.py
@@ -94,7 +94,7 @@ class AudioSource:
         per frame (20ms worth of audio).
 
         Returns
-        --------
+        -------
         :class:`bytes`
             A bytes like object that represents the PCM or Opus data.
         """
@@ -120,7 +120,7 @@ class PCMAudio(AudioSource):
     """Represents raw 16-bit 48KHz stereo PCM audio source.
 
     Attributes
-    -----------
+    ----------
     stream: :term:`py:file object`
         A file-like object that reads byte data representing raw PCM.
     """
@@ -247,7 +247,7 @@ class FFmpegPCMAudio(FFmpegAudio):
         variable in order for this to work.
 
     Parameters
-    ------------
+    ----------
     source: Union[:class:`str`, :class:`io.BufferedIOBase`]
         The input that ffmpeg will take and convert to PCM bytes.
         If ``pipe`` is ``True`` then this is a file-like object that is
@@ -266,7 +266,7 @@ class FFmpegPCMAudio(FFmpegAudio):
         Extra command line arguments to pass to ffmpeg after the ``-i`` flag.
 
     Raises
-    --------
+    ------
     ClientException
         The subprocess failed to be created.
     """
@@ -333,7 +333,7 @@ class FFmpegOpusAudio(FFmpegAudio):
         variable in order for this to work.
 
     Parameters
-    ------------
+    ----------
     source: Union[:class:`str`, :class:`io.BufferedIOBase`]
         The input that ffmpeg will take and convert to Opus bytes.
         If ``pipe`` is ``True`` then this is a file-like object that is
@@ -367,7 +367,7 @@ class FFmpegOpusAudio(FFmpegAudio):
         Extra command line arguments to pass to ffmpeg after the ``-i`` flag.
 
     Raises
-    --------
+    ------
     ClientException
         The subprocess failed to be created.
     """
@@ -465,7 +465,7 @@ class FFmpegOpusAudio(FFmpegAudio):
             voice_client.play(source)
 
         Parameters
-        ------------
+        ----------
         source
             Identical to the ``source`` parameter for the constructor.
         method: Optional[Union[:class:`str`, Callable[:class:`str`, :class:`str`]]]
@@ -479,14 +479,14 @@ class FFmpegOpusAudio(FFmpegAudio):
             excluding ``bitrate`` and ``codec``.
 
         Raises
-        --------
+        ------
         AttributeError
             Invalid probe method, must be ``'native'`` or ``'fallback'``.
         TypeError
             Invalid value for ``probe`` parameter, must be :class:`str` or a callable.
 
         Returns
-        --------
+        -------
         :class:`FFmpegOpusAudio`
             An instance of this class.
         """
@@ -510,7 +510,7 @@ class FFmpegOpusAudio(FFmpegAudio):
         Probes the input source for bitrate and codec information.
 
         Parameters
-        ------------
+        ----------
         source
             Identical to the ``source`` parameter for :class:`FFmpegOpusAudio`.
         method
@@ -519,14 +519,14 @@ class FFmpegOpusAudio(FFmpegAudio):
             Identical to the ``executable`` parameter for :class:`FFmpegOpusAudio`.
 
         Raises
-        --------
+        ------
         AttributeError
             Invalid probe method, must be ``'native'`` or ``'fallback'``.
         TypeError
             Invalid value for ``probe`` parameter, must be :class:`str` or a callable.
 
         Returns
-        ---------
+        -------
         Optional[Tuple[Optional[:class:`str`], Optional[:class:`int`]]]
             A 2-tuple with the codec and bitrate of the input source.
         """
@@ -640,7 +640,7 @@ class PCMVolumeTransformer(AudioSource, Generic[AT]):
     set to ``True``.
 
     Parameters
-    ------------
+    ----------
     original: :class:`AudioSource`
         The original AudioSource to transform.
     volume: :class:`float`
@@ -648,7 +648,7 @@ class PCMVolumeTransformer(AudioSource, Generic[AT]):
         See :attr:`volume` for more info.
 
     Raises
-    -------
+    ------
     TypeError
         Not an audio source.
     ClientException

--- a/nextcord/player.py
+++ b/nextcord/player.py
@@ -442,7 +442,7 @@ class FFmpegOpusAudio(FFmpegAudio):
         the input source for audio codec and bitrate information.
 
         Examples
-        ----------
+        --------
 
         Use this function to create an :class:`FFmpegOpusAudio` instance instead of the constructor: ::
 

--- a/nextcord/raw_models.py
+++ b/nextcord/raw_models.py
@@ -70,7 +70,7 @@ class RawMessageDeleteEvent(_RawReprMixin):
     """Represents the event payload for a :func:`on_raw_message_delete` event.
 
     Attributes
-    ------------
+    ----------
     channel_id: :class:`int`
         The channel ID where the deletion took place.
     guild_id: Optional[:class:`int`]
@@ -97,7 +97,7 @@ class RawBulkMessageDeleteEvent(_RawReprMixin):
     """Represents the event payload for a :func:`on_raw_bulk_message_delete` event.
 
     Attributes
-    -----------
+    ----------
     message_ids: Set[:class:`int`]
         A :class:`set` of the message IDs that were deleted.
     channel_id: :class:`int`
@@ -125,7 +125,7 @@ class RawMessageUpdateEvent(_RawReprMixin):
     """Represents the payload for a :func:`on_raw_message_edit` event.
 
     Attributes
-    -----------
+    ----------
     message_id: :class:`int`
         The message ID that got updated.
     channel_id: :class:`int`
@@ -163,7 +163,7 @@ class RawReactionActionEvent(_RawReprMixin):
     :func:`on_raw_reaction_remove` event.
 
     Attributes
-    -----------
+    ----------
     message_id: :class:`int`
         The message ID that got or lost a reaction.
     user_id: :class:`int`
@@ -207,7 +207,7 @@ class RawReactionClearEvent(_RawReprMixin):
     """Represents the payload for a :func:`on_raw_reaction_clear` event.
 
     Attributes
-    -----------
+    ----------
     message_id: :class:`int`
         The message ID that got its reactions cleared.
     channel_id: :class:`int`
@@ -234,7 +234,7 @@ class RawReactionClearEmojiEvent(_RawReprMixin):
     .. versionadded:: 1.3
 
     Attributes
-    -----------
+    ----------
     message_id: :class:`int`
         The message ID that got its reactions cleared.
     channel_id: :class:`int`
@@ -264,7 +264,7 @@ class RawIntegrationDeleteEvent(_RawReprMixin):
     .. versionadded:: 2.0
 
     Attributes
-    -----------
+    ----------
     integration_id: :class:`int`
         The ID of the integration that got deleted.
     application_id: Optional[:class:`int`]
@@ -291,7 +291,7 @@ class RawTypingEvent(_RawReprMixin):
     .. versionadded:: 2.0
 
     Attributes
-    -----------
+    ----------
     channel_id: :class:`int`
         The channel ID where the typing originated from.
     user_id: :class:`int`
@@ -326,7 +326,7 @@ class RawMemberRemoveEvent(_RawReprMixin):
     .. versionadded:: 2.0
 
     Attributes
-    -----------
+    ----------
     guild_id: :class:`int`
         The guild ID where the member left from.
     """

--- a/nextcord/reaction.py
+++ b/nextcord/reaction.py
@@ -173,7 +173,7 @@ class Reaction:
         and meet the :class:`abc.Snowflake` abc.
 
         Examples
-        ---------
+        --------
 
         Usage ::
 

--- a/nextcord/reaction.py
+++ b/nextcord/reaction.py
@@ -65,7 +65,7 @@ class Reaction:
             Returns the string form of the reaction's emoji.
 
     Attributes
-    -----------
+    ----------
     emoji: Union[:class:`Emoji`, :class:`PartialEmoji`, :class:`str`]
         The reaction emoji. May be a custom emoji, or a unicode emoji.
     count: :class:`int`
@@ -126,12 +126,12 @@ class Reaction:
         the :class:`abc.Snowflake` abc.
 
         Parameters
-        -----------
+        ----------
         user: :class:`abc.Snowflake`
              The user or member from which to remove the reaction.
 
         Raises
-        -------
+        ------
         HTTPException
             Removing the reaction failed.
         Forbidden
@@ -152,7 +152,7 @@ class Reaction:
         .. versionadded:: 1.3
 
         Raises
-        --------
+        ------
         HTTPException
             Clearing the reaction failed.
         Forbidden
@@ -189,7 +189,7 @@ class Reaction:
             await channel.send(f'{winner} has won the raffle.')
 
         Parameters
-        ------------
+        ----------
         limit: Optional[:class:`int`]
             The maximum number of results to return.
             If not provided, returns all the users who
@@ -198,12 +198,12 @@ class Reaction:
             For pagination, reactions are sorted by member.
 
         Raises
-        --------
+        ------
         HTTPException
             Getting the users for the reaction failed.
 
         Yields
-        --------
+        ------
         Union[:class:`User`, :class:`Member`]
             The member (if retrievable) or the user that has reacted
             to this message. The case where it can be a :class:`Member` is

--- a/nextcord/role.py
+++ b/nextcord/role.py
@@ -62,7 +62,7 @@ class RoleTags:
     .. versionadded:: 1.6
 
     Attributes
-    ------------
+    ----------
     bot_id: Optional[:class:`int`]
         The bot's user ID that manages this role.
     integration_id: Optional[:class:`int`]
@@ -399,7 +399,7 @@ class Role(Hashable):
             The ``icon`` parameter now accepts :class:`Attachment`, and :class:`Asset`.
 
         Parameters
-        -----------
+        ----------
         name: :class:`str`
             The new role name to change to.
         permissions: :class:`Permissions`
@@ -419,7 +419,7 @@ class Role(Hashable):
             The reason for editing this role. Shows up on the audit log.
 
         Raises
-        -------
+        ------
         Forbidden
             You do not have permissions to change the role.
         HTTPException
@@ -429,7 +429,7 @@ class Role(Hashable):
             role was asked to be moved.
 
         Returns
-        --------
+        -------
         :class:`Role`
             The newly edited role.
         """
@@ -476,12 +476,12 @@ class Role(Hashable):
         use this.
 
         Parameters
-        -----------
+        ----------
         reason: Optional[:class:`str`]
             The reason for deleting this role. Shows up on the audit log.
 
         Raises
-        --------
+        ------
         Forbidden
             You do not have permissions to delete the role.
         HTTPException

--- a/nextcord/scheduled_events.py
+++ b/nextcord/scheduled_events.py
@@ -462,7 +462,7 @@ class ScheduledEvent(Hashable):
             A snowflake id to end with, useful for chunks of usersby default None
 
         Yields
-        -------
+        ------
         :class:`ScheduledEventUser`
             A full event user object
         """

--- a/nextcord/shard.py
+++ b/nextcord/shard.py
@@ -233,7 +233,7 @@ class ShardInfo:
     .. versionadded:: 1.4
 
     Attributes
-    ------------
+    ----------
     id: :class:`int`
         The shard ID for this shard.
     shard_count: Optional[:class:`int`]
@@ -321,7 +321,7 @@ class AutoShardedClient(Client):
     0 to ``shard_count - 1``.
 
     Attributes
-    ------------
+    ----------
     shard_ids: Optional[List[:class:`int`]]
         An optional list of shard_ids to launch the shards with.
     """

--- a/nextcord/stage_instance.py
+++ b/nextcord/stage_instance.py
@@ -60,7 +60,7 @@ class StageInstance(Hashable):
             Returns the stage instance's hash.
 
     Attributes
-    -----------
+    ----------
     id: :class:`int`
         The stage instance's ID.
     guild: :class:`Guild`
@@ -125,7 +125,7 @@ class StageInstance(Hashable):
         use this.
 
         Parameters
-        -----------
+        ----------
         topic: :class:`str`
             The stage instance's new topic.
         privacy_level: :class:`StagePrivacyLevel`
@@ -166,7 +166,7 @@ class StageInstance(Hashable):
         use this.
 
         Parameters
-        -----------
+        ----------
         reason: :class:`str`
             The reason the stage instance was deleted. Shows up on the audit log.
 

--- a/nextcord/sticker.py
+++ b/nextcord/sticker.py
@@ -78,7 +78,7 @@ class StickerPack(Hashable):
            Checks if the sticker pack is not equal to another sticker pack.
 
     Attributes
-    -----------
+    ----------
     name: :class:`str`
         The name of the sticker pack.
     description: :class:`str`
@@ -190,7 +190,7 @@ class StickerItem(_StickerTag):
            Checks if the sticker item is not equal to another sticker item.
 
     Attributes
-    -----------
+    ----------
     name: :class:`str`
         The sticker's name.
     id: :class:`int`
@@ -222,12 +222,12 @@ class StickerItem(_StickerTag):
         Attempts to retrieve the full sticker data of the sticker item.
 
         Raises
-        --------
+        ------
         HTTPException
             Retrieving the sticker failed.
 
         Returns
-        --------
+        -------
         Union[:class:`StandardSticker`, :class:`GuildSticker`]
             The retrieved sticker.
         """
@@ -355,14 +355,14 @@ class StandardSticker(Sticker):
         Retrieves the sticker pack that this sticker belongs to.
 
         Raises
-        --------
+        ------
         InvalidData
             The corresponding sticker pack was not found.
         HTTPException
             Retrieving the sticker pack failed.
 
         Returns
-        --------
+        -------
         :class:`StickerPack`
             The retrieved sticker pack.
         """
@@ -451,7 +451,7 @@ class GuildSticker(Sticker):
         Edits a :class:`GuildSticker` for the guild.
 
         Parameters
-        -----------
+        ----------
         name: :class:`str`
             The sticker's new name. Must be at least 2 characters.
         description: Optional[:class:`str`]
@@ -462,14 +462,14 @@ class GuildSticker(Sticker):
             The reason for editing this sticker. Shows up on the audit log.
 
         Raises
-        -------
+        ------
         Forbidden
             You are not allowed to edit stickers.
         HTTPException
             An error occurred editing the sticker.
 
         Returns
-        --------
+        -------
         :class:`GuildSticker`
             The newly modified sticker.
         """
@@ -505,12 +505,12 @@ class GuildSticker(Sticker):
         do this.
 
         Parameters
-        -----------
+        ----------
         reason: Optional[:class:`str`]
             The reason for deleting this sticker. Shows up on the audit log.
 
         Raises
-        -------
+        ------
         Forbidden
             You are not allowed to delete stickers.
         HTTPException

--- a/nextcord/team.py
+++ b/nextcord/team.py
@@ -45,7 +45,7 @@ class Team:
     """Represents an application team for a bot provided by Discord.
 
     Attributes
-    -------------
+    ----------
     id: :class:`int`
         The team ID.
     name: :class:`str`
@@ -111,7 +111,7 @@ class TeamMember(BaseUser):
     .. versionadded:: 1.3
 
     Attributes
-    -------------
+    ----------
     name: :class:`str`
         The team member's username.
     id: :class:`int`

--- a/nextcord/template.py
+++ b/nextcord/template.py
@@ -96,7 +96,7 @@ class Template:
     .. versionadded:: 1.4
 
     Attributes
-    -----------
+    ----------
     code: :class:`str`
         The template code.
     uses: :class:`int`
@@ -234,7 +234,7 @@ class Template:
             The template is no longer edited in-place, instead it is returned.
 
         Raises
-        -------
+        ------
         HTTPException
             Editing the template failed.
         Forbidden
@@ -243,7 +243,7 @@ class Template:
             This template does not exist.
 
         Returns
-        --------
+        -------
         :class:`Template`
             The newly edited template.
         """
@@ -270,14 +270,14 @@ class Template:
             The template is no longer edited in-place, instead it is returned.
 
         Parameters
-        ------------
+        ----------
         name: :class:`str`
             The template's new name.
         description: Optional[:class:`str`]
             The template's new description.
 
         Raises
-        -------
+        ------
         HTTPException
             Editing the template failed.
         Forbidden
@@ -286,7 +286,7 @@ class Template:
             This template does not exist.
 
         Returns
-        --------
+        -------
         :class:`Template`
             The newly edited template.
         """
@@ -311,7 +311,7 @@ class Template:
         .. versionadded:: 1.7
 
         Raises
-        -------
+        ------
         HTTPException
             Editing the template failed.
         Forbidden

--- a/nextcord/threads.py
+++ b/nextcord/threads.py
@@ -457,7 +457,7 @@ class Thread(Messageable, Hashable, PinsMixin):
         also needed to retrieve message history.
 
         Examples
-        ---------
+        --------
 
         Deleting bot's messages ::
 

--- a/nextcord/threads.py
+++ b/nextcord/threads.py
@@ -85,7 +85,7 @@ class Thread(Messageable, Hashable, PinsMixin):
     .. versionadded:: 2.0
 
     Attributes
-    -----------
+    ----------
     name: :class:`str`
         The thread name.
     guild: :class:`Guild`
@@ -271,7 +271,7 @@ class Thread(Messageable, Hashable, PinsMixin):
             attribute.
 
         Returns
-        ---------
+        -------
         Optional[:class:`Message`]
             The last message in this channel or ``None`` if not found.
         """
@@ -282,7 +282,7 @@ class Thread(Messageable, Hashable, PinsMixin):
         """The category channel the parent channel belongs to, if applicable.
 
         Raises
-        -------
+        ------
         ClientException
             The parent channel was not cached and returned ``None``.
 
@@ -302,7 +302,7 @@ class Thread(Messageable, Hashable, PinsMixin):
         """The category channel ID the parent channel belongs to, if applicable.
 
         Raises
-        -------
+        ------
         ClientException
             The parent channel was not cached and returned ``None``.
 
@@ -367,7 +367,7 @@ class Thread(Messageable, Hashable, PinsMixin):
             are not computed.
 
         Raises
-        -------
+        ------
         ClientException
             The parent channel was not cached and returned ``None``
 
@@ -401,7 +401,7 @@ class Thread(Messageable, Hashable, PinsMixin):
         Usable only by bot accounts.
 
         Parameters
-        -----------
+        ----------
         messages: Iterable[:class:`abc.Snowflake`]
             An iterable of messages denoting which ones to bulk delete.
 
@@ -468,7 +468,7 @@ class Thread(Messageable, Hashable, PinsMixin):
             await thread.send(f'Deleted {len(deleted)} message(s)')
 
         Parameters
-        -----------
+        ----------
         limit: Optional[:class:`int`]
             The number of messages to search through. This is not the number
             of messages that will be deleted, though it can be.
@@ -489,14 +489,14 @@ class Thread(Messageable, Hashable, PinsMixin):
             fall back to single delete if messages are older than two weeks.
 
         Raises
-        -------
+        ------
         Forbidden
             You do not have proper permissions to do the actions required.
         HTTPException
             Purging the messages failed.
 
         Returns
-        --------
+        -------
         List[:class:`.Message`]
             The list of messages that were deleted.
         """
@@ -638,7 +638,7 @@ class Thread(Messageable, Hashable, PinsMixin):
         If the thread is private, :attr:`~Permissions.manage_threads` is also needed.
 
         Raises
-        -------
+        ------
         Forbidden
             You do not have permissions to join the thread.
         HTTPException
@@ -652,7 +652,7 @@ class Thread(Messageable, Hashable, PinsMixin):
         Leaves this thread.
 
         Raises
-        -------
+        ------
         HTTPException
             Leaving the thread failed.
         """
@@ -669,12 +669,12 @@ class Thread(Messageable, Hashable, PinsMixin):
         is required to add a user to the thread.
 
         Parameters
-        -----------
+        ----------
         user: :class:`abc.Snowflake`
             The user to add to the thread.
 
         Raises
-        -------
+        ------
         Forbidden
             You do not have permissions to add the user to the thread.
         HTTPException
@@ -690,12 +690,12 @@ class Thread(Messageable, Hashable, PinsMixin):
         You must have :attr:`~Permissions.manage_threads` or be the creator of the thread to remove a user.
 
         Parameters
-        -----------
+        ----------
         user: :class:`abc.Snowflake`
             The user to add to the thread.
 
         Raises
-        -------
+        ------
         Forbidden
             You do not have permissions to remove the user from the thread.
         HTTPException
@@ -712,12 +712,12 @@ class Thread(Messageable, Hashable, PinsMixin):
         other than yourself.
 
         Raises
-        -------
+        ------
         HTTPException
             Retrieving the members failed.
 
         Returns
-        --------
+        -------
         List[:class:`ThreadMember`]
             All thread members in the thread.
         """
@@ -733,7 +733,7 @@ class Thread(Messageable, Hashable, PinsMixin):
         You must have :attr:`~Permissions.manage_threads` to delete threads.
 
         Raises
-        -------
+        ------
         Forbidden
             You do not have permissions to delete this thread.
         HTTPException
@@ -750,12 +750,12 @@ class Thread(Messageable, Hashable, PinsMixin):
         .. versionadded:: 2.0
 
         Parameters
-        ------------
+        ----------
         message_id: :class:`int`
             The message ID to create a partial message for.
 
         Returns
-        ---------
+        -------
         :class:`PartialMessage`
             The partial message.
         """
@@ -795,7 +795,7 @@ class ThreadMember(Hashable):
     .. versionadded:: 2.0
 
     Attributes
-    -----------
+    ----------
     id: :class:`int`
         The thread member's ID.
     thread_id: :class:`int`

--- a/nextcord/ui/button.py
+++ b/nextcord/ui/button.py
@@ -54,7 +54,7 @@ class Button(Item[V]):
     .. versionadded:: 2.0
 
     Parameters
-    ------------
+    ----------
     style: :class:`nextcord.ButtonStyle`
         The style of the button.
     custom_id: Optional[:class:`str`]
@@ -255,7 +255,7 @@ def button(
         with it.
 
     Parameters
-    ------------
+    ----------
     label: Optional[:class:`str`]
         The label of the button, if any.
     custom_id: Optional[:class:`str`]

--- a/nextcord/ui/item.py
+++ b/nextcord/ui/item.py
@@ -125,7 +125,7 @@ class Item(Generic[V]):
         This can be overridden by subclasses.
 
         Parameters
-        -----------
+        ----------
         interaction: :class:`.Interaction`
             The interaction that triggered this UI item.
         """

--- a/nextcord/ui/modal.py
+++ b/nextcord/ui/modal.py
@@ -387,7 +387,7 @@ class Modal:
         or it times out.
 
         Returns
-        --------
+        -------
         :class:`bool`
             If ``True``, then the modal timed out. If ``False`` then
             the modal finished normally.

--- a/nextcord/ui/modal.py
+++ b/nextcord/ui/modal.py
@@ -194,7 +194,7 @@ class Modal:
             The item to add to the modal.
 
         Raises
-        --------
+        ------
         TypeError
             An :class:`Item` was not passed.
         ValueError

--- a/nextcord/ui/modal.py
+++ b/nextcord/ui/modal.py
@@ -73,7 +73,7 @@ class Modal:
     .. versionadded:: 2.0
 
     Parameters
-    -----------
+    ----------
     title: :class:`str`
         The title of the modal.
     timeout: Optional[:class:`float`] = None
@@ -88,7 +88,7 @@ class Modal:
         handle the modal interaction outside of the callback.
 
     Attributes
-    ------------
+    ----------
     title: :class:`str`
         The title of the modal.
     timeout: Optional[:class:`float`]
@@ -189,7 +189,7 @@ class Modal:
         """Adds an item to the modal.
 
         Parameters
-        -----------
+        ----------
         item: :class:`Item`
             The item to add to the modal.
 
@@ -214,7 +214,7 @@ class Modal:
         """Removes an item from the modal.
 
         Parameters
-        -----------
+        ----------
         item: :class:`Item`
             The item to remove from the modal.
         """
@@ -265,7 +265,7 @@ class Modal:
         The default implementation prints the traceback to stderr.
 
         Parameters
-        -----------
+        ----------
         error: :class:`Exception`
             The exception that was raised.
         item: :class:`Item`

--- a/nextcord/ui/select.py
+++ b/nextcord/ui/select.py
@@ -206,7 +206,7 @@ class Select(Item[V]):
             Whether this option is selected by default.
 
         Raises
-        -------
+        ------
         ValueError
             The number of options exceeds 25.
         """
@@ -230,7 +230,7 @@ class Select(Item[V]):
             The option to append to the select menu.
 
         Raises
-        -------
+        ------
         ValueError
             The number of options exceeds 25.
         """

--- a/nextcord/ui/select.py
+++ b/nextcord/ui/select.py
@@ -59,7 +59,7 @@ class Select(Item[V]):
     .. versionadded:: 2.0
 
     Parameters
-    ------------
+    ----------
     custom_id: :class:`str`
         The ID of the select menu that gets received during an interaction.
         If not given then one is generated for you.
@@ -189,7 +189,7 @@ class Select(Item[V]):
         :meth:`append_option` method instead.
 
         Parameters
-        -----------
+        ----------
         label: :class:`str`
             The label of the option. This is displayed to users.
             Can only be up to 100 characters.
@@ -225,7 +225,7 @@ class Select(Item[V]):
         """Appends an option to the select menu.
 
         Parameters
-        -----------
+        ----------
         option: :class:`nextcord.SelectOption`
             The option to append to the select menu.
 
@@ -307,7 +307,7 @@ def select(
     use :attr:`Select.values`.
 
     Parameters
-    ------------
+    ----------
     placeholder: Optional[:class:`str`]
         The placeholder text that is shown if nothing is selected, if any.
     custom_id: :class:`str`

--- a/nextcord/ui/view.py
+++ b/nextcord/ui/view.py
@@ -138,7 +138,7 @@ class View:
     .. versionadded:: 2.0
 
     Parameters
-    -----------
+    ----------
     timeout: Optional[:class:`float`]
         Timeout in seconds from last interaction with the UI before no longer accepting input.
         If ``None`` then there is no timeout.
@@ -148,7 +148,7 @@ class View:
         handle view interactions outside of the callback.
 
     Attributes
-    ------------
+    ----------
     timeout: Optional[:class:`float`]
         Timeout from last interaction with the UI before no longer accepting input.
         If ``None`` then there is no timeout.
@@ -244,7 +244,7 @@ class View:
         converted into a :class:`View` first.
 
         Parameters
-        -----------
+        ----------
         message: :class:`nextcord.Message`
             The message with components to convert into a view.
         timeout: Optional[:class:`float`]
@@ -278,7 +278,7 @@ class View:
         """Adds an item to the view.
 
         Parameters
-        -----------
+        ----------
         item: :class:`Item`
             The item to add to the view.
 
@@ -306,7 +306,7 @@ class View:
         """Removes an item from the view.
 
         Parameters
-        -----------
+        ----------
         item: :class:`Item`
             The item to remove from the view.
         """
@@ -340,7 +340,7 @@ class View:
             is considered a failure and :meth:`on_error` is called.
 
         Parameters
-        -----------
+        ----------
         interaction: :class:`~nextcord.Interaction`
             The interaction that occurred.
 
@@ -367,7 +367,7 @@ class View:
         The default implementation prints the traceback to stderr.
 
         Parameters
-        -----------
+        ----------
         error: :class:`Exception`
             The exception that was raised.
         item: :class:`Item`

--- a/nextcord/ui/view.py
+++ b/nextcord/ui/view.py
@@ -251,7 +251,7 @@ class View:
             The timeout of the converted view.
 
         Returns
-        --------
+        -------
         :class:`View`
             The converted view. This always returns a :class:`View` and not
             one of its subclasses.
@@ -283,7 +283,7 @@ class View:
             The item to add to the view.
 
         Raises
-        --------
+        ------
         TypeError
             An :class:`Item` was not passed.
         ValueError
@@ -345,7 +345,7 @@ class View:
             The interaction that occurred.
 
         Returns
-        ---------
+        -------
         :class:`bool`
             Whether the view children's callbacks should be called.
         """
@@ -487,7 +487,7 @@ class View:
         or it times out.
 
         Returns
-        --------
+        -------
         :class:`bool`
             If ``True``, then the view timed out. If ``False`` then
             the view finished normally.

--- a/nextcord/user.py
+++ b/nextcord/user.py
@@ -265,7 +265,7 @@ class BaseUser(_UserTag):
         """Checks if the user is mentioned in the specified message.
 
         Parameters
-        -----------
+        ----------
         message: :class:`Message`
             The message to check if you're mentioned in.
 
@@ -303,7 +303,7 @@ class ClientUser(BaseUser):
             Returns the user's name with discriminator.
 
     Attributes
-    -----------
+    ----------
     name: :class:`str`
         The user's username.
     id: :class:`int`
@@ -376,7 +376,7 @@ class ClientUser(BaseUser):
             The ``avatar`` parameter now accepts :class:`File`, :class:`Attachment`, and :class:`Asset`.
 
         Parameters
-        -----------
+        ----------
         username: :class:`str`
             The new username you wish to change to.
         avatar: Optional[Union[:class:`bytes`, :class:`Asset`, :class:`Attachment`, :class:`File`]]
@@ -391,7 +391,7 @@ class ClientUser(BaseUser):
             Wrong image format passed for ``avatar``.
 
         Returns
-        ---------
+        -------
         :class:`ClientUser`
             The newly edited client user.
         """
@@ -427,7 +427,7 @@ class User(BaseUser, abc.Messageable):
             Returns the user's name with discriminator.
 
     Attributes
-    -----------
+    ----------
     name: :class:`str`
         The user's username.
     id: :class:`int`

--- a/nextcord/utils.py
+++ b/nextcord/utils.py
@@ -284,7 +284,7 @@ def oauth_url(
     into guilds.
 
     Parameters
-    -----------
+    ----------
     client_id: Union[:class:`int`, :class:`str`]
         The client ID for your bot.
     permissions: :class:`~nextcord.Permissions`
@@ -304,7 +304,7 @@ def oauth_url(
         .. versionadded:: 2.0
 
     Returns
-    --------
+    -------
     :class:`str`
         The OAuth2 URL for inviting the bot into guilds.
     """
@@ -326,12 +326,12 @@ def oauth_url(
 def snowflake_time(id: int) -> datetime.datetime:
     """
     Parameters
-    -----------
+    ----------
     id: :class:`int`
         The snowflake ID.
 
     Returns
-    --------
+    -------
     :class:`datetime.datetime`
         An aware datetime in UTC representing the creation time of the snowflake.
     """
@@ -349,7 +349,7 @@ def time_snowflake(dt: datetime.datetime, high: bool = False) -> int:
     to be inclusive, ``high=False`` to be exclusive
 
     Parameters
-    -----------
+    ----------
     dt: :class:`datetime.datetime`
         A datetime object to convert to a snowflake.
         If naive, the timezone is assumed to be local time.
@@ -357,7 +357,7 @@ def time_snowflake(dt: datetime.datetime, high: bool = False) -> int:
         Whether or not to set the lower 22 bit to high or low.
 
     Returns
-    --------
+    -------
     :class:`int`
         The snowflake representing the time given.
     """
@@ -378,7 +378,7 @@ def find(predicate: Callable[[T], Any], seq: Iterable[T]) -> Optional[T]:
     a valid entry.
 
     Parameters
-    -----------
+    ----------
     predicate
         A function that returns a boolean-like result.
     seq: :class:`collections.abc.Iterable`
@@ -421,7 +421,7 @@ def get(iterable: Iterable[T], **attrs: Any) -> Optional[T]:
     ``None`` is returned.
 
     Examples
-    ---------
+    --------
 
     Basic usage:
 
@@ -442,7 +442,7 @@ def get(iterable: Iterable[T], **attrs: Any) -> Optional[T]:
         channel = nextcord.utils.get(client.get_all_channels(), guild__name='Cool', name='general')
 
     Parameters
-    -----------
+    ----------
     iterable
         An iterable to search through.
     \*\*attrs
@@ -598,7 +598,7 @@ async def sleep_until(when: datetime.datetime, result: Optional[T] = None) -> Op
     .. versionadded:: 1.3
 
     Parameters
-    -----------
+    ----------
     when: :class:`datetime.datetime`
         The timestamp in which to sleep until. If the datetime is naive then
         it is assumed to be local time.
@@ -618,7 +618,7 @@ def utcnow() -> datetime.datetime:
     .. versionadded:: 2.0
 
     Returns
-    --------
+    -------
     :class:`datetime.datetime`
         The current aware datetime in UTC.
     """
@@ -684,12 +684,12 @@ def resolve_invite(invite: Union[Invite, str]) -> str:
     Resolves an invite from a :class:`~nextcord.Invite`, URL or code.
 
     Parameters
-    -----------
+    ----------
     invite: Union[:class:`~nextcord.Invite`, :class:`str`]
         The invite.
 
     Returns
-    --------
+    -------
     :class:`str`
         The invite code.
     """
@@ -715,12 +715,12 @@ def resolve_template(code: Union[Template, str]) -> str:
     .. versionadded:: 1.4
 
     Parameters
-    -----------
+    ----------
     code: Union[:class:`~nextcord.Template`, :class:`str`]
         The code.
 
     Returns
-    --------
+    -------
     :class:`str`
         The template code.
     """
@@ -761,7 +761,7 @@ def remove_markdown(text: str, *, ignore_links: bool = True) -> str:
             if the input contains ``10 * 5`` then it will be converted into ``10  5``.
 
     Parameters
-    -----------
+    ----------
     text: :class:`str`
         The text to remove markdown from.
     ignore_links: :class:`bool`
@@ -770,7 +770,7 @@ def remove_markdown(text: str, *, ignore_links: bool = True) -> str:
         be left alone. Defaults to ``True``.
 
     Returns
-    --------
+    -------
     :class:`str`
         The text with the markdown special characters removed.
     """
@@ -789,7 +789,7 @@ def escape_markdown(text: str, *, as_needed: bool = False, ignore_links: bool = 
     r"""A helper function that escapes Discord's markdown.
 
     Parameters
-    -----------
+    ----------
     text: :class:`str`
         The text to escape markdown from.
     as_needed: :class:`bool`
@@ -805,7 +805,7 @@ def escape_markdown(text: str, *, as_needed: bool = False, ignore_links: bool = 
         Defaults to ``True``.
 
     Returns
-    --------
+    -------
     :class:`str`
         The text with the markdown special characters escaped with a slash.
     """
@@ -842,12 +842,12 @@ def escape_mentions(text: str) -> str:
         class.
 
     Parameters
-    -----------
+    ----------
     text: :class:`str`
         The text to escape mentions from.
 
     Returns
-    --------
+    -------
     :class:`str`
         The text with the mentions removed.
     """
@@ -866,12 +866,12 @@ def parse_raw_mentions(text: str) -> List[int]:
     .. versionadded:: 2.2
 
     Parameters
-    -----------
+    ----------
     text: :class:`str`
         The text to parse mentions from.
 
     Returns
-    --------
+    -------
     List[:class:`int`]
         A list of user IDs that were mentioned.
     """
@@ -885,12 +885,12 @@ def parse_raw_role_mentions(text: str) -> List[int]:
     .. versionadded:: 2.2
 
     Parameters
-    -----------
+    ----------
     text: :class:`str`
         The text to parse mentions from.
 
     Returns
-    --------
+    -------
     List[:class:`int`]
         A list of role IDs that were mentioned.
     """
@@ -904,12 +904,12 @@ def parse_raw_channel_mentions(text: str) -> List[int]:
     .. versionadded:: 2.2
 
     Parameters
-    -----------
+    ----------
     text: :class:`str`
         The text to parse mentions from.
 
     Returns
-    --------
+    -------
     List[:class:`int`]
         A list of channel IDs that were mentioned.
     """
@@ -972,7 +972,7 @@ def as_chunks(iterator: _Iter[T], max_size: int) -> _Iter[List[T]]:
         The last chunk collected may not be as large as ``max_size``.
 
     Returns
-    --------
+    -------
     Union[:class:`Iterator`, :class:`AsyncIterator`]
         A new iterator which yields chunks of a given size.
     """
@@ -1115,14 +1115,14 @@ def format_dt(dt: datetime.datetime, /, style: Optional[TimestampStyle] = None) 
     .. versionadded:: 2.0
 
     Parameters
-    -----------
+    ----------
     dt: :class:`datetime.datetime`
         The datetime to format.
     style: :class:`str`
         The style to format the datetime with.
 
     Returns
-    --------
+    -------
     :class:`str`
         The formatted string.
     """
@@ -1161,14 +1161,14 @@ def _trim_text(text: str, max_chars: int) -> str:
     """Trims a string and adds an ellpsis if it exceeds the maximum length.
 
     Parameters
-    -----------
+    ----------
     text: :class:`str`
         The string to trim.
     max_chars: :class:`int`
         The maximum number of characters to allow.
 
     Returns
-    --------
+    -------
     :class:`str`
         The trimmed string.
     """
@@ -1182,7 +1182,7 @@ def parse_docstring(func: Callable, max_chars: int = MISSING) -> Dict[str, Any]:
     """Parses the docstring of a function into a dictionary.
 
     Parameters
-    ------------
+    ----------
     func: :class:`Callable`
         The function to parse the docstring of.
     max_chars: :class:`int`
@@ -1190,7 +1190,7 @@ def parse_docstring(func: Callable, max_chars: int = MISSING) -> Dict[str, Any]:
         If MISSING, then there is no maximum.
 
     Returns
-    --------
+    -------
     :class:`Dict[str, Any]`
         The parsed docstring including the function description and
         descriptions of arguments.

--- a/nextcord/voice_client.py
+++ b/nextcord/voice_client.py
@@ -99,7 +99,7 @@ class VoiceProtocol:
     .. _Lavalink: https://github.com/freyacodes/Lavalink
 
     Parameters
-    ------------
+    ----------
     client: :class:`Client`
         The client (or its subclasses) that started the connection request.
     channel: :class:`abc.Connectable`
@@ -117,7 +117,7 @@ class VoiceProtocol:
         has changed. This corresponds to ``VOICE_STATE_UPDATE``.
 
         Parameters
-        ------------
+        ----------
         data: :class:`dict`
             The raw `voice state payload`__.
 
@@ -134,7 +134,7 @@ class VoiceProtocol:
         This corresponds to ``VOICE_SERVER_UPDATE``.
 
         Parameters
-        ------------
+        ----------
         data: :class:`dict`
             The raw `voice server update payload`__.
 
@@ -159,7 +159,7 @@ class VoiceProtocol:
         The order that these two are called is unspecified.
 
         Parameters
-        ------------
+        ----------
         timeout: :class:`float`
             The timeout for the connection.
         reconnect: :class:`bool`
@@ -175,7 +175,7 @@ class VoiceProtocol:
         See :meth:`cleanup`.
 
         Parameters
-        ------------
+        ----------
         force: :class:`bool`
             Whether the disconnection was forced.
         """
@@ -209,7 +209,7 @@ class VoiceClient(VoiceProtocol):
     or the library will not be able to transmit audio.
 
     Attributes
-    -----------
+    ----------
     session_id: :class:`str`
         The voice connection session ID.
     token: :class:`str`
@@ -515,7 +515,7 @@ class VoiceClient(VoiceProtocol):
         Moves you to a different voice channel.
 
         Parameters
-        -----------
+        ----------
         channel: :class:`abc.Snowflake`
             The channel to move to. Must be a voice channel.
         """
@@ -575,7 +575,7 @@ class VoiceClient(VoiceProtocol):
         passed, any caught exception will be displayed as if it were raised.
 
         Parameters
-        -----------
+        ----------
         source: :class:`AudioSource`
             The audio source we're reading from.
         after: Callable[[Optional[:class:`Exception`]], Any]
@@ -585,7 +585,7 @@ class VoiceClient(VoiceProtocol):
             If the function is a coroutine, it will be awaited when called.
 
         Raises
-        -------
+        ------
         ClientException
             Already playing audio or not connected.
         TypeError
@@ -664,7 +664,7 @@ class VoiceClient(VoiceProtocol):
             Indicates if ``data`` should be encoded into Opus.
 
         Raises
-        -------
+        ------
         ClientException
             You are not connected.
         opus.OpusError

--- a/nextcord/voice_client.py
+++ b/nextcord/voice_client.py
@@ -202,7 +202,7 @@ class VoiceClient(VoiceProtocol):
     e.g. :meth:`VoiceChannel.connect`.
 
     Warning
-    --------
+    -------
     In order to use PCM based AudioSources, you must have the opus library
     installed on your system and loaded through :func:`opus.load_opus`.
     Otherwise, your AudioSources must be opus encoded (e.g. using :class:`FFmpegOpusAudio`)

--- a/nextcord/webhook/__init__.py
+++ b/nextcord/webhook/__init__.py
@@ -1,6 +1,6 @@
 """
 nextcord.webhook
-~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~
 
 Webhook support
 

--- a/nextcord/webhook/async_.py
+++ b/nextcord/webhook/async_.py
@@ -1216,7 +1216,7 @@ class Webhook(BaseWebhook):
             .. versionadded:: 2.0
 
         Raises
-        -------
+        ------
         HTTPException
             Deleting the webhook failed.
         NotFound
@@ -1278,7 +1278,7 @@ class Webhook(BaseWebhook):
             .. versionadded:: 2.0
 
         Raises
-        -------
+        ------
         HTTPException
             Editing the webhook failed.
         NotFound
@@ -1723,7 +1723,7 @@ class Webhook(BaseWebhook):
             The message ID to delete.
 
         Raises
-        -------
+        ------
         HTTPException
             Deleting the message failed.
         Forbidden

--- a/nextcord/webhook/async_.py
+++ b/nextcord/webhook/async_.py
@@ -598,7 +598,7 @@ class PartialWebhookChannel(Hashable):
     .. versionadded:: 2.0
 
     Attributes
-    -----------
+    ----------
     id: :class:`int`
         The partial channel's ID.
     name: :class:`str`
@@ -623,7 +623,7 @@ class PartialWebhookGuild(Hashable):
     .. versionadded:: 2.0
 
     Attributes
-    -----------
+    ----------
     id: :class:`int`
         The partial guild's ID.
     name: :class:`str`
@@ -735,7 +735,7 @@ class WebhookMessage(Message):
             The edit is no longer in-place, instead the newly edited message is returned.
 
         Parameters
-        ------------
+        ----------
         content: Optional[:class:`str`]
             The content to edit the message with or ``None`` to clear it.
         embeds: List[:class:`Embed`]
@@ -773,7 +773,7 @@ class WebhookMessage(Message):
             .. versionadded:: 2.0
 
         Raises
-        -------
+        ------
         HTTPException
             Editing the message failed.
         Forbidden
@@ -786,7 +786,7 @@ class WebhookMessage(Message):
             There was no token associated with this webhook.
 
         Returns
-        --------
+        -------
         :class:`WebhookMessage`
             The newly edited message.
         """
@@ -813,7 +813,7 @@ class WebhookMessage(Message):
         Deletes the message.
 
         Parameters
-        -----------
+        ----------
         delay: Optional[:class:`float`]
             If provided, the number of seconds to wait before deleting the message.
             The waiting is done in the background and deletion failures are ignored.
@@ -991,7 +991,7 @@ class Webhook(BaseWebhook):
         Webhooks are now comparable and hashable.
 
     Attributes
-    ------------
+    ----------
     id: :class:`int`
         The webhook's ID
     type: :class:`WebhookType`
@@ -1051,7 +1051,7 @@ class Webhook(BaseWebhook):
         """Creates a partial :class:`Webhook`.
 
         Parameters
-        -----------
+        ----------
         id: :class:`int`
             The ID of the webhook.
         token: :class:`str`
@@ -1069,7 +1069,7 @@ class Webhook(BaseWebhook):
             .. versionadded:: 2.0
 
         Returns
-        --------
+        -------
         :class:`Webhook`
             A partial :class:`Webhook`.
             A partial webhook is just a webhook object with an ID and a token.
@@ -1089,7 +1089,7 @@ class Webhook(BaseWebhook):
         """Creates a partial :class:`Webhook` from a webhook URL.
 
         Parameters
-        ------------
+        ----------
         url: :class:`str`
             The URL of the webhook.
         session: :class:`aiohttp.ClientSession`
@@ -1105,12 +1105,12 @@ class Webhook(BaseWebhook):
             .. versionadded:: 2.0
 
         Raises
-        -------
+        ------
         InvalidArgument
             The URL is invalid.
 
         Returns
-        --------
+        -------
         :class:`Webhook`
             A partial :class:`Webhook`.
             A partial webhook is just a webhook object with an ID and a token.
@@ -1168,13 +1168,13 @@ class Webhook(BaseWebhook):
             returned webhook does not contain any user information.
 
         Parameters
-        -----------
+        ----------
         prefer_auth: :class:`bool`
             Whether to use the bot token over the webhook token
             if available. Defaults to ``True``.
 
         Raises
-        -------
+        ------
         HTTPException
             Could not fetch the webhook
         NotFound
@@ -1183,7 +1183,7 @@ class Webhook(BaseWebhook):
             This webhook does not have a token associated with it.
 
         Returns
-        --------
+        -------
         :class:`Webhook`
             The fetched webhook.
         """
@@ -1204,7 +1204,7 @@ class Webhook(BaseWebhook):
         Deletes this Webhook.
 
         Parameters
-        ------------
+        ----------
         reason: Optional[:class:`str`]
             The reason for deleting this webhook. Shows up on the audit log.
 
@@ -1257,7 +1257,7 @@ class Webhook(BaseWebhook):
             The ``avatar`` parameter now accepts :class:`File`, :class:`Attachment`, and :class:`Asset`.
 
         Parameters
-        ------------
+        ----------
         name: Optional[:class:`str`]
             The webhook's new default name.
         avatar: Optional[Union[:class:`bytes`, :class:`Asset`, :class:`Attachment`, :class:`File`]]
@@ -1405,7 +1405,7 @@ class Webhook(BaseWebhook):
         ``embeds`` parameter, which must be a :class:`list` of :class:`Embed` objects to send.
 
         Parameters
-        ------------
+        ----------
         content: :class:`str`
             The content of the message to send.
         wait: :class:`bool`
@@ -1461,7 +1461,7 @@ class Webhook(BaseWebhook):
             .. versionadded:: 2.0
 
         Raises
-        --------
+        ------
         HTTPException
             Sending the message failed.
         NotFound
@@ -1478,7 +1478,7 @@ class Webhook(BaseWebhook):
             attached with this webhook when giving it a view.
 
         Returns
-        ---------
+        -------
         Optional[:class:`WebhookMessage`]
             If ``wait`` is ``True`` then the message that was sent, otherwise ``None``.
         """
@@ -1556,12 +1556,12 @@ class Webhook(BaseWebhook):
         .. versionadded:: 2.0
 
         Parameters
-        ------------
+        ----------
         id: :class:`int`
             The message ID to look for.
 
         Raises
-        --------
+        ------
         ~nextcord.NotFound
             The specified message was not found.
         ~nextcord.Forbidden
@@ -1572,7 +1572,7 @@ class Webhook(BaseWebhook):
             There was no token associated with this webhook.
 
         Returns
-        --------
+        -------
         :class:`~nextcord.WebhookMessage`
             The message asked for.
         """
@@ -1615,7 +1615,7 @@ class Webhook(BaseWebhook):
             The edit is no longer in-place, instead the newly edited message is returned.
 
         Parameters
-        ------------
+        ----------
         message_id: :class:`int`
             The message ID to edit.
         content: Optional[:class:`str`]
@@ -1649,7 +1649,7 @@ class Webhook(BaseWebhook):
             .. versionadded:: 2.0
 
         Raises
-        -------
+        ------
         HTTPException
             Editing the message failed.
         Forbidden
@@ -1663,7 +1663,7 @@ class Webhook(BaseWebhook):
             no state.
 
         Returns
-        --------
+        -------
         :class:`WebhookMessage`
             The newly edited webhook message.
         """
@@ -1718,7 +1718,7 @@ class Webhook(BaseWebhook):
         .. versionadded:: 1.6
 
         Parameters
-        ------------
+        ----------
         message_id: :class:`int`
             The message ID to delete.
 

--- a/nextcord/webhook/sync.py
+++ b/nextcord/webhook/sync.py
@@ -424,7 +424,7 @@ class SyncWebhookMessage(Message):
         """Edits the message.
 
         Parameters
-        ------------
+        ----------
         content: Optional[:class:`str`]
             The content to edit the message with or ``None`` to clear it.
         embeds: List[:class:`Embed`]
@@ -445,7 +445,7 @@ class SyncWebhookMessage(Message):
             See :meth:`.abc.Messageable.send` for more information.
 
         Raises
-        -------
+        ------
         HTTPException
             Editing the message failed.
         Forbidden
@@ -458,7 +458,7 @@ class SyncWebhookMessage(Message):
             There was no token associated with this webhook.
 
         Returns
-        --------
+        -------
         :class:`SyncWebhookMessage`
             The newly edited message.
         """
@@ -477,7 +477,7 @@ class SyncWebhookMessage(Message):
         """Deletes the message.
 
         Parameters
-        -----------
+        ----------
         delay: Optional[:class:`float`]
             If provided, the number of seconds to wait before deleting the message.
             This blocks the thread.
@@ -520,7 +520,7 @@ class SyncWebhook(BaseWebhook):
         Webhooks are now comparable and hashable.
 
     Attributes
-    ------------
+    ----------
     id: :class:`int`
         The webhook's ID
     type: :class:`WebhookType`
@@ -576,7 +576,7 @@ class SyncWebhook(BaseWebhook):
         """Creates a partial :class:`Webhook`.
 
         Parameters
-        -----------
+        ----------
         id: :class:`int`
             The ID of the webhook.
         token: :class:`str`
@@ -591,7 +591,7 @@ class SyncWebhook(BaseWebhook):
             involving the webhook.
 
         Returns
-        --------
+        -------
         :class:`Webhook`
             A partial :class:`Webhook`.
             A partial webhook is just a webhook object with an ID and a token.
@@ -617,7 +617,7 @@ class SyncWebhook(BaseWebhook):
         """Creates a partial :class:`Webhook` from a webhook URL.
 
         Parameters
-        ------------
+        ----------
         url: :class:`str`
             The URL of the webhook.
         session: :class:`requests.Session`
@@ -630,12 +630,12 @@ class SyncWebhook(BaseWebhook):
             involving the webhook.
 
         Raises
-        -------
+        ------
         InvalidArgument
             The URL is invalid.
 
         Returns
-        --------
+        -------
         :class:`Webhook`
             A partial :class:`Webhook`.
             A partial webhook is just a webhook object with an ID and a token.
@@ -670,13 +670,13 @@ class SyncWebhook(BaseWebhook):
             returned webhook does not contain any user information.
 
         Parameters
-        -----------
+        ----------
         prefer_auth: :class:`bool`
             Whether to use the bot token over the webhook token
             if available. Defaults to ``True``.
 
         Raises
-        -------
+        ------
         HTTPException
             Could not fetch the webhook
         NotFound
@@ -685,7 +685,7 @@ class SyncWebhook(BaseWebhook):
             This webhook does not have a token associated with it.
 
         Returns
-        --------
+        -------
         :class:`SyncWebhook`
             The fetched webhook.
         """
@@ -704,7 +704,7 @@ class SyncWebhook(BaseWebhook):
         """Deletes this Webhook.
 
         Parameters
-        ------------
+        ----------
         reason: Optional[:class:`str`]
             The reason for deleting this webhook. Shows up on the audit log.
 
@@ -714,7 +714,7 @@ class SyncWebhook(BaseWebhook):
             if available. Defaults to ``True``.
 
         Raises
-        -------
+        ------
         HTTPException
             Deleting the webhook failed.
         NotFound
@@ -753,7 +753,7 @@ class SyncWebhook(BaseWebhook):
             The ``avatar`` parameter now accepts :class:`File`.
 
         Parameters
-        ------------
+        ----------
         name: Optional[:class:`str`]
             The webhook's new default name.
         avatar: Optional[Union[:class:`bytes`, :class:`File`]]
@@ -769,7 +769,7 @@ class SyncWebhook(BaseWebhook):
             if available. Defaults to ``True``.
 
         Raises
-        -------
+        ------
         HTTPException
             Editing the webhook failed.
         NotFound
@@ -779,7 +779,7 @@ class SyncWebhook(BaseWebhook):
             or it tried editing a channel without authentication.
 
         Returns
-        --------
+        -------
         :class:`SyncWebhook`
             The newly edited webhook.
         """
@@ -895,7 +895,7 @@ class SyncWebhook(BaseWebhook):
         ``embeds`` parameter, which must be a :class:`list` of :class:`Embed` objects to send.
 
         Parameters
-        ------------
+        ----------
         content: :class:`str`
             The content of the message to send.
         wait: :class:`bool`
@@ -932,7 +932,7 @@ class SyncWebhook(BaseWebhook):
             .. versionadded:: 2.0
 
         Raises
-        --------
+        ------
         HTTPException
             Sending the message failed.
         NotFound
@@ -947,7 +947,7 @@ class SyncWebhook(BaseWebhook):
             There was no token associated with this webhook.
 
         Returns
-        ---------
+        -------
         Optional[:class:`SyncWebhookMessage`]
             If ``wait`` is ``True`` then the message that was sent, otherwise ``None``.
         """
@@ -997,12 +997,12 @@ class SyncWebhook(BaseWebhook):
         .. versionadded:: 2.0
 
         Parameters
-        ------------
+        ----------
         id: :class:`int`
             The message ID to look for.
 
         Raises
-        --------
+        ------
         ~nextcord.NotFound
             The specified message was not found.
         ~nextcord.Forbidden
@@ -1013,7 +1013,7 @@ class SyncWebhook(BaseWebhook):
             There was no token associated with this webhook.
 
         Returns
-        --------
+        -------
         :class:`~nextcord.SyncWebhookMessage`
             The message asked for.
         """
@@ -1050,7 +1050,7 @@ class SyncWebhook(BaseWebhook):
         .. versionadded:: 1.6
 
         Parameters
-        ------------
+        ----------
         message_id: :class:`int`
             The message ID to edit.
         content: Optional[:class:`str`]
@@ -1072,7 +1072,7 @@ class SyncWebhook(BaseWebhook):
             See :meth:`.abc.Messageable.send` for more information.
 
         Raises
-        -------
+        ------
         HTTPException
             Editing the message failed.
         Forbidden
@@ -1122,12 +1122,12 @@ class SyncWebhook(BaseWebhook):
         .. versionadded:: 1.6
 
         Parameters
-        ------------
+        ----------
         message_id: :class:`int`
             The message ID to delete.
 
         Raises
-        -------
+        ------
         HTTPException
             Deleting the message failed.
         Forbidden

--- a/nextcord/widget.py
+++ b/nextcord/widget.py
@@ -68,7 +68,7 @@ class WidgetChannel:
             Returns the partial channel's name.
 
     Attributes
-    -----------
+    ----------
     id: :class:`int`
         The channel's ID.
     name: :class:`str`
@@ -123,7 +123,7 @@ class WidgetMember(BaseUser):
             Returns the widget member's `name#discriminator`.
 
     Attributes
-    -----------
+    ----------
     id: :class:`int`
         The member's ID.
     name: :class:`str`
@@ -219,7 +219,7 @@ class Widget:
             Returns the widget's JSON URL.
 
     Attributes
-    -----------
+    ----------
     id: :class:`int`
         The guild's ID.
     name: :class:`str`
@@ -299,14 +299,14 @@ class Widget:
         code is abstracted away.
 
         Parameters
-        -----------
+        ----------
         with_counts: :class:`bool`
             Whether to include count information in the invite. This fills the
             :attr:`Invite.approximate_member_count` and :attr:`Invite.approximate_presence_count`
             fields.
 
         Returns
-        --------
+        -------
         :class:`Invite`
             The invite from the widget's invite URL.
         """


### PR DESCRIPTION
## Summary

This PR fixes all trailing headers in docstrings. Most of the trailing headers are from the remains of discord.py.

A majority of the changes were made via a find and replace while some have been manual (due to my search query not being specific enough).

Places that need to be double-checked:
- [x] nextcord/ext
    - [x] ext/application_checks
    - [x] ext/commands
    - [x] ext/slash_utils
    - [x] ext/tasks
- [x] nextcord/ui

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
  - [ ] I have updated the documentation to reflect the changes.
  - [ ] I have run `task pyright` and fixed the relevant issues.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
