### PR TITLE
fix(app-cmds): Resolve error with integer conversion in slash commands

### DIFF
--- a/nextcord/application_command.py
+++ b/nextcord/application_command.py
@@ -1616,9 +1616,15 @@ class SlashCommandOption(BaseCommandOption, SlashOption, AutocompleteOptionMixin
 
             value = interaction.guild.get_role(int(value))
         elif self.type is ApplicationCommandOptionType.integer:
-            value = int(value) if value.isdigit() else None
+            try:
+                value = int(value)
+            except ValueError:
+                value = None
         elif self.type is ApplicationCommandOptionType.number:
-            value = float(value)
+            try:
+                value = float(value)
+            except ValueError:
+                value = None
         elif self.type is ApplicationCommandOptionType.attachment:
             try:
                 # this looks messy but is too much effort to handle


### PR DESCRIPTION
## Summary

Seems like the temporary fix in https://github.com/nextcord/nextcord/pull/835 (unreleased) caused `int` typehints to start throwing an error.

It seems like this occurs whether the numbers entered are positive or negative.

The code seems to previously be assuming the value is always a string and non-negative, when it is actually not necessarily either of those.

Traceback for issue resolved ([discord.com/channels/881118111967883295/1033104159584555189/1033104420935839884](https://discord.com/channels/881118111967883295/1033104159584555189/1033104420935839884))

```
Ignoring exception in on_interaction
Traceback (most recent call last):
  File "nextcord/client.py", line 502, in _run_event
    await coro(*args, **kwargs)
  File "nextcord/client.py", line 1948, in on_interaction
    await self.process_application_commands(interaction)
  File "nextcord/client.py", line 1968, in process_application_commands
    await app_cmd.call_from_interaction(interaction)
  File "nextcord/application_command.py", line 2317, in call_from_interaction
    await self.call(self._state, interaction)  # type: ignore
  File "nextcord/application_command.py", line 2691, in call
    await self.call_slash(state, interaction, option_data)
  File "nextcord/application_command.py", line 1742, in call_slash
    kwargs = await self.get_slash_kwargs(state, interaction, option_data)
  File "nextcord/application_command.py", line 1705, in get_slash_kwargs
    kwargs[self.options[arg_data["name"]].functional_name] = await self.options[
  File "nextcord/application_command.py", line 1619, in handle_value
    value = int(value) if value.isdigit() else None
AttributeError: 'int' object has no attribute 'isdigit'
```

Code for testing

```py
@bot.slash_command()
async def test(interaction: MyInteraction, integer: int, floating: float):
    await interaction.send(f"Your values are {integer} and {floating}")
```

![image](https://user-images.githubusercontent.com/20955511/197285939-22d07e6f-79e0-43d3-b986-e90596b26761.png)


## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
  - [x] I have updated the documentation to reflect the changes.
  - [x] I have run `task pyright` and fixed the relevant issues.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
