### PR TITLE
docs(client): fix nextcord.new mistake

### DIFF
--- a/nextcord/client.py
+++ b/nextcord/client.py
@@ -1421,7 +1421,7 @@ class Client:
         Parameters
         ----------
         code: Union[:class:`.Template`, :class:`str`]
-            The Discord Template Code or URL (must be a nextcord.new URL).
+            The Discord Template Code or URL (must be a discord.new URL).
 
         Raises
         ------

--- a/nextcord/client.py
+++ b/nextcord/client.py
@@ -1416,7 +1416,7 @@ class Client:
     async def fetch_template(self, code: Union[Template, str]) -> Template:
         """|coro|
 
-        Gets a :class:`.Template` from a nextcord.new URL or code.
+        Gets a :class:`.Template` from a discord.new URL or code.
 
         Parameters
         ----------


### PR DESCRIPTION
## Summary

This fixes the `nextcord.new` mistake in `Client.fetch_template`. Assuming that the Search & Replace replaced that on the big rename.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
  - [ ] I have updated the documentation to reflect the changes.
  - [ ] I have run `task pyright` and fixed the relevant issues.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
