### PR TITLE
Adding component type 5, 6, 7 and 8

### DIFF
--- a/nextcord/components.py
+++ b/nextcord/components.py
@@ -230,6 +230,8 @@ class SelectMenu(Component):
         A list of options that can be selected in this menu.
     disabled: :class:`bool`
         Whether the select is disabled or not.
+    channel_types: List[:class:`ChannelType`]
+        A list of channel types that are allowed to be chosen in this select menu.
     """
 
     __slots__: Tuple[str, ...] = (
@@ -239,6 +241,7 @@ class SelectMenu(Component):
         'max_values',
         'options',
         'disabled',
+        'channel_types'
     )
 
     __repr_info__: ClassVar[Tuple[str, ...]] = __slots__
@@ -258,12 +261,17 @@ class SelectMenu(Component):
             'custom_id': self.custom_id,
             'min_values': self.min_values,
             'max_values': self.max_values,
-            'options': [op.to_dict() for op in self.options],
             'disabled': self.disabled,
         }
 
         if self.placeholder:
             payload['placeholder'] = self.placeholder
+            
+        if hasattr(self, 'channel_types'):
+            payload['channel_types'] = [channel_type.value for channel_type in self.channel_types]
+            
+        if hasattr(self, 'options'):
+            payload['options'] = [op.to_dict() for op in self.options]
 
         return payload
 

--- a/nextcord/enums.py
+++ b/nextcord/enums.py
@@ -593,6 +593,10 @@ class ComponentType(Enum):
     button = 2
     select = 3
     text_input = 4
+    user_select = 5
+    role_select = 6
+    mentionable_select = 7
+    channel_select = 8
 
     def __int__(self):
         return self.value

--- a/nextcord/types/components.py
+++ b/nextcord/types/components.py
@@ -55,6 +55,7 @@ class _SelectMenuOptional(TypedDict, total=False):
     min_values: int
     max_values: int
     disabled: bool
+    options: List[SelectOption]
 
 
 class _SelectOptionsOptional(TypedDict, total=False):
@@ -71,7 +72,6 @@ class SelectOption(_SelectOptionsOptional):
 class SelectMenu(_SelectMenuOptional):
     type: Literal[3]
     custom_id: str
-    options: List[SelectOption]
 
 
 class _TextInputComponentOptional(TypedDict, total=False):

--- a/nextcord/types/components.py
+++ b/nextcord/types/components.py
@@ -70,7 +70,7 @@ class SelectOption(_SelectOptionsOptional):
 
 
 class SelectMenu(_SelectMenuOptional):
-    type: Literal[3]
+    type: Literal[3, 5, 6, 7, 8]
     custom_id: str
 
 

--- a/nextcord/ui/__init__.py
+++ b/nextcord/ui/__init__.py
@@ -9,9 +9,13 @@ Bot UI Kit helper for the Discord API
 
 """
 
-from .view import *
-from .modal import *
-from .item import *
 from .button import *
+from .channel_select import *
+from .item import *
+from .mentionable_select import *
+from .modal import *
+from .role_select import *
 from .select import *
 from .text_input import *
+from .user_select import *
+from .view import *

--- a/nextcord/ui/channel_select.py
+++ b/nextcord/ui/channel_select.py
@@ -1,0 +1,250 @@
+"""
+The MIT License (MIT)
+
+Copyright (c) 2015-present Rapptz
+Copyright (c) 2021-present tag-epic
+
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of this software and associated documentation files (the "Software"),
+to deal in the Software without restriction, including without limitation
+the rights to use, copy, modify, merge, publish, distribute, sublicense,
+and/or sell copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+from typing import TYPE_CHECKING, Callable, List, Optional, Union
+
+from .item import Item, ItemCallbackType
+from .select import Select
+
+from ..components import SelectMenu, SelectOption
+from ..enums import ComponentType
+from ..utils import MISSING
+
+if TYPE_CHECKING:
+    from ..abc import GuildChannel
+    from ..enums import ChannelType
+    from ..guild import Guild
+    from ..threads import Thread
+
+__all__ = (
+    "ChannelSelect",
+    "channel_select"
+)
+
+class ChannelSelect(Select):
+    
+    """Represents a UI channel select menu.
+
+    This is usually represented as a drop down menu.
+
+    In order to get the selected items that the user has chosen, 
+    use :attr:`Select.values`., :meth:`Select.get_channels` or :meth:`Select.fetch_channels`.
+
+    .. versionadded:: 2.0
+
+    Parameters
+    ------------
+    custom_id: :class:`str`
+        The ID of the select menu that gets received during an interaction.
+        If not given then one is generated for you.
+    placeholder: Optional[:class:`str`]
+        The placeholder text that is shown if nothing is selected, if any.
+    min_values: :class:`int`
+        The minimum number of items that must be chosen for this select menu.
+        Defaults to 1 and must be between 1 and 25.
+    max_values: :class:`int`
+        The maximum number of items that must be chosen for this select menu.
+        Defaults to 1 and must be between 1 and 25.
+    disabled: :class:`bool`
+        Whether the select is disabled or not.
+    row: Optional[:class:`int`]
+        The relative row this select menu belongs to. A Discord component can only have 5
+        rows. By default, items are arranged automatically into those 5 rows. If you'd
+        like to control the relative positioning of the row then passing an index is advised.
+        For example, row=1 will show up before row=2. Defaults to ``None``, which is automatic
+        ordering. The row number must be between 0 and 4 (i.e. zero indexed).
+    channel_types: List[:class:`nextcord.ChannelType`]
+        The types of channels that can be selected. If not given, all channel types are allowed.
+    """
+    
+    def __init__(
+        self,
+        *,
+        custom_id: str = MISSING,
+        placeholder: Optional[str] = None,
+        min_values: int = 1,
+        max_values: int = 1,
+        disabled: bool = False,
+        row: Optional[int] = None,
+        channel_types: List[ChannelType] = MISSING,
+    ) -> None:
+        Item.__init__(self)
+        self._selected_values: List[str] = []
+        self._provided_custom_id = custom_id is not MISSING
+        custom_id = os.urandom(16).hex() if custom_id is MISSING else custom_id
+        kwargs = {}
+        if channel_types is not MISSING:
+            kwargs["channel_types"] = channel_types
+        self._underlying = SelectMenu._raw_construct(
+            custom_id=custom_id,
+            type=ComponentType.channel_select,
+            placeholder=placeholder,
+            min_values=min_values,
+            max_values=max_values,
+            disabled=disabled,
+            **kwargs
+        )
+        self.row = row
+        
+    @property
+    def options(self) -> List[SelectOption]:
+        """List[:class:`nextcord.SelectOption`]: A list of options that can be selected in this menu.
+        This will always be an empty list since channel selects cannot have any options."""
+        return []
+    
+    @property
+    def values(self) -> List[int]:
+        """List[:class:`int`]: A list of channel ids that have been selected by the user."""
+        return [int(id) for id in self._selected_values]
+        
+    def get_channels(self, guild: Guild) -> List[Union[GuildChannel, Thread]]:
+        """A shortcut for getting all :class:`nextcord.abc.GuildChannel`'s of :attr:`.values`.
+        Channels that are not found in cache will not be returned.
+        To get all channels regardless of whether they are in cache or not, use :meth:`.fetch_channels`.
+        
+        Parameters
+        ----------
+        guild: :class:`nextcord.Guild`
+            The guild to get the channels from.
+            
+        Returns
+        -------
+        List[Union[:class:`nextcord.abc.GuildChannel`, :class:`nextcord.Thread`]]
+            A list of channels that have been selected by the user.
+        """
+        channels: List[Union[GuildChannel, Thread]] = []
+        for id in self.values:
+            channel = guild.get_channel_or_thread(id)
+            if channel is not None:
+                channels.append(channel)
+        return channels
+    
+    async def fetch_channels(self, guild: Guild) -> List[Union[GuildChannel, Thread]]:
+        """A shortcut for fetching all :class:`nextcord.abc.GuildChannel`'s of :attr:`.values`.
+        Channels that are not found in cache will be fetched.
+        
+        Parameters
+        ----------
+        guild: :class:`nextcord.Guild`
+            The guild to get the channels from.
+            
+        Raises
+        ------
+        :exc:`.HTTPException`
+            Fetching the channels failed.
+        :exc:`.NotFound`
+            A channel was not found.
+        :exc:`.Forbidden`
+            You do not have the proper permissions to fetch a channel.
+        :exc:`.InvalidArgument`
+            The channel type is not supported.
+            
+        Returns
+        -------
+        List[Union[:class:`nextcord.abc.GuildChannel`, :class:`nextcord.Thread`]]
+            A list of channels that have been selected by the user.
+        """
+        channels: List[Union[GuildChannel, Thread]] = []
+        guild_channels = None
+        for id in self.values:
+            channel = guild.get_channel_or_thread(id)
+            if channel is None:
+                if guild_channels is None:
+                    guild_channels = await guild.fetch_channels()
+                for channel in guild_channels:
+                    if channel.id == id:
+                        channels.append(channel)
+                        break
+            else:
+                channels.append(channel)
+        return channels
+         
+        
+def channel_select(
+    *,
+    placeholder: Optional[str] = None,
+    custom_id: str = MISSING,
+    min_values: int = 1,
+    max_values: int = 1,
+    disabled: bool = False,
+    row: Optional[int] = None,
+    channel_types: List[ChannelType] = MISSING,
+) -> Callable[[ItemCallbackType], ItemCallbackType]:
+    """A decorator that attaches a channel select menu to a component.
+
+    The function being decorated should have three parameters, ``self`` representing
+    the :class:`nextcord.ui.View`, the :class:`nextcord.ui.ChannelSelect` being pressed and
+    the :class:`nextcord.Interaction` you receive.
+
+    In order to get the selected items that the user has chosen within the callback
+    use :attr:`Select.values`., :attr:`Select.get_channels` or :attr:`Select.fetch_channels`.
+
+    Parameters
+    ------------
+    placeholder: Optional[:class:`str`]
+        The placeholder text that is shown if nothing is selected, if any.
+    custom_id: :class:`str`
+        The ID of the select menu that gets received during an interaction.
+        It is recommended not to set this parameter to prevent conflicts.
+    row: Optional[:class:`int`]
+        The relative row this select menu belongs to. A Discord component can only have 5
+        rows. By default, items are arranged automatically into those 5 rows. If you'd
+        like to control the relative positioning of the row then passing an index is advised.
+        For example, row=1 will show up before row=2. Defaults to ``None``, which is automatic
+        ordering. The row number must be between 0 and 4 (i.e. zero indexed).
+    min_values: :class:`int`
+        The minimum number of items that must be chosen for this select menu.
+        Defaults to 1 and must be between 1 and 25.
+    max_values: :class:`int`
+        The maximum number of items that must be chosen for this select menu.
+        Defaults to 1 and must be between 1 and 25.
+    disabled: :class:`bool`
+        Whether the select is disabled or not. Defaults to ``False``.
+    channel_types: List[:class:`nextcord.ChannelType`]
+        A list of channel types that can be selected in this menu.
+    """
+
+    def decorator(func: ItemCallbackType) -> ItemCallbackType:
+        if not asyncio.iscoroutinefunction(func):
+            raise TypeError("Select function must be a coroutine function")
+
+        func.__discord_ui_model_type__ = ChannelSelect
+        func.__discord_ui_model_kwargs__ = {
+            "placeholder": placeholder,
+            "custom_id": custom_id,
+            "row": row,
+            "min_values": min_values,
+            "max_values": max_values,
+            "disabled": disabled,
+            "channel_types": channel_types,
+        }
+        return func
+
+    return decorator
+        

--- a/nextcord/ui/mentionable_select.py
+++ b/nextcord/ui/mentionable_select.py
@@ -1,0 +1,238 @@
+"""
+The MIT License (MIT)
+
+Copyright (c) 2015-present Rapptz
+Copyright (c) 2021-present tag-epic
+
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of this software and associated documentation files (the "Software"),
+to deal in the Software without restriction, including without limitation
+the rights to use, copy, modify, merge, publish, distribute, sublicense,
+and/or sell copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+from typing import TYPE_CHECKING, Callable, List, Optional, Union
+
+from .item import Item, ItemCallbackType
+from .select import Select
+
+from ..components import SelectMenu, SelectOption
+from ..enums import ComponentType
+from ..utils import MISSING
+
+if TYPE_CHECKING:
+    from ..guild import Guild
+    from ..member import Member
+    from ..role import Role
+
+__all__ = (
+    "MentionableSelect",
+    "mentionable_select"
+)
+
+class MentionableSelect(Select):
+    
+    """Represents a UI mentionable select menu.
+
+    This is usually represented as a drop down menu.
+
+    In order to get the selected items that the user has chosen, 
+    use :attr:`Select.values`., :meth:`Select.get_mentionables` or :meth:`Select.fetch_mentionables`.
+
+    .. versionadded:: 2.0
+
+    Parameters
+    ------------
+    custom_id: :class:`str`
+        The ID of the select menu that gets received during an interaction.
+        If not given then one is generated for you.
+    placeholder: Optional[:class:`str`]
+        The placeholder text that is shown if nothing is selected, if any.
+    min_values: :class:`int`
+        The minimum number of items that must be chosen for this select menu.
+        Defaults to 1 and must be between 1 and 25.
+    max_values: :class:`int`
+        The maximum number of items that must be chosen for this select menu.
+        Defaults to 1 and must be between 1 and 25.
+    disabled: :class:`bool`
+        Whether the select is disabled or not.
+    row: Optional[:class:`int`]
+        The relative row this select menu belongs to. A Discord component can only have 5
+        rows. By default, items are arranged automatically into those 5 rows. If you'd
+        like to control the relative positioning of the row then passing an index is advised.
+        For example, row=1 will show up before row=2. Defaults to ``None``, which is automatic
+        ordering. The row number must be between 0 and 4 (i.e. zero indexed).
+    """
+    
+    def __init__(
+        self,
+        *,
+        custom_id: str = MISSING,
+        placeholder: Optional[str] = None,
+        min_values: int = 1,
+        max_values: int = 1,
+        disabled: bool = False,
+        row: Optional[int] = None,
+    ) -> None:
+        Item.__init__(self)
+        self._selected_values: List[str] = []
+        self._provided_custom_id = custom_id is not MISSING
+        custom_id = os.urandom(16).hex() if custom_id is MISSING else custom_id
+        self._underlying = SelectMenu._raw_construct(
+            custom_id=custom_id,
+            type=ComponentType.mentionable_select,
+            placeholder=placeholder,
+            min_values=min_values,
+            max_values=max_values,
+            disabled=disabled,
+        )
+        self.row = row
+        
+    @property
+    def options(self) -> List[SelectOption]:
+        """List[:class:`nextcord.SelectOption`]: A list of options that can be selected in this menu.
+        This will always be an empty list since mentionable selects cannot have any options."""
+        return []
+    
+    @property
+    def values(self) -> List[int]:
+        """List[:class:`int`]: A list of mentionable ids that have been selected by the user."""
+        return [int(id) for id in self._selected_values]
+        
+    def get_mentionables(self, guild: Guild) -> List[Union[Member, Role]]:
+        """A shortcut for getting all :class:`nextcord.Member`'s and :class:`nextcord.Role`'s of :attr:`.values`.
+        Mentionables that are not found in cache will not be returned.
+        To get all mentionables regardless of whether they are in cache or not, use :meth:`.fetch_mentionables`.
+        
+        Parameters
+        ----------
+        guild: :class:`nextcord.Guild`
+            The guild to get the mentionables from.
+            
+        Returns
+        -------
+        List[Union[:class:`nextcord.Member`, :class:`nextcord.Role`]]
+            A list of mentionables that have been selected by the user.
+        """
+        mentionables: List[Union[Member, Role]] = []
+        for id in self.values:
+            mentionable = guild.get_member(id) or guild.get_role(id)
+            if mentionable:
+                mentionables.append(mentionable)
+        return mentionables
+    
+    async def fetch_mentionables(self, guild: Guild) -> List[Union[Member, Role]]:
+        """A shortcut for fetching all :class:`nextcord.Member`'s and :class:`nextcord.Role`'s of :attr:`.values`.
+        Mentionables that are not found in cache will be fetched.
+        
+        Parameters
+        ----------
+        guild: :class:`nextcord.Guild`
+            The guild to get the mentionables from.
+            
+        Raises
+        ------
+        :exc:`.HTTPException`
+            Fetching the mentionables failed.
+        :exc:`.Forbidden`
+            You do not have the proper permissions to fetch the mentionables.
+            
+        Returns
+        -------
+        List[Union[:class:`nextcord.Member`, :class:`nextcord.Role`]]
+            A list of mentionables that have been selected by the user.
+        """
+        mentionables = self.get_mentionables(guild)
+        if len(mentionables) == len(self.values):
+            return mentionables
+        mentionables: List[Union[Member, Role]] = []
+        guild_roles = None
+        for id in self.values:
+            mentionable = guild.get_member(id) or guild.get_role(id)
+            if not mentionable:
+                if not guild_roles:
+                    guild_roles = await guild.fetch_roles()
+                for role in guild_roles:
+                    if role.id == id:
+                        mentionable = role
+                        break
+                if not mentionable:
+                    mentionable = await guild.fetch_member(id)
+            mentionables.append(mentionable)
+        return mentionables
+         
+        
+def mentionable_select(
+    *,
+    placeholder: Optional[str] = None,
+    custom_id: str = MISSING,
+    min_values: int = 1,
+    max_values: int = 1,
+    disabled: bool = False,
+    row: Optional[int] = None,
+) -> Callable[[ItemCallbackType], ItemCallbackType]:
+    """A decorator that attaches a mentionable select menu to a component.
+
+    The function being decorated should have three parameters, ``self`` representing
+    the :class:`nextcord.ui.View`, the :class:`nextcord.ui.MentionableSelect` being pressed and
+    the :class:`nextcord.Interaction` you receive.
+
+    In order to get the selected items that the user has chosen within the callback
+    use :attr:`Select.values`., :attr:`Select.get_mentionables` or :attr:`Select.fetch_mentionables`.
+
+    Parameters
+    ------------
+    placeholder: Optional[:class:`str`]
+        The placeholder text that is shown if nothing is selected, if any.
+    custom_id: :class:`str`
+        The ID of the select menu that gets received during an interaction.
+        It is recommended not to set this parameter to prevent conflicts.
+    row: Optional[:class:`int`]
+        The relative row this select menu belongs to. A Discord component can only have 5
+        rows. By default, items are arranged automatically into those 5 rows. If you'd
+        like to control the relative positioning of the row then passing an index is advised.
+        For example, row=1 will show up before row=2. Defaults to ``None``, which is automatic
+        ordering. The row number must be between 0 and 4 (i.e. zero indexed).
+    min_values: :class:`int`
+        The minimum number of items that must be chosen for this select menu.
+        Defaults to 1 and must be between 1 and 25.
+    max_values: :class:`int`
+        The maximum number of items that must be chosen for this select menu.
+        Defaults to 1 and must be between 1 and 25.
+    disabled: :class:`bool`
+        Whether the select is disabled or not. Defaults to ``False``.
+    """
+
+    def decorator(func: ItemCallbackType) -> ItemCallbackType:
+        if not asyncio.iscoroutinefunction(func):
+            raise TypeError("Select function must be a coroutine function")
+
+        func.__discord_ui_model_type__ = MentionableSelect
+        func.__discord_ui_model_kwargs__ = {
+            "placeholder": placeholder,
+            "custom_id": custom_id,
+            "row": row,
+            "min_values": min_values,
+            "max_values": max_values,
+            "disabled": disabled,
+        }
+        return func
+
+    return decorator
+        

--- a/nextcord/ui/role_select.py
+++ b/nextcord/ui/role_select.py
@@ -1,0 +1,225 @@
+"""
+The MIT License (MIT)
+
+Copyright (c) 2015-present Rapptz
+Copyright (c) 2021-present tag-epic
+
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of this software and associated documentation files (the "Software"),
+to deal in the Software without restriction, including without limitation
+the rights to use, copy, modify, merge, publish, distribute, sublicense,
+and/or sell copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+from typing import TYPE_CHECKING, Callable, List, Optional
+
+from .item import Item, ItemCallbackType
+from .select import Select
+
+from ..components import SelectMenu, SelectOption
+from ..enums import ComponentType
+from ..utils import MISSING
+
+if TYPE_CHECKING:
+    from ..guild import Guild
+    from ..role import Role
+
+__all__ = (
+    "RoleSelect",
+    "role_select"
+)
+
+class RoleSelect(Select):
+    
+    """Represents a UI role select menu.
+
+    This is usually represented as a drop down menu.
+
+    In order to get the selected items that the user has chosen, 
+    use :attr:`Select.values`., :meth:`Select.get_roles` or :meth:`Select.fetch_roles`.
+
+    .. versionadded:: 2.0
+
+    Parameters
+    ------------
+    custom_id: :class:`str`
+        The ID of the select menu that gets received during an interaction.
+        If not given then one is generated for you.
+    placeholder: Optional[:class:`str`]
+        The placeholder text that is shown if nothing is selected, if any.
+    min_values: :class:`int`
+        The minimum number of items that must be chosen for this select menu.
+        Defaults to 1 and must be between 1 and 25.
+    max_values: :class:`int`
+        The maximum number of items that must be chosen for this select menu.
+        Defaults to 1 and must be between 1 and 25.
+    disabled: :class:`bool`
+        Whether the select is disabled or not.
+    row: Optional[:class:`int`]
+        The relative row this select menu belongs to. A Discord component can only have 5
+        rows. By default, items are arranged automatically into those 5 rows. If you'd
+        like to control the relative positioning of the row then passing an index is advised.
+        For example, row=1 will show up before row=2. Defaults to ``None``, which is automatic
+        ordering. The row number must be between 0 and 4 (i.e. zero indexed).
+    """
+    
+    def __init__(
+        self,
+        *,
+        custom_id: str = MISSING,
+        placeholder: Optional[str] = None,
+        min_values: int = 1,
+        max_values: int = 1,
+        disabled: bool = False,
+        row: Optional[int] = None,
+    ) -> None:
+        Item.__init__(self)
+        self._selected_values: List[str] = []
+        self._provided_custom_id = custom_id is not MISSING
+        custom_id = os.urandom(16).hex() if custom_id is MISSING else custom_id
+        self._underlying = SelectMenu._raw_construct(
+            custom_id=custom_id,
+            type=ComponentType.role_select,
+            placeholder=placeholder,
+            min_values=min_values,
+            max_values=max_values,
+            disabled=disabled,
+        )
+        self.row = row
+        
+    @property
+    def options(self) -> List[SelectOption]:
+        """List[:class:`nextcord.SelectOption`]: A list of options that can be selected in this menu.
+        This will always be an empty list since role selects cannot have any options."""
+        return []
+    
+    @property
+    def values(self) -> List[int]:
+        """List[:class:`int`]: A list of role ids that have been selected by the user."""
+        return [int(id) for id in self._selected_values]
+        
+    def get_roles(self, guild: Guild) -> List[Role]:
+        """A shortcut for getting all :class:`nextcord.Role`'s of :attr:`.values`.
+        Roles that are not found in cache will not be returned.
+        To get all roles regardless of whether they are in cache or not, use :meth:`.fetch_roles`.
+        
+        Parameters
+        ----------
+        guild: :class:`nextcord.Guild`
+            The guild to get the roles from.
+            
+        Returns
+        -------
+        List[:class:`nextcord.Role`]
+            A list of roles that were found."""
+        roles: List[Role] = []
+        for id in self.values:
+            member = guild.get_role(id)
+            if member is not None:
+                roles.append(member)
+        return roles
+        
+    async def fetch_roles(self, guild: Guild) -> List[Role]:
+        """A shortcut for fetching all :class:`nextcord.Role`'s of :attr:`.values`.
+        Roles that are not found in cache will be fetched.
+        
+        Parameters
+        ----------
+        guild: :class:`nextcord.Guild`
+            The guild to fetch the roles from.
+            
+        Raises
+        ------
+        :exc:`.HTTPException`
+            Retrieving the roles failed.
+            
+        Returns
+        -------
+        List[:class:`nextcord.Role`]
+            A list of all roles that have been selected."""
+        roles: List[Role] = self.get_roles(guild)
+        if len(roles) == len(self.values):
+            return roles
+        guild_roles: List[Role] = await guild.fetch_roles()
+        for id in self.values:
+            for role in guild_roles:
+                if role.id == id:
+                    roles.append(role)
+                    break
+        return roles
+        
+        
+def role_select(
+    *,
+    placeholder: Optional[str] = None,
+    custom_id: str = MISSING,
+    min_values: int = 1,
+    max_values: int = 1,
+    disabled: bool = False,
+    row: Optional[int] = None,
+) -> Callable[[ItemCallbackType], ItemCallbackType]:
+    """A decorator that attaches a role select menu to a component.
+
+    The function being decorated should have three parameters, ``self`` representing
+    the :class:`nextcord.ui.View`, the :class:`nextcord.ui.RoleSelect` being pressed and
+    the :class:`nextcord.Interaction` you receive.
+
+    In order to get the selected items that the user has chosen within the callback
+    use :attr:`Select.values`., :attr:`Select.get_roles` or :attr:`Select.fetch_roles`.
+
+    Parameters
+    ------------
+    placeholder: Optional[:class:`str`]
+        The placeholder text that is shown if nothing is selected, if any.
+    custom_id: :class:`str`
+        The ID of the select menu that gets received during an interaction.
+        It is recommended not to set this parameter to prevent conflicts.
+    row: Optional[:class:`int`]
+        The relative row this select menu belongs to. A Discord component can only have 5
+        rows. By default, items are arranged automatically into those 5 rows. If you'd
+        like to control the relative positioning of the row then passing an index is advised.
+        For example, row=1 will show up before row=2. Defaults to ``None``, which is automatic
+        ordering. The row number must be between 0 and 4 (i.e. zero indexed).
+    min_values: :class:`int`
+        The minimum number of items that must be chosen for this select menu.
+        Defaults to 1 and must be between 1 and 25.
+    max_values: :class:`int`
+        The maximum number of items that must be chosen for this select menu.
+        Defaults to 1 and must be between 1 and 25.
+    disabled: :class:`bool`
+        Whether the select is disabled or not. Defaults to ``False``.
+    """
+
+    def decorator(func: ItemCallbackType) -> ItemCallbackType:
+        if not asyncio.iscoroutinefunction(func):
+            raise TypeError("Select function must be a coroutine function")
+
+        func.__discord_ui_model_type__ = RoleSelect
+        func.__discord_ui_model_kwargs__ = {
+            "placeholder": placeholder,
+            "custom_id": custom_id,
+            "row": row,
+            "min_values": min_values,
+            "max_values": max_values,
+            "disabled": disabled,
+        }
+        return func
+
+    return decorator
+        

--- a/nextcord/ui/user_select.py
+++ b/nextcord/ui/user_select.py
@@ -1,0 +1,224 @@
+"""
+The MIT License (MIT)
+
+Copyright (c) 2015-present Rapptz
+Copyright (c) 2021-present tag-epic
+
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of this software and associated documentation files (the "Software"),
+to deal in the Software without restriction, including without limitation
+the rights to use, copy, modify, merge, publish, distribute, sublicense,
+and/or sell copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+from typing import TYPE_CHECKING, Callable, List, Optional
+
+from .item import Item, ItemCallbackType
+from .select import Select
+
+from ..components import SelectMenu, SelectOption
+from ..enums import ComponentType
+from ..utils import MISSING
+
+if TYPE_CHECKING:
+    from ..guild import Guild
+    from ..member import Member
+
+__all__ = (
+    "UserSelect",
+    "user_select"
+)
+
+class UserSelect(Select):
+    
+    """Represents a UI user select menu.
+
+    This is usually represented as a drop down menu.
+
+    In order to get the selected items that the user has chosen, 
+    use :attr:`Select.values`., :meth:`Select.get_members` or :meth:`Select.fetch_members`.
+
+    .. versionadded:: 2.0
+
+    Parameters
+    ------------
+    custom_id: :class:`str`
+        The ID of the select menu that gets received during an interaction.
+        If not given then one is generated for you.
+    placeholder: Optional[:class:`str`]
+        The placeholder text that is shown if nothing is selected, if any.
+    min_values: :class:`int`
+        The minimum number of items that must be chosen for this select menu.
+        Defaults to 1 and must be between 1 and 25.
+    max_values: :class:`int`
+        The maximum number of items that must be chosen for this select menu.
+        Defaults to 1 and must be between 1 and 25.
+    disabled: :class:`bool`
+        Whether the select is disabled or not.
+    row: Optional[:class:`int`]
+        The relative row this select menu belongs to. A Discord component can only have 5
+        rows. By default, items are arranged automatically into those 5 rows. If you'd
+        like to control the relative positioning of the row then passing an index is advised.
+        For example, row=1 will show up before row=2. Defaults to ``None``, which is automatic
+        ordering. The row number must be between 0 and 4 (i.e. zero indexed).
+    """
+    
+    def __init__(
+        self,
+        *,
+        custom_id: str = MISSING,
+        placeholder: Optional[str] = None,
+        min_values: int = 1,
+        max_values: int = 1,
+        disabled: bool = False,
+        row: Optional[int] = None,
+    ) -> None:
+        Item.__init__(self)
+        self._selected_values: List[str] = []
+        self._provided_custom_id = custom_id is not MISSING
+        custom_id = os.urandom(16).hex() if custom_id is MISSING else custom_id
+        self._underlying = SelectMenu._raw_construct(
+            custom_id=custom_id,
+            type=ComponentType.user_select,
+            placeholder=placeholder,
+            min_values=min_values,
+            max_values=max_values,
+            disabled=disabled,
+        )
+        self.row = row
+        
+    @property
+    def options(self) -> List[SelectOption]:
+        """List[:class:`nextcord.SelectOption`]: A list of options that can be selected in this menu.
+        This will always be an empty list since user selects cannot have any options."""
+        return []
+    
+    @property
+    def values(self) -> List[int]:
+        """List[:class:`int`]: A list of user ids that have been selected by the user."""
+        return [int(id) for id in self._selected_values]
+        
+    def get_members(self, guild: Guild) -> List[Member]:
+        """A shortcut for getting all :class:`nextcord.Member`'s of :attr:`.values`.
+        Users that are not found in cache will not be returned.
+        To get all members regardless of whether they are in cache or not, use :meth:`.fetch_members`.
+        
+        Parameters
+        ----------
+        guild: :class:`nextcord.Guild`
+            The guild to get the members from.
+            
+        Returns
+        -------
+        List[:class:`nextcord.Member`]
+            A list of members that were found."""
+        members: List[Member] = []
+        for id in self.values:
+            member = guild.get_member(id)
+            if member is not None:
+                members.append(member)
+        return members
+        
+    async def fetch_members(self, guild: Guild) -> List[Member]:
+        """A shortcut for fetching all :class:`nextcord.Member`'s of :attr:`.values`.
+        Users that are not found in cache will be fetched.
+        
+        Parameters
+        ----------
+        guild: :class:`nextcord.Guild`
+            The guild to fetch the members from.
+            
+        Raises
+        ------
+        :exc:`.Forbidden`
+            You do not have access to the guild.
+        :exc:`.HTTPException`
+            Fetching a member failed.
+            
+        Returns
+        -------
+        List[:class:`nextcord.Member`]
+            A list of all members that have been selected."""
+        members: List[Member] = []
+        for id in self.values:
+            member = guild.get_member(id)
+            if member is None:
+                member = await guild.fetch_member(id)
+            members.append(member)
+        return members
+        
+        
+def user_select(
+    *,
+    placeholder: Optional[str] = None,
+    custom_id: str = MISSING,
+    min_values: int = 1,
+    max_values: int = 1,
+    disabled: bool = False,
+    row: Optional[int] = None,
+) -> Callable[[ItemCallbackType], ItemCallbackType]:
+    """A decorator that attaches a user select menu to a component.
+
+    The function being decorated should have three parameters, ``self`` representing
+    the :class:`nextcord.ui.View`, the :class:`nextcord.ui.UserSelect` being pressed and
+    the :class:`nextcord.Interaction` you receive.
+
+    In order to get the selected items that the user has chosen within the callback
+    use :attr:`Select.values`., :attr:`Select.get_members` or :attr:`Select.fetch_members`.
+
+    Parameters
+    ------------
+    placeholder: Optional[:class:`str`]
+        The placeholder text that is shown if nothing is selected, if any.
+    custom_id: :class:`str`
+        The ID of the select menu that gets received during an interaction.
+        It is recommended not to set this parameter to prevent conflicts.
+    row: Optional[:class:`int`]
+        The relative row this select menu belongs to. A Discord component can only have 5
+        rows. By default, items are arranged automatically into those 5 rows. If you'd
+        like to control the relative positioning of the row then passing an index is advised.
+        For example, row=1 will show up before row=2. Defaults to ``None``, which is automatic
+        ordering. The row number must be between 0 and 4 (i.e. zero indexed).
+    min_values: :class:`int`
+        The minimum number of items that must be chosen for this select menu.
+        Defaults to 1 and must be between 1 and 25.
+    max_values: :class:`int`
+        The maximum number of items that must be chosen for this select menu.
+        Defaults to 1 and must be between 1 and 25.
+    disabled: :class:`bool`
+        Whether the select is disabled or not. Defaults to ``False``.
+    """
+
+    def decorator(func: ItemCallbackType) -> ItemCallbackType:
+        if not asyncio.iscoroutinefunction(func):
+            raise TypeError("Select function must be a coroutine function")
+
+        func.__discord_ui_model_type__ = UserSelect
+        func.__discord_ui_model_kwargs__ = {
+            "placeholder": placeholder,
+            "custom_id": custom_id,
+            "row": row,
+            "min_values": min_values,
+            "max_values": max_values,
+            "disabled": disabled,
+        }
+        return func
+
+    return decorator
+        


### PR DESCRIPTION
## Summary

<!-- What is this pull request for? Does it fix any issues? -->

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
  - [x] I have updated the documentation to reflect the changes.
  - [x] I have run `task pyright` and fixed the relevant issues.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)

This PR adds the new select menu types (5, 6, 7, 8) that discord announced today. `.values` of these select menus return the ids that the user selected as an integer. Those selects have new helper functions to get or fetch these ids to make them objects.

Testing code: https://paste.nextcord.dev/?id=1665731303366171