### PR TITLE
fix(app-cmds): temporarily fix autocomplete integer conversion

### DIFF
--- a/nextcord/application_command.py
+++ b/nextcord/application_command.py
@@ -1616,7 +1616,7 @@ class SlashCommandOption(BaseCommandOption, SlashOption, AutocompleteOptionMixin
 
             value = interaction.guild.get_role(int(value))
         elif self.type is ApplicationCommandOptionType.integer:
-            value = int(value) if value != "" else None
+            value = int(value) if value.isdigit() else None
         elif self.type is ApplicationCommandOptionType.number:
             value = float(value)
         elif self.type is ApplicationCommandOptionType.attachment:


### PR DESCRIPTION

## Summary

<!-- What is this pull request for? Does it fix any issues? -->
<https://github.com/discord/discord-api-docs/issues/5433#issuecomment-1266168023>
This PR fixes the following traceback due to the Discord client sending invalid option data in autocomplete.

```py
  File "/root/.cache/pypoetry/virtualenvs/vibr-TFcQMFAJ-py3.9/lib/python3.9/site-packages/nextcord/application_command.py", line 1609, in handle_value
    value = int(value) if value != "" else None
ValueError: invalid literal for int() with base 10: 'd'
```

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
  - [x] I have updated the documentation to reflect the changes.
  - [x] I have run `task pyright` and fixed the relevant issues.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
