### PR TITLE
docs: lock sphinx and fix toctree

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -358,6 +358,11 @@ texinfo_documents = [
 # texinfo_no_detailmenu = False
 
 
+# Remove members from toctree, added by sphinx 5.2
+# This *could* be re-enabled once the docs uses multiple pages.
+toc_object_entries = False
+
+
 def setup(app):
     if app.config.language == "ja":
         app.config.intersphinx_mapping["py"] = ("https://docs.python.org/ja/3", None)

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ with open("README.rst") as f:
 extras_require = {
     "voice": ["PyNaCl>=1.3.0,<1.5"],
     "docs": [
-        "sphinx>=5.0.1,<6",
+        "sphinx==5.2.3",
         "sphinxcontrib_trio==1.1.2",
         "sphinxcontrib-websupport",
         "typing_extensions>=4.2.0, <5",


### PR DESCRIPTION
## Summary

<!-- What is this pull request for? Does it fix any issues? -->
sphinx-doc/sphinx#10807 decided to add a feature which was enabled by default.
This feature however increased the toctree's height and width by a huge amount - a breaking change.
This locks sphinx to an exact version to reduce issues like this again.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
  - [x] I have updated the documentation to reflect the changes.
  - [ ] I have run `task pyright` and fixed the relevant issues.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
