### PR TITLE
feat(app-cmds): add support for 3.10 unions

### DIFF
--- a/nextcord/application_command.py
+++ b/nextcord/application_command.py
@@ -95,6 +95,7 @@ else:
 
 if sys.version_info[1] >= 10:
     from types import UnionType
+
     # UnionType is the annotation origin when doing Python 3.10 unions. Example: "str | None"
 else:
     UnionType = None

--- a/nextcord/application_command.py
+++ b/nextcord/application_command.py
@@ -27,6 +27,7 @@ from __future__ import annotations
 import asyncio
 import inspect
 import logging
+import sys
 import typing
 import warnings
 from inspect import Parameter, signature
@@ -91,6 +92,12 @@ if TYPE_CHECKING:
     _CustomTypingMetaBase = Any
 else:
     _CustomTypingMetaBase = object
+
+if sys.version_info[1] >= 10:
+    from types import UnionType
+    # UnionType is the annotation origin when doing Python 3.10 unions. Example: "str | None"
+else:
+    UnionType = None
 
 __all__ = (
     "CallbackWrapper",
@@ -1379,7 +1386,7 @@ class SlashCommandOption(BaseCommandOption, SlashOption, AutocompleteOptionMixin
 
             annotation_type = found_type
             annotation_choices = found_choices
-        elif typehint_origin in (Union, Optional, Annotated, None):
+        elif typehint_origin in (Union, Optional, Annotated, UnionType, None):
             # If the typehint base is Union, Optional, or not any grouping...
             found_type = MISSING
             found_channel_types: List[ChannelType] = []
@@ -3337,7 +3344,9 @@ def unpack_annotation(
         unpacked_type, unpacked_literal = unpack_annotation(located_annotation, annotated_list)
         type_ret.extend(unpacked_type)
         literal_ret.extend(unpacked_literal)
-    elif origin in (Union, Optional, Literal):
+    elif origin in (Union, UnionType, Optional, Literal):
+        # Note for someone refactoring this: UnionType (at this time) will be None on Python sub-3.10
+        # This doesn't matter for now since None is explicitly checked first, but may trip you up when modifying this.
         # for anno in typing.get_args(given_annotation):  # TODO: Once Python 3.10 is standard, use this.
         for anno in typing_extensions.get_args(given_annotation):
             unpacked_type, unpacked_literal = unpack_annotation(anno, annotated_list)

--- a/nextcord/application_command.py
+++ b/nextcord/application_command.py
@@ -93,7 +93,7 @@ if TYPE_CHECKING:
 else:
     _CustomTypingMetaBase = object
 
-if sys.version_info[1] >= 10:
+if sys.version_info >= (3, 10):
     from types import UnionType
 
     # UnionType is the annotation origin when doing Python 3.10 unions. Example: "str | None"


### PR DESCRIPTION
Signed-off-by: Alex Schoenhofen <alexanderschoenhofen@gmail.com>

## Summary

<!-- What is this pull request for? Does it fix any issues? -->

Adds PEP 604 support to application commands, allowing the Python 3.10 style of unions.
Example: `arg1: str | None`

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [X] If code changes were made then they have been tested.
  - [ ] I have updated the documentation to reflect the changes.
  - [ ] I have run `task pyright` and fixed the relevant issues.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
