### PR TITLE
feat(app-cmds): default_guild_ids

### DIFF
--- a/docs/interactions.rst
+++ b/docs/interactions.rst
@@ -266,3 +266,24 @@ Shown below is an example of a simple command running in a cog:
             await interaction.response.send_message("Hello I am a slash command in a cog!")
 
 Context menu commands can also be made in cogs using the :meth:`nextcord.user_command` or :meth:`nextcord.message_command` decorators.
+
+
+Default Guild Ids
+-----------------
+
+If you would like for all of your application commands to have the same guild ids unless explicitly stated, then you can set the ``default_guild_ids`` keyword argument in :class:`nextcord.ext.commands.Bot` and :class:`nextcord.ext.commands.AutoShardedBot`!
+
+Here's an example of this:
+
+.. code-block:: python3
+
+    bot = commands.Bot(..., default_guild_ids=[TESTING_GUILD_ID])
+
+    @bot.slash_command()
+    async def bye(interaction: nextcord.Interaction):
+        await interaction.response.send_message(f"Goodbye {bot.default_guild_ids}!")
+
+    @bot.slash_command(guild_ids=None)
+    async def bye_global(interaction: nextcord.Interaction):
+        await interaction.response.send_message("Goodbye everyone!")
+

--- a/docs/interactions.rst
+++ b/docs/interactions.rst
@@ -268,7 +268,7 @@ Shown below is an example of a simple command running in a cog:
 Context menu commands can also be made in cogs using the :meth:`nextcord.user_command` or :meth:`nextcord.message_command` decorators.
 
 
-Default Guild Ids
+Default Guild IDs
 -----------------
 
 If you would like for all of your application commands to have the same guild ids unless explicitly stated, then you can set the ``default_guild_ids`` keyword argument in :class:`nextcord.ext.commands.Bot` and :class:`nextcord.ext.commands.AutoShardedBot`!

--- a/docs/interactions.rst
+++ b/docs/interactions.rst
@@ -286,4 +286,3 @@ Here's an example of this:
     @bot.slash_command(guild_ids=None)
     async def bye_global(interaction: nextcord.Interaction):
         await interaction.response.send_message("Goodbye everyone!")
-

--- a/docs/interactions.rst
+++ b/docs/interactions.rst
@@ -271,7 +271,7 @@ Context menu commands can also be made in cogs using the :meth:`nextcord.user_co
 Default Guild IDs
 -----------------
 
-If you would like for all of your application commands to have the same guild ids unless explicitly stated, then you can set the ``default_guild_ids`` keyword argument in :class:`nextcord.ext.commands.Bot` and :class:`nextcord.ext.commands.AutoShardedBot`!
+If you would like for all of your application commands to have the same guild ids unless explicitly stated, then you can set the ``default_guild_ids`` keyword argument in :class:`~nextcord.Client`, :class:`~nextcord.ext.commands.Bot`, or :class:`~nextcord.ext.commands.AutoShardedBot`!
 
 Here's an example of this:
 

--- a/nextcord/application_command.py
+++ b/nextcord/application_command.py
@@ -1815,7 +1815,7 @@ class BaseApplicationCommand(CallbackMixin, CallbackWrapperMixin):
             Callback to make the application command from, and to run when the application command is called.
         guild_ids: Iterable[:class:`int`]
             An iterable list/set/whatever of guild ID's that the application command should register to.
-            If not passed and :attr:`Client.default_guild_ids` is set, then those default guild ids will 
+            If not passed and :attr:`Client.default_guild_ids` is set, then those default guild ids will
             be used instead. If both of those are unset, then the command will be a global command. Defaults to ``MISSING``.
         dm_permission: :class:`bool`
             If the command should be usable in DMs or not. Setting to ``False`` will disable the command from being

--- a/nextcord/application_command.py
+++ b/nextcord/application_command.py
@@ -2912,7 +2912,7 @@ def slash_command(
     *,
     name_localizations: Optional[Dict[Union[Locale, str], str]] = None,
     description_localizations: Optional[Dict[Union[Locale, str], str]] = None,
-    guild_ids: Optional[Iterable[int]] = None,
+    guild_ids: Optional[Iterable[int]] = MISSING,
     dm_permission: Optional[bool] = None,
     default_member_permissions: Optional[Union[Permissions, int]] = None,
     force_global: bool = False,
@@ -2933,8 +2933,10 @@ def slash_command(
     description_localizations: Dict[Union[:class:`Locale`, :class:`str`], :class:`str`]
         Description(s) of the subcommand for users of specific locales. The locale code should be the key, with the
         localized description as the value.
-    guild_ids: Iterable[:class:`int`]
-        IDs of :class:`Guild`'s to add this command to. If unset, this will be a global command.
+    guild_ids: Optional[Iterable[:class:`int`]]
+        IDs of :class:`Guild`'s to add this command to. If set to :attr:`utils.MISSING` and :attr:`Client.default_guild_ids` is
+        set, then those default guild ids will be used instead. If both of those are unset, then the command will
+        be a global command. Defaults to `MISSING`.
     dm_permission: :class:`bool`
         If the command should be usable in DMs or not. Setting to ``False`` will disable the command from being
         usable in DMs. Only for global commands, but will not error on guild.
@@ -2971,7 +2973,7 @@ def message_command(
     name: Optional[str] = None,
     *,
     name_localizations: Optional[Dict[Union[Locale, str], str]] = None,
-    guild_ids: Optional[Iterable[int]] = None,
+    guild_ids: Optional[Iterable[int]] = MISSING,
     dm_permission: Optional[bool] = None,
     default_member_permissions: Optional[Union[Permissions, int]] = None,
     force_global: bool = False,
@@ -2986,8 +2988,10 @@ def message_command(
     name_localizations: Dict[Union[:class:`Locale`, :class:`str`], :class:`str`]
         Name(s) of the command for users of specific locales. The locale code should be the key, with the localized
         name as the value
-    guild_ids: Iterable[:class:`int`]
-        IDs of :class:`Guild`'s to add this command to. If unset, this will be a global command.
+    guild_ids: Optional[Iterable[:class:`int`]]
+        IDs of :class:`Guild`'s to add this command to. If set to :attr:`utils.MISSING` and :attr:`Client.default_guild_ids` is
+        set, then those default guild ids will be used instead. If both of those are unset, then the command will
+        be a global command. Defaults to `MISSING`.
     dm_permission: :class:`bool`
         If the command should be usable in DMs or not. Setting to ``False`` will disable the command from being
         usable in DMs. Only for global commands, but will not error on guild.
@@ -3022,7 +3026,7 @@ def user_command(
     name: Optional[str] = None,
     *,
     name_localizations: Optional[Dict[Union[Locale, str], str]] = None,
-    guild_ids: Optional[Iterable[int]] = None,
+    guild_ids: Optional[Iterable[int]] = MISSING,
     dm_permission: Optional[bool] = None,
     default_member_permissions: Optional[Union[Permissions, int]] = None,
     force_global: bool = False,
@@ -3037,8 +3041,10 @@ def user_command(
     name_localizations: Dict[Union[:class:`Locale`, :class:`str`], :class:`str`]
         Name(s) of the command for users of specific locales. The locale code should be the key, with the localized
         name as the value
-    guild_ids: Iterable[:class:`int`]
-        IDs of :class:`Guild`'s to add this command to. If unset, this will be a global command.
+    guild_ids: Optional[Iterable[:class:`int`]]
+        IDs of :class:`Guild`'s to add this command to. If set to :attr:`utils.MISSING` and :attr:`Client.default_guild_ids` is
+        set, then those default guild ids will be used instead. If both of those are unset, then the command will
+        be a global command. Defaults to `MISSING`.
     dm_permission: :class:`bool`
         If the command should be usable in DMs or not. Setting to ``False`` will disable the command from being
         usable in DMs. Only for global commands, but will not error on guild.

--- a/nextcord/application_command.py
+++ b/nextcord/application_command.py
@@ -2936,7 +2936,7 @@ def slash_command(
     guild_ids: Optional[Iterable[:class:`int`]]
         IDs of :class:`Guild`'s to add this command to. If set to :attr:`utils.MISSING` and :attr:`Client.default_guild_ids` is
         set, then those default guild ids will be used instead. If both of those are unset, then the command will
-        be a global command. Defaults to `MISSING`.
+        be a global command. Defaults to ``MISSING``.
     dm_permission: :class:`bool`
         If the command should be usable in DMs or not. Setting to ``False`` will disable the command from being
         usable in DMs. Only for global commands, but will not error on guild.
@@ -2991,7 +2991,7 @@ def message_command(
     guild_ids: Optional[Iterable[:class:`int`]]
         IDs of :class:`Guild`'s to add this command to. If set to :attr:`utils.MISSING` and :attr:`Client.default_guild_ids` is
         set, then those default guild ids will be used instead. If both of those are unset, then the command will
-        be a global command. Defaults to `MISSING`.
+        be a global command. Defaults to ``MISSING``.
     dm_permission: :class:`bool`
         If the command should be usable in DMs or not. Setting to ``False`` will disable the command from being
         usable in DMs. Only for global commands, but will not error on guild.

--- a/nextcord/application_command.py
+++ b/nextcord/application_command.py
@@ -1788,7 +1788,7 @@ class BaseApplicationCommand(CallbackMixin, CallbackWrapperMixin):
         name_localizations: Optional[Dict[Union[Locale, str], str]] = None,
         description_localizations: Optional[Dict[Union[Locale, str], str]] = None,
         callback: Optional[Callable] = None,
-        guild_ids: Optional[Iterable[int]] = None,
+        guild_ids: Optional[Iterable[int]] = MISSING,
         dm_permission: Optional[bool] = None,
         default_member_permissions: Optional[Union[Permissions, int]] = None,
         parent_cog: Optional[ClientCog] = None,
@@ -1815,6 +1815,8 @@ class BaseApplicationCommand(CallbackMixin, CallbackWrapperMixin):
             Callback to make the application command from, and to run when the application command is called.
         guild_ids: Iterable[:class:`int`]
             An iterable list/set/whatever of guild ID's that the application command should register to.
+            If not passed and :attr:`Client.default_guild_ids` is set, then those default guild ids will 
+            be used instead. If both of those are unset, then the command will be a global command. Defaults to ``MISSING``.
         dm_permission: :class:`bool`
             If the command should be usable in DMs or not. Setting to ``False`` will disable the command from being
             usable in DMs. Only for global commands, but will not error on guild.
@@ -2934,7 +2936,7 @@ def slash_command(
         Description(s) of the subcommand for users of specific locales. The locale code should be the key, with the
         localized description as the value.
     guild_ids: Optional[Iterable[:class:`int`]]
-        IDs of :class:`Guild`'s to add this command to. If set to :attr:`utils.MISSING` and :attr:`Client.default_guild_ids` is
+        IDs of :class:`Guild`'s to add this command to. If not passed and :attr:`Client.default_guild_ids` is
         set, then those default guild ids will be used instead. If both of those are unset, then the command will
         be a global command. Defaults to ``MISSING``.
     dm_permission: :class:`bool`
@@ -2989,7 +2991,7 @@ def message_command(
         Name(s) of the command for users of specific locales. The locale code should be the key, with the localized
         name as the value
     guild_ids: Optional[Iterable[:class:`int`]]
-        IDs of :class:`Guild`'s to add this command to. If set to :attr:`utils.MISSING` and :attr:`Client.default_guild_ids` is
+        IDs of :class:`Guild`'s to add this command to. If not passed and :attr:`Client.default_guild_ids` is
         set, then those default guild ids will be used instead. If both of those are unset, then the command will
         be a global command. Defaults to ``MISSING``.
     dm_permission: :class:`bool`
@@ -3042,9 +3044,9 @@ def user_command(
         Name(s) of the command for users of specific locales. The locale code should be the key, with the localized
         name as the value
     guild_ids: Optional[Iterable[:class:`int`]]
-        IDs of :class:`Guild`'s to add this command to. If set to :attr:`utils.MISSING` and :attr:`Client.default_guild_ids` is
+        IDs of :class:`Guild`'s to add this command to. If not passed and :attr:`Client.default_guild_ids` is
         set, then those default guild ids will be used instead. If both of those are unset, then the command will
-        be a global command. Defaults to `MISSING`.
+        be a global command. Defaults to ``MISSING``.
     dm_permission: :class:`bool`
         If the command should be usable in DMs or not. Setting to ``False`` will disable the command from being
         usable in DMs. Only for global commands, but will not error on guild.

--- a/nextcord/application_command.py
+++ b/nextcord/application_command.py
@@ -1838,6 +1838,7 @@ class BaseApplicationCommand(CallbackMixin, CallbackWrapperMixin):
             Dict[Union[str, Locale], str]
         ] = description_localizations
         self.guild_ids_to_rollout: Set[int] = set(guild_ids) if guild_ids else set()
+        self.use_default_guild_ids: bool = guild_ids is MISSING and not force_global
         self.dm_permission: Optional[bool] = dm_permission
         self.default_member_permissions: Optional[
             Union[Permissions, int]

--- a/nextcord/application_command.py
+++ b/nextcord/application_command.py
@@ -1816,7 +1816,7 @@ class BaseApplicationCommand(CallbackMixin, CallbackWrapperMixin):
         guild_ids: Iterable[:class:`int`]
             An iterable list/set/whatever of guild ID's that the application command should register to.
             If not passed and :attr:`Client.default_guild_ids` is set, then those default guild ids will
-            be used instead. If both of those are unset, then the command will be a global command. Defaults to ``MISSING``.
+            be used instead. If both of those are unset, then the command will be a global command.
         dm_permission: :class:`bool`
             If the command should be usable in DMs or not. Setting to ``False`` will disable the command from being
             usable in DMs. Only for global commands, but will not error on guild.
@@ -2938,7 +2938,7 @@ def slash_command(
     guild_ids: Optional[Iterable[:class:`int`]]
         IDs of :class:`Guild`'s to add this command to. If not passed and :attr:`Client.default_guild_ids` is
         set, then those default guild ids will be used instead. If both of those are unset, then the command will
-        be a global command. Defaults to ``MISSING``.
+        be a global command.
     dm_permission: :class:`bool`
         If the command should be usable in DMs or not. Setting to ``False`` will disable the command from being
         usable in DMs. Only for global commands, but will not error on guild.
@@ -2993,7 +2993,7 @@ def message_command(
     guild_ids: Optional[Iterable[:class:`int`]]
         IDs of :class:`Guild`'s to add this command to. If not passed and :attr:`Client.default_guild_ids` is
         set, then those default guild ids will be used instead. If both of those are unset, then the command will
-        be a global command. Defaults to ``MISSING``.
+        be a global command.
     dm_permission: :class:`bool`
         If the command should be usable in DMs or not. Setting to ``False`` will disable the command from being
         usable in DMs. Only for global commands, but will not error on guild.
@@ -3046,7 +3046,7 @@ def user_command(
     guild_ids: Optional[Iterable[:class:`int`]]
         IDs of :class:`Guild`'s to add this command to. If not passed and :attr:`Client.default_guild_ids` is
         set, then those default guild ids will be used instead. If both of those are unset, then the command will
-        be a global command. Defaults to ``MISSING``.
+        be a global command.
     dm_permission: :class:`bool`
         If the command should be usable in DMs or not. Setting to ``False`` will disable the command from being
         usable in DMs. Only for global commands, but will not error on guild.

--- a/nextcord/client.py
+++ b/nextcord/client.py
@@ -340,7 +340,7 @@ class Client:
             intents=intents,
             chunk_guilds_at_startup=chunk_guilds_at_startup,
             member_cache_flags=member_cache_flags,
-            default_guild_ids=default_guild_ids
+            default_guild_ids=default_guild_ids,
         )
 
         self._connection.shard_count = self.shard_count

--- a/nextcord/client.py
+++ b/nextcord/client.py
@@ -2535,8 +2535,8 @@ class Client:
             Name(s) of the command for users of specific locales. The locale code should be the key, with the localized
             name as the value
         guild_ids: Optional[Iterable[:class:`int`]]
-            IDs of :class:`Guild`'s to add this command to. If set to :attr:`utils.MISSING` and `default_guild_ids` is 
-            set, then those default guild ids will be used instead. If both of those are unset, then the command will 
+            IDs of :class:`Guild`'s to add this command to. If set to :attr:`utils.MISSING` and `default_guild_ids` is
+            set, then those default guild ids will be used instead. If both of those are unset, then the command will
             be a global command. Defaults to `None`.
         dm_permission: :class:`bool`
             If the command should be usable in DMs or not. Setting to ``False`` will disable the command from being
@@ -2584,8 +2584,8 @@ class Client:
             Name(s) of the command for users of specific locales. The locale code should be the key, with the localized
             name as the value
         guild_ids: Optional[Iterable[:class:`int`]]
-            IDs of :class:`Guild`'s to add this command to. If set to :attr:`utils.MISSING` and `default_guild_ids` is 
-            set, then those default guild ids will be used instead. If both of those are unset, then the command will 
+            IDs of :class:`Guild`'s to add this command to. If set to :attr:`utils.MISSING` and `default_guild_ids` is
+            set, then those default guild ids will be used instead. If both of those are unset, then the command will
             be a global command. Defaults to `None`.
         dm_permission: :class:`bool`
             If the command should be usable in DMs or not. Setting to ``False`` will disable the command from being
@@ -2641,8 +2641,8 @@ class Client:
             Description(s) of the command for users of specific locales. The locale code should be the key, with the
             localized description as the value.
         guild_ids: Optional[Iterable[:class:`int`]]
-            IDs of :class:`Guild`'s to add this command to. If set to :attr:`utils.MISSING` and `default_guild_ids` is 
-            set, then those default guild ids will be used instead. If both of those are unset, then the command will 
+            IDs of :class:`Guild`'s to add this command to. If set to :attr:`utils.MISSING` and `default_guild_ids` is
+            set, then those default guild ids will be used instead. If both of those are unset, then the command will
             be a global command. Defaults to `None`.
         dm_permission: :class:`bool`
             If the command should be usable in DMs or not. Setting to ``False`` will disable the command from being

--- a/nextcord/client.py
+++ b/nextcord/client.py
@@ -265,6 +265,10 @@ class Client:
         Warning: While enabling this will prevent "ghost" commands on guilds with removed code references, rolling out
         to ALL guilds with anything other than a very small bot will likely cause it to get rate limited.
 
+    default_guild_ids: List[:class:`int`]
+        The default guild ids for every application command set. If the application command doesn't have any explicit
+        guild ids set and this list is not empty, then the application command's guild ids will be set to this.
+        Defaults to `[]`.
 
     Attributes
     ----------
@@ -301,6 +305,7 @@ class Client:
         rollout_register_new: bool = True,
         rollout_update_known: bool = True,
         rollout_all_guilds: bool = False,
+        default_guild_ids: List[int] = [],
     ):
         # self.ws is set in the connect method
         self.ws: DiscordWebSocket = None  # type: ignore
@@ -335,6 +340,7 @@ class Client:
             intents=intents,
             chunk_guilds_at_startup=chunk_guilds_at_startup,
             member_cache_flags=member_cache_flags,
+            default_guild_ids=default_guild_ids
         )
 
         self._connection.shard_count = self.shard_count
@@ -374,6 +380,7 @@ class Client:
         intents: Intents,
         chunk_guilds_at_startup: bool,
         member_cache_flags: MemberCacheFlags,
+        default_guild_ids: List[int],
     ) -> ConnectionState:
         return ConnectionState(
             dispatch=self.dispatch,
@@ -391,6 +398,7 @@ class Client:
             intents=intents,
             chunk_guilds_at_startup=chunk_guilds_at_startup,
             member_cache_flags=member_cache_flags,
+            default_guild_ids=default_guild_ids,
         )
 
     def _handle_ready(self) -> None:
@@ -2522,7 +2530,8 @@ class Client:
             Name(s) of the command for users of specific locales. The locale code should be the key, with the localized
             name as the value
         guild_ids: Iterable[:class:`int`]
-            IDs of :class:`Guild`'s to add this command to. If unset, this will be a global command.
+            IDs of :class:`Guild`'s to add this command to. If unset and `default_guild_ids` is set, then those
+            default guild ids will be used instead. If both of those are unset, then the command will be a global command.
         dm_permission: :class:`bool`
             If the command should be usable in DMs or not. Setting to ``False`` will disable the command from being
             usable in DMs. Only for global commands, but will not error on guild.
@@ -2569,7 +2578,8 @@ class Client:
             Name(s) of the command for users of specific locales. The locale code should be the key, with the localized
             name as the value
         guild_ids: Iterable[:class:`int`]
-            IDs of :class:`Guild`'s to add this command to. If unset, this will be a global command.
+            IDs of :class:`Guild`'s to add this command to. If unset and `default_guild_ids` is set, then those
+            default guild ids will be used instead. If both of those are unset, then the command will be a global command.
         dm_permission: :class:`bool`
             If the command should be usable in DMs or not. Setting to ``False`` will disable the command from being
             usable in DMs. Only for global commands, but will not error on guild.
@@ -2624,7 +2634,8 @@ class Client:
             Description(s) of the command for users of specific locales. The locale code should be the key, with the
             localized description as the value.
         guild_ids: Iterable[:class:`int`]
-            IDs of :class:`Guild`'s to add this command to. If unset, this will be a global command.
+            IDs of :class:`Guild`'s to add this command to. If unset and `default_guild_ids` is set, then those
+            default guild ids will be used instead. If both of those are unset, then the command will be a global command.
         dm_permission: :class:`bool`
             If the command should be usable in DMs or not. Setting to ``False`` will disable the command from being
             usable in DMs. Only for global commands, but will not error on guild.

--- a/nextcord/client.py
+++ b/nextcord/client.py
@@ -2520,7 +2520,7 @@ class Client:
         name: Optional[str] = None,
         *,
         name_localizations: Optional[Dict[Union[Locale, str], str]] = None,
-        guild_ids: Optional[Iterable[int]] = None,
+        guild_ids: Optional[Iterable[int]] = MISSING,
         dm_permission: Optional[bool] = None,
         default_member_permissions: Optional[Union[Permissions, int]] = None,
         force_global: bool = False,
@@ -2537,7 +2537,7 @@ class Client:
         guild_ids: Optional[Iterable[:class:`int`]]
             IDs of :class:`Guild`'s to add this command to. If set to :attr:`utils.MISSING` and `default_guild_ids` is
             set, then those default guild ids will be used instead. If both of those are unset, then the command will
-            be a global command. Defaults to `None`.
+            be a global command. Defaults to `MISSING`.
         dm_permission: :class:`bool`
             If the command should be usable in DMs or not. Setting to ``False`` will disable the command from being
             usable in DMs. Only for global commands, but will not error on guild.
@@ -2569,7 +2569,7 @@ class Client:
         name: Optional[str] = None,
         *,
         name_localizations: Optional[Dict[Union[Locale, str], str]] = None,
-        guild_ids: Optional[Iterable[int]] = None,
+        guild_ids: Optional[Iterable[int]] = MISSING,
         dm_permission: Optional[bool] = None,
         default_member_permissions: Optional[Union[Permissions, int]] = None,
         force_global: bool = False,
@@ -2586,7 +2586,7 @@ class Client:
         guild_ids: Optional[Iterable[:class:`int`]]
             IDs of :class:`Guild`'s to add this command to. If set to :attr:`utils.MISSING` and `default_guild_ids` is
             set, then those default guild ids will be used instead. If both of those are unset, then the command will
-            be a global command. Defaults to `None`.
+            be a global command. Defaults to `MISSING`.
         dm_permission: :class:`bool`
             If the command should be usable in DMs or not. Setting to ``False`` will disable the command from being
             usable in DMs. Only for global commands, but will not error on guild.
@@ -2620,7 +2620,7 @@ class Client:
         *,
         name_localizations: Optional[Dict[Union[Locale, str], str]] = None,
         description_localizations: Optional[Dict[Union[Locale, str], str]] = None,
-        guild_ids: Optional[Iterable[int]] = None,
+        guild_ids: Optional[Iterable[int]] = MISSING,
         dm_permission: Optional[bool] = None,
         default_member_permissions: Optional[Union[Permissions, int]] = None,
         force_global: bool = False,
@@ -2643,7 +2643,7 @@ class Client:
         guild_ids: Optional[Iterable[:class:`int`]]
             IDs of :class:`Guild`'s to add this command to. If set to :attr:`utils.MISSING` and `default_guild_ids` is
             set, then those default guild ids will be used instead. If both of those are unset, then the command will
-            be a global command. Defaults to `None`.
+            be a global command. Defaults to `MISSING`.
         dm_permission: :class:`bool`
             If the command should be usable in DMs or not. Setting to ``False`` will disable the command from being
             usable in DMs. Only for global commands, but will not error on guild.

--- a/nextcord/client.py
+++ b/nextcord/client.py
@@ -268,7 +268,7 @@ class Client:
     default_guild_ids: Optional[List[:class:`int`]]
         The default guild ids for every application command set. If the application command doesn't have any explicit
         guild ids set and this list is not empty, then the application command's guild ids will be set to this.
-        Defaults to `None`.
+        Defaults to ``None``.
 
     Attributes
     ----------
@@ -2582,9 +2582,9 @@ class Client:
             Name(s) of the command for users of specific locales. The locale code should be the key, with the localized
             name as the value
         guild_ids: Optional[Iterable[:class:`int`]]
-            IDs of :class:`Guild`'s to add this command to. If set to :attr:`utils.MISSING` and `default_guild_ids` is
+            IDs of :class:`Guild`'s to add this command to. If set to :attr:`utils.MISSING` and ``default_guild_ids`` is
             set, then those default guild ids will be used instead. If both of those are unset, then the command will
-            be a global command. Defaults to `MISSING`.
+            be a global command. Defaults to ``MISSING``.
         dm_permission: :class:`bool`
             If the command should be usable in DMs or not. Setting to ``False`` will disable the command from being
             usable in DMs. Only for global commands, but will not error on guild.

--- a/nextcord/client.py
+++ b/nextcord/client.py
@@ -499,7 +499,7 @@ class Client:
     @property
     def default_guild_ids(self) -> List[int]:
         """List[:class:`int`] The default guild ids for all application commands.
-        
+
         .. versionadded:: 2.3
         """
         return self._default_guild_ids

--- a/nextcord/client.py
+++ b/nextcord/client.py
@@ -270,6 +270,8 @@ class Client:
         guild ids set and this list is not empty, then the application command's guild ids will be set to this.
         Defaults to ``None``.
 
+        .. versionadded:: 2.3
+
     Attributes
     ----------
     ws
@@ -493,6 +495,14 @@ class Client:
         .. versionadded:: 2.0
         """
         return self._connection.application_flags
+
+    @property
+    def default_guild_ids(self) -> List[int]:
+        """List[:class:`int`] The default guild ids for all application commands.
+        
+        .. versionadded:: 2.3
+        """
+        return self._default_guild_ids
 
     def is_ready(self) -> bool:
         """:class:`bool`: Specifies if the client's internal cache is ready for use."""
@@ -2533,9 +2543,9 @@ class Client:
             Name(s) of the command for users of specific locales. The locale code should be the key, with the localized
             name as the value
         guild_ids: Optional[Iterable[:class:`int`]]
-            IDs of :class:`Guild`'s to add this command to. If set to :attr:`utils.MISSING` and `default_guild_ids` is
+            IDs of :class:`Guild`'s to add this command to. If not passed and :attr:`Client.default_guild_ids` is
             set, then those default guild ids will be used instead. If both of those are unset, then the command will
-            be a global command. Defaults to `MISSING`.
+            be a global command. Defaults to ``MISSING``.
         dm_permission: :class:`bool`
             If the command should be usable in DMs or not. Setting to ``False`` will disable the command from being
             usable in DMs. Only for global commands, but will not error on guild.
@@ -2582,7 +2592,7 @@ class Client:
             Name(s) of the command for users of specific locales. The locale code should be the key, with the localized
             name as the value
         guild_ids: Optional[Iterable[:class:`int`]]
-            IDs of :class:`Guild`'s to add this command to. If set to :attr:`utils.MISSING` and ``default_guild_ids`` is
+            IDs of :class:`Guild`'s to add this command to. If not passed and :attr:`Client.default_guild_ids` is
             set, then those default guild ids will be used instead. If both of those are unset, then the command will
             be a global command. Defaults to ``MISSING``.
         dm_permission: :class:`bool`
@@ -2639,9 +2649,9 @@ class Client:
             Description(s) of the command for users of specific locales. The locale code should be the key, with the
             localized description as the value.
         guild_ids: Optional[Iterable[:class:`int`]]
-            IDs of :class:`Guild`'s to add this command to. If set to :attr:`utils.MISSING` and `default_guild_ids` is
+            IDs of :class:`Guild`'s to add this command to. If not passed and :attr:`Client.default_guild_ids` is
             set, then those default guild ids will be used instead. If both of those are unset, then the command will
-            be a global command. Defaults to `MISSING`.
+            be a global command. Defaults to ``MISSING``.
         dm_permission: :class:`bool`
             If the command should be usable in DMs or not. Setting to ``False`` will disable the command from being
             usable in DMs. Only for global commands, but will not error on guild.

--- a/nextcord/client.py
+++ b/nextcord/client.py
@@ -2122,7 +2122,7 @@ class Client:
             If the command should be removed before adding it. This will clear all signatures from storage, including
             rollout ones.
         """
-        if not command.force_global and not command.guild_ids_to_rollout:
+        if command.use_default_guild_ids:
             for id in self._default_guild_ids:
                 command.add_guild_rollout(id)
 

--- a/nextcord/client.py
+++ b/nextcord/client.py
@@ -2534,9 +2534,10 @@ class Client:
         name_localizations: Dict[Union[:class:`Locale`, :class:`str`], :class:`str`]
             Name(s) of the command for users of specific locales. The locale code should be the key, with the localized
             name as the value
-        guild_ids: Iterable[:class:`int`]
-            IDs of :class:`Guild`'s to add this command to. If unset and `default_guild_ids` is set, then those
-            default guild ids will be used instead. If both of those are unset, then the command will be a global command.
+        guild_ids: Optional[Iterable[:class:`int`]]
+            IDs of :class:`Guild`'s to add this command to. If set to :attr:`utils.MISSING` and `default_guild_ids` is 
+            set, then those default guild ids will be used instead. If both of those are unset, then the command will 
+            be a global command. Defaults to `None`.
         dm_permission: :class:`bool`
             If the command should be usable in DMs or not. Setting to ``False`` will disable the command from being
             usable in DMs. Only for global commands, but will not error on guild.
@@ -2582,9 +2583,10 @@ class Client:
         name_localizations: Dict[Union[:class:`Locale`, :class:`str`], :class:`str`]
             Name(s) of the command for users of specific locales. The locale code should be the key, with the localized
             name as the value
-        guild_ids: Iterable[:class:`int`]
-            IDs of :class:`Guild`'s to add this command to. If unset and `default_guild_ids` is set, then those
-            default guild ids will be used instead. If both of those are unset, then the command will be a global command.
+        guild_ids: Optional[Iterable[:class:`int`]]
+            IDs of :class:`Guild`'s to add this command to. If set to :attr:`utils.MISSING` and `default_guild_ids` is 
+            set, then those default guild ids will be used instead. If both of those are unset, then the command will 
+            be a global command. Defaults to `None`.
         dm_permission: :class:`bool`
             If the command should be usable in DMs or not. Setting to ``False`` will disable the command from being
             usable in DMs. Only for global commands, but will not error on guild.
@@ -2638,9 +2640,10 @@ class Client:
         description_localizations: Dict[Union[:class:`Locale`, :class:`str`], :class:`str`]
             Description(s) of the command for users of specific locales. The locale code should be the key, with the
             localized description as the value.
-        guild_ids: Iterable[:class:`int`]
-            IDs of :class:`Guild`'s to add this command to. If unset and `default_guild_ids` is set, then those
-            default guild ids will be used instead. If both of those are unset, then the command will be a global command.
+        guild_ids: Optional[Iterable[:class:`int`]]
+            IDs of :class:`Guild`'s to add this command to. If set to :attr:`utils.MISSING` and `default_guild_ids` is 
+            set, then those default guild ids will be used instead. If both of those are unset, then the command will 
+            be a global command. Defaults to `None`.
         dm_permission: :class:`bool`
             If the command should be usable in DMs or not. Setting to ``False`` will disable the command from being
             usable in DMs. Only for global commands, but will not error on guild.

--- a/nextcord/client.py
+++ b/nextcord/client.py
@@ -265,10 +265,10 @@ class Client:
         Warning: While enabling this will prevent "ghost" commands on guilds with removed code references, rolling out
         to ALL guilds with anything other than a very small bot will likely cause it to get rate limited.
 
-    default_guild_ids: List[:class:`int`]
+    default_guild_ids: Optional[List[:class:`int`]]
         The default guild ids for every application command set. If the application command doesn't have any explicit
         guild ids set and this list is not empty, then the application command's guild ids will be set to this.
-        Defaults to `[]`.
+        Defaults to `None`.
 
     Attributes
     ----------
@@ -305,7 +305,7 @@ class Client:
         rollout_register_new: bool = True,
         rollout_update_known: bool = True,
         rollout_all_guilds: bool = False,
-        default_guild_ids: List[int] = [],
+        default_guild_ids: Optional[List[int]] = None,
     ):
         # self.ws is set in the connect method
         self.ws: DiscordWebSocket = None  # type: ignore
@@ -328,6 +328,9 @@ class Client:
         self._hooks: Dict[str, Callable] = {"before_identify": self._call_before_identify_hook}
 
         self._enable_debug_events: bool = enable_debug_events
+
+        if default_guild_ids is None:
+            default_guild_ids = []
 
         self._connection: ConnectionState = self._get_state(
             max_messages=max_messages,

--- a/nextcord/client.py
+++ b/nextcord/client.py
@@ -356,9 +356,7 @@ class Client:
         self._rollout_all_guilds: bool = rollout_all_guilds
         self._application_commands_to_add: Set[BaseApplicationCommand] = set()
 
-        if default_guild_ids is None:
-            default_guild_ids = []
-        self._default_guild_ids = default_guild_ids
+        self._default_guild_ids = default_guild_ids or []
 
         if VoiceClient.warn_nacl:
             VoiceClient.warn_nacl = False

--- a/nextcord/client.py
+++ b/nextcord/client.py
@@ -2545,7 +2545,7 @@ class Client:
         guild_ids: Optional[Iterable[:class:`int`]]
             IDs of :class:`Guild`'s to add this command to. If not passed and :attr:`Client.default_guild_ids` is
             set, then those default guild ids will be used instead. If both of those are unset, then the command will
-            be a global command. Defaults to ``MISSING``.
+            be a global command.
         dm_permission: :class:`bool`
             If the command should be usable in DMs or not. Setting to ``False`` will disable the command from being
             usable in DMs. Only for global commands, but will not error on guild.
@@ -2594,7 +2594,7 @@ class Client:
         guild_ids: Optional[Iterable[:class:`int`]]
             IDs of :class:`Guild`'s to add this command to. If not passed and :attr:`Client.default_guild_ids` is
             set, then those default guild ids will be used instead. If both of those are unset, then the command will
-            be a global command. Defaults to ``MISSING``.
+            be a global command.
         dm_permission: :class:`bool`
             If the command should be usable in DMs or not. Setting to ``False`` will disable the command from being
             usable in DMs. Only for global commands, but will not error on guild.
@@ -2651,7 +2651,7 @@ class Client:
         guild_ids: Optional[Iterable[:class:`int`]]
             IDs of :class:`Guild`'s to add this command to. If not passed and :attr:`Client.default_guild_ids` is
             set, then those default guild ids will be used instead. If both of those are unset, then the command will
-            be a global command. Defaults to ``MISSING``.
+            be a global command.
         dm_permission: :class:`bool`
             If the command should be usable in DMs or not. Setting to ``False`` will disable the command from being
             usable in DMs. Only for global commands, but will not error on guild.

--- a/nextcord/ext/commands/bot.py
+++ b/nextcord/ext/commands/bot.py
@@ -1650,6 +1650,7 @@ class Bot(BotBase, nextcord.Client):
         rollout_register_new: bool = True,
         rollout_update_known: bool = True,
         rollout_all_guilds: bool = False,
+        default_guild_ids: Optional[List[int]] = None,
         owner_id: Optional[int] = None,
         owner_ids: Optional[Iterable[int]] = None,
         strip_after_prefix: bool = False,
@@ -1681,6 +1682,7 @@ class Bot(BotBase, nextcord.Client):
             rollout_register_new=rollout_register_new,
             rollout_update_known=rollout_update_known,
             rollout_all_guilds=rollout_all_guilds,
+            default_guild_ids=default_guild_ids,
         )
 
         BotBase.__init__(
@@ -1737,6 +1739,7 @@ class AutoShardedBot(BotBase, nextcord.AutoShardedClient):
         rollout_register_new: bool = True,
         rollout_update_known: bool = True,
         rollout_all_guilds: bool = False,
+        default_guild_ids: Optional[List[int]] = None,
         owner_id: Optional[int] = None,
         owner_ids: Optional[Iterable[int]] = None,
         strip_after_prefix: bool = False,
@@ -1769,6 +1772,7 @@ class AutoShardedBot(BotBase, nextcord.AutoShardedClient):
             rollout_register_new=rollout_register_new,
             rollout_update_known=rollout_update_known,
             rollout_all_guilds=rollout_all_guilds,
+            default_guild_ids=default_guild_ids,
         )
 
         BotBase.__init__(

--- a/nextcord/shard.py
+++ b/nextcord/shard.py
@@ -357,7 +357,7 @@ class AutoShardedClient(Client):
         rollout_register_new: bool = True,
         rollout_update_known: bool = True,
         rollout_all_guilds: bool = False,
-        default_guild_ids: List[int] = [],
+        default_guild_ids: Optional[List[int]] = None,
     ) -> None:
         self.shard_ids: Optional[List[int]] = shard_ids
         super().__init__(

--- a/nextcord/shard.py
+++ b/nextcord/shard.py
@@ -423,7 +423,6 @@ class AutoShardedClient(Client):
         intents: Intents,
         chunk_guilds_at_startup: bool,
         member_cache_flags: MemberCacheFlags,
-        default_guild_ids: List[int],
     ) -> AutoShardedConnectionState:
         return AutoShardedConnectionState(
             dispatch=self.dispatch,
@@ -441,7 +440,6 @@ class AutoShardedClient(Client):
             intents=intents,
             chunk_guilds_at_startup=chunk_guilds_at_startup,
             member_cache_flags=member_cache_flags,
-            default_guild_ids=default_guild_ids,
         )
 
     @property

--- a/nextcord/shard.py
+++ b/nextcord/shard.py
@@ -357,6 +357,7 @@ class AutoShardedClient(Client):
         rollout_register_new: bool = True,
         rollout_update_known: bool = True,
         rollout_all_guilds: bool = False,
+        default_guild_ids: List[int] = [],
     ) -> None:
         self.shard_ids: Optional[List[int]] = shard_ids
         super().__init__(
@@ -384,6 +385,7 @@ class AutoShardedClient(Client):
             rollout_register_new=rollout_register_new,
             rollout_update_known=rollout_update_known,
             rollout_all_guilds=rollout_all_guilds,
+            default_guild_ids=default_guild_ids,
         )
 
         if self.shard_ids is not None:
@@ -421,6 +423,7 @@ class AutoShardedClient(Client):
         intents: Intents,
         chunk_guilds_at_startup: bool,
         member_cache_flags: MemberCacheFlags,
+        default_guild_ids: List[int],
     ) -> AutoShardedConnectionState:
         return AutoShardedConnectionState(
             dispatch=self.dispatch,
@@ -438,6 +441,7 @@ class AutoShardedClient(Client):
             intents=intents,
             chunk_guilds_at_startup=chunk_guilds_at_startup,
             member_cache_flags=member_cache_flags,
+            default_guild_ids=default_guild_ids,
         )
 
     @property

--- a/nextcord/state.py
+++ b/nextcord/state.py
@@ -189,7 +189,6 @@ class ConnectionState:
         intents: Intents = Intents.default(),
         chunk_guilds_at_startup: bool = MISSING,
         member_cache_flags: MemberCacheFlags = MISSING,
-        default_guild_ids: List[int],
     ) -> None:
         self.loop: asyncio.AbstractEventLoop = loop
         self.http: HTTPClient = http
@@ -260,7 +259,6 @@ class ConnectionState:
         self._activity: Optional[ActivityPayload] = raw_activity
         self._status: Optional[str] = raw_status
         self._intents: Intents = intents
-        self._default_guild_ids: List[int] = default_guild_ids
         # A set of all application command objects available. Set because duplicates should not exist.
         self._application_commands: Set[BaseApplicationCommand] = set()
         # A dictionary of all available unique command signatures. Compiled at runtime because needing to iterate
@@ -620,10 +618,6 @@ class ConnectionState:
         """
         if pre_remove:
             self.remove_application_command(command)
-
-        if not command.force_global and not command.guild_ids_to_rollout:
-            for id in self._default_guild_ids:
-                command.add_guild_rollout(id)
 
         signature_set = (
             command.get_rollout_signatures() if use_rollout else command.get_signatures()

--- a/nextcord/state.py
+++ b/nextcord/state.py
@@ -189,6 +189,7 @@ class ConnectionState:
         intents: Intents = Intents.default(),
         chunk_guilds_at_startup: bool = MISSING,
         member_cache_flags: MemberCacheFlags = MISSING,
+        default_guild_ids: List[int],
     ) -> None:
         self.loop: asyncio.AbstractEventLoop = loop
         self.http: HTTPClient = http
@@ -259,6 +260,7 @@ class ConnectionState:
         self._activity: Optional[ActivityPayload] = raw_activity
         self._status: Optional[str] = raw_status
         self._intents: Intents = intents
+        self._default_guild_ids: List[int] = default_guild_ids
         # A set of all application command objects available. Set because duplicates should not exist.
         self._application_commands: Set[BaseApplicationCommand] = set()
         # A dictionary of all available unique command signatures. Compiled at runtime because needing to iterate
@@ -618,6 +620,11 @@ class ConnectionState:
         """
         if pre_remove:
             self.remove_application_command(command)
+
+        if not command.force_global and not command.guild_ids_to_rollout:
+            for id in self._default_guild_ids:
+                command.add_guild_rollout(id)
+
         signature_set = (
             command.get_rollout_signatures() if use_rollout else command.get_signatures()
         )

--- a/nextcord/state.py
+++ b/nextcord/state.py
@@ -618,7 +618,6 @@ class ConnectionState:
         """
         if pre_remove:
             self.remove_application_command(command)
-
         signature_set = (
             command.get_rollout_signatures() if use_rollout else command.get_signatures()
         )


### PR DESCRIPTION
## Summary

This PR adds a new parameter to `Client` and `AutoShardedClient` named `default_guild_ids` that acts as the default guild ids for application commands that don't have any guild ids set. Closes #395.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
  - [x] I have updated the documentation to reflect the changes.
  - [ ] I have run `task pyright` and fixed the relevant issues.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
