### PR TITLE
feat: http ratelimit events

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -255,9 +255,9 @@ to handle it, which defaults to print a traceback and ignoring the exception.
     :type remaining: :class:`int`
     :param reset_after: The amount of time we have to wait before making another request under the same bucket.
     :type reset_after: :class:`float`
-    :param bucket: The hash correlating to the bucket of the request from Discord.
+    :param bucket: The hash correlating to the bucket of the request from Discord. This hash denotes the rate limit being encountered.
     :type bucket: :class:`str`
-    :param scope: If we get a 429, the scope of the 429 response.
+    :param scope: If we get a 429, the scope of the 429 response. This value can either be "user" (rate limit relating to the user) or "shared" (rate limit relating to a resource).
     :type scope: Optional[:class:`str`]
 
 .. function:: on_global_http_ratelimit(retry_after)

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -247,7 +247,7 @@ to handle it, which defaults to print a traceback and ignoring the exception.
 
     If the 429 response is a global ratelimit, then use :func:`on_global_http_ratelimit` instead.
 
-    .. versionadded:: 2.3
+    .. versionadded:: 2.4
 
     :param limit: The amount of requests that have been made under the bucket that the request correlates to.
     :type limit: :class:`int`
@@ -266,6 +266,8 @@ to handle it, which defaults to print a traceback and ignoring the exception.
 
     If the 429 response is a non-global ratelimit or you want to track when the bucket expires,
     then use :func:`on_http_ratelimit` instead.
+
+    .. versionadded:: 2.4
 
     :param retry_after: The amount of time we have to wait before making another request.
     :type retry_after: :class:`float`

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -244,6 +244,7 @@ to handle it, which defaults to print a traceback and ignoring the exception.
 .. function:: on_http_ratelimit(limit, remaining, reset_after, bucket, scope)
 
     Called when a HTTP request in progress either exhausts its bucket or gets a 429 response.
+    For more information on how a ratelimit bucket is defined, check out the [Discord API Docs](https://discord.dev/topics/rate-limits).
 
     If the 429 response is a global ratelimit, then use :func:`on_global_http_ratelimit` instead.
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -245,6 +245,8 @@ to handle it, which defaults to print a traceback and ignoring the exception.
 
     Called when a HTTP request in progress either exhausts its bucket or gets a 429 response.
 
+    If the 429 response is a global ratelimit, then use :func:`on_global_http_ratelimit` instead.
+
     .. versionadded:: 2.3
 
     :param limit: The amount of requests that have been made under the bucket that the request correlates to.
@@ -257,6 +259,16 @@ to handle it, which defaults to print a traceback and ignoring the exception.
     :type bucket: :class:`str`
     :param scope: If we get a 429, the scope of the 429 response.
     :type scope: Optional[:class:`str`]
+
+.. function:: on_global_http_ratelimit(retry_after)
+
+    Called when a HTTP request in progress gets a 429 response and the scope is global.
+
+    If the 429 response is a non-global ratelimit or you want to track when the bucket expires,
+    then use :func:`on_http_ratelimit` instead.
+
+    :param retry_after: The amount of time we have to wait before making another request.
+    :type retry_after: :class:`float`
 
 .. function:: on_ready()
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -241,6 +241,23 @@ to handle it, which defaults to print a traceback and ignoring the exception.
     :param shard_id: The shard ID that has disconnected.
     :type shard_id: :class:`int`
 
+.. function:: on_http_ratelimit(limit, remaining, reset_after, bucket, scope)
+
+    Called when a HTTP request in progress either exhausts its bucket or gets a 429 response.
+
+    .. versionadded:: 2.3
+
+    :param limit: The amount of requests that have been made under the bucket that the request correlates to.
+    :type limit: :class:`int`
+    :param remaining: The amount of remaining requests that can be made under the bucket that the request correlates to.
+    :type remaining: :class:`int`
+    :param reset_after: The amount of time we have to wait before making another request under the same bucket.
+    :type reset_after: :class:`float`
+    :param bucket: The hash correlating to the bucket of the request from Discord.
+    :type bucket: :class:`str`
+    :param scope: If we get a 429, the scope of the 429 response.
+    :type scope: Optional[:class:`str`]
+
 .. function:: on_ready()
 
     Called when the client is done preparing the data received from Discord. Usually after login is successful

--- a/nextcord/client.py
+++ b/nextcord/client.py
@@ -316,6 +316,7 @@ class Client:
             proxy_auth=proxy_auth,
             unsync_clock=assume_unsync_clock,
             loop=self.loop,
+            dispatch=self.dispatch,
         )
 
         self._handlers: Dict[str, Callable] = {"ready": self._handle_ready}

--- a/nextcord/http.py
+++ b/nextcord/http.py
@@ -335,12 +335,8 @@ class HTTPClient:
                         # check if we have rate limit header information
                         is_global = bool(response.headers.get("X-RateLimit-Global", False))
 
-                        if is_global:
-                            limit = response.headers.get("X-RateLimit-Limit", "")
-                            remaining = response.headers.get("X-Ratelimit-Remaining", "")
-                        else:
-                            limit = response.headers["X-RateLimit-Limit"]
-                            remaining = response.headers["X-RateLimit-Remaining"]
+                        limit = response.headers.get("X-RateLimit-Limit", "")
+                        remaining = response.headers.get("X-Ratelimit-Remaining", "")
 
                         bucket = response.headers.get("X-RateLimit-Bucket")
                         if remaining == "0" and response.status != 429:

--- a/nextcord/http.py
+++ b/nextcord/http.py
@@ -359,7 +359,7 @@ class HTTPClient:
                                 int(remaining),
                                 delta,
                                 bucket,
-                                None,
+                                response.headers.get("X-RateLimit-Scope"),
                             )
                             maybe_lock.defer()
                             self.loop.call_later(delta, lock.release)

--- a/nextcord/http.py
+++ b/nextcord/http.py
@@ -344,7 +344,14 @@ class HTTPClient:
                                 bucket,
                                 delta,
                             )
-                            self._dispatch("http_ratelimit", 5, 0, delta, response.headers.get("X-RateLimit-Bucket"), None)
+                            self._dispatch(
+                                "http_ratelimit",
+                                5,
+                                0,
+                                delta,
+                                response.headers.get("X-RateLimit-Bucket"),
+                                None,
+                            )
                             maybe_lock.defer()
                             self.loop.call_later(delta, lock.release)
 
@@ -365,7 +372,14 @@ class HTTPClient:
                             retry_after: float = data["retry_after"]
                             _log.warning(fmt, retry_after, bucket)
 
-                            self._dispatch("http_ratelimit", 5, 0, retry_after, response.headers.get("X-RateLimit-Bucket"), response.headers.get("X-RateLimit-Scope"))
+                            self._dispatch(
+                                "http_ratelimit",
+                                5,
+                                0,
+                                retry_after,
+                                response.headers.get("X-RateLimit-Bucket"),
+                                response.headers.get("X-RateLimit-Scope"),
+                            )
 
                             # check if it's a global rate limit
                             is_global = data.get("global", False)


### PR DESCRIPTION
## Summary

This adds a new ratelimit event that is dispatched whenever an HTTP request exhausts a bucket or gets a 429 response. Closes #154.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
  - [x] I have updated the documentation to reflect the changes.
  - [ ] I have run `task pyright` and fixed the relevant issues.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
