### PR TITLE
fix(enums): resolve less than or equal comparison

### DIFF
--- a/nextcord/enums.py
+++ b/nextcord/enums.py
@@ -95,7 +95,7 @@ class UnknownEnumValue(NamedTuple):
         try:
             return self.value <= other.value
         except AttributeError:
-            return self.value >= other
+            return self.value <= other
 
     def __ge__(self, other):
         try:


### PR DESCRIPTION
## Summary

Small typo noticed in the enums PR (#801). This causes an issue using `<=` with an `UnknownEnumValue` and an `int` or `string`.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
  - [ ] I have updated the documentation to reflect the changes.
  - [x] I have run `task pyright` and fixed the relevant issues.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
