### PR TITLE
docs: Fix version directives in documentation

### DIFF
--- a/nextcord/application_command.py
+++ b/nextcord/application_command.py
@@ -1666,7 +1666,6 @@ class SlashCommandMixin(CallbackMixin):
         """Returns the sub-commands and sub-command groups of the command.
 
         .. versionchanged:: 2.3
-
             ``.children`` is now a read-only property.
         """
         return self._children

--- a/nextcord/application_command.py
+++ b/nextcord/application_command.py
@@ -1665,7 +1665,7 @@ class SlashCommandMixin(CallbackMixin):
     def children(self) -> Dict[str, SlashApplicationSubcommand]:
         """Returns the sub-commands and sub-command groups of the command.
 
-        .. versionupdated:: 2.3
+        .. versionchanged:: 2.3
 
             ``.children`` is now a read-only property.
         """

--- a/nextcord/guild.py
+++ b/nextcord/guild.py
@@ -2899,9 +2899,13 @@ class Guild(Hashable):
         delete_message_seconds: Optional[:class:`int`]
             The number of seconds worth of messages to delete from the user
             in the guild. The minimum is 0 and the maximum is 604800 (7 days).
+
+            .. versionadded:: 2.3
         delete_message_days: Optional[:class:`int`]
             The number of days worth of messages to delete from the user
             in the guild. The minimum is 0 and the maximum is 7.
+
+            .. deprecated:: 2.3
         reason: Optional[:class:`str`]
             The reason the user got banned.
 


### PR DESCRIPTION
## Summary

Fixes a docs "unknown directive" issue:

```rst
nextcord/nextcord/application_command.py:docstring of nextcord.SlashApplicationCommand.children:3:
WARNING: Unknown directive type "versionupdated".

.. versionupdated:: 2.3

    ``.children`` is now a read-only property.
```

Also added missing version directives to Guild.ban.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
  - [ ] I have updated the documentation to reflect the changes.
  - [ ] I have run `task pyright` and fixed the relevant issues.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
