### PR TITLE
docs(app-cmds): document SlashCommandMixin.children

### DIFF
--- a/nextcord/application_command.py
+++ b/nextcord/application_command.py
@@ -1653,12 +1653,25 @@ class SlashCommandMixin(CallbackMixin):
         _description: Optional[str]
         command_ids: Dict[Optional[int], int]
         qualified_name: str
+        _children: Dict[str, SlashApplicationSubcommand]
 
     def __init__(self, callback: Optional[Callable], parent_cog: Optional[ClientCog]):
         CallbackMixin.__init__(self, callback=callback, parent_cog=parent_cog)
         self.options: Dict[str, SlashCommandOption] = {}
-        self.children: Dict[str, SlashApplicationSubcommand] = {}
         self._parsed_docstring: Optional[Dict[str, Any]] = None
+
+    @property
+    def children(self) -> Dict[str, SlashApplicationSubcommand]:
+        """Returns the sub-commands and sub-command groups of the command.
+        
+        .. versionupdated:: 2.3
+
+            ``.children`` is now a read-only property.
+        """
+        if self._children is not None:
+            return self._children
+        else:
+            return {}
 
     @property
     def description(self) -> str:
@@ -2416,7 +2429,6 @@ class SlashApplicationSubcommand(SlashCommandMixin, AutocompleteCommandMixin, Ca
         self._inherit_hooks: bool = inherit_hooks
 
         self.options: Dict[str, SlashCommandOption] = {}
-        self.children: Dict[str, SlashApplicationSubcommand] = {}
 
     @property
     def qualified_name(self) -> str:

--- a/nextcord/application_command.py
+++ b/nextcord/application_command.py
@@ -2577,7 +2577,7 @@ class SlashApplicationSubcommand(SlashCommandMixin, AutocompleteCommandMixin, Ca
                 parent_cog=self.parent_cog,
                 inherit_hooks=inherit_hooks,
             )
-            self.children[
+            self._children[
                 ret.name
                 or (func.callback.__name__ if isinstance(func, CallbackWrapper) else func.__name__)
             ] = ret

--- a/nextcord/application_command.py
+++ b/nextcord/application_command.py
@@ -1664,7 +1664,7 @@ class SlashCommandMixin(CallbackMixin):
     @property
     def children(self) -> Dict[str, SlashApplicationSubcommand]:
         """Returns the sub-commands and sub-command groups of the command.
-        
+
         .. versionupdated:: 2.3
 
             ``.children`` is now a read-only property.

--- a/nextcord/application_command.py
+++ b/nextcord/application_command.py
@@ -1659,6 +1659,7 @@ class SlashCommandMixin(CallbackMixin):
         CallbackMixin.__init__(self, callback=callback, parent_cog=parent_cog)
         self.options: Dict[str, SlashCommandOption] = {}
         self._parsed_docstring: Optional[Dict[str, Any]] = None
+        self._children: Dict[str, SlashApplicationSubcommand] = {}
 
     @property
     def children(self) -> Dict[str, SlashApplicationSubcommand]:

--- a/nextcord/application_command.py
+++ b/nextcord/application_command.py
@@ -1669,10 +1669,7 @@ class SlashCommandMixin(CallbackMixin):
 
             ``.children`` is now a read-only property.
         """
-        if self._children is not None:
-            return self._children
-        else:
-            return {}
+        return self._children
 
     @property
     def description(self) -> str:


### PR DESCRIPTION
## Summary

Closes #798

This documents the `SlashCommandMixin.children` property.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
  - [x] I have updated the documentation to reflect the changes.
  - [ ] I have run `task pyright` and fixed the relevant issues.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
