### PR TITLE
docs: Fix single-backtick words to double-backtick or links

### DIFF
--- a/docs/ext/commands/commands.rst
+++ b/docs/ext/commands/commands.rst
@@ -760,7 +760,7 @@ given as a :class:`dict` rather than a :class:`list`.
 Error Handling
 --------------
 
-When our commands fail to parse we will, by default, receive a noisy error in ``stderr`` of our console that tells us
+When our commands fail to parse we will, by default, receive a noisy error in :data:`~sys.stderr` of our console that tells us
 that an error has happened and has been silently ignored.
 
 In order to handle our errors, we must use something called an error handler. There is a global error handler, called

--- a/docs/whats_new.rst
+++ b/docs/whats_new.rst
@@ -1127,7 +1127,7 @@ v0.14.1
 Bug fixes
 ~~~~~~~~~
 
-- Fix bug with `Reaction` not being visible at import.
+- Fix bug with ``Reaction`` not being visible at import.
     - This was also breaking the documentation.
 
 .. _v0p14p0:

--- a/nextcord/application_command.py
+++ b/nextcord/application_command.py
@@ -593,7 +593,7 @@ class CallbackMixin:
 
         Parameters
         ----------
-        callback: Optional[:class:`Callable`]
+        callback: Optional[:data:`~typing.Callable`]
             Callback to create options from and invoke. If provided, it must be a coroutine function.
         parent_cog: Optional[:class:`ClientCog`]
             Class that the callback resides on. Will be passed into the callback if provided.
@@ -714,7 +714,7 @@ class CallbackMixin:
 
         Parameters
         ----------
-        callback: Optional[Callable]
+        callback: Optional[:data:`~typing.Callable`]
             Callback to create options from. Must be a coroutine function.
         option_class: Optional[Type[:class:`BaseCommandOption`]]
             Class to create the options using. Should either be or subclass :class:`BaseCommandOption`. Defaults
@@ -970,7 +970,7 @@ class AutocompleteOptionMixin:
 
         Parameters
         ----------
-        autocomplete_callback: Optional[:class:`Callable`]
+        autocomplete_callback: Optional[:data:`~typing.Callable`]
             Callback to create options from and invoke. If provided, it must be a coroutine function.
         parent_cog: Optional[:class:`ClientCog`]
             Class that the callback resides on. Will be passed into the callback if provided.
@@ -1208,7 +1208,7 @@ class SlashOption(ApplicationCommandOption, _CustomTypingMetaBase):
     autocomplete: :class:`bool`
         If this parameter has an autocomplete function decorated for it. If unset, it will automatically be ``True``
         if an autocomplete function for it is found.
-    autocomplete_callback: Optional[:class:`Callable`]
+    autocomplete_callback: Optional[:data:`~typing.Callable`]
         The function that will be used to autocomplete this parameter. If not specified, it will be looked for
         using the :meth:`~SlashApplicationSubcommand.on_autocomplete` decorator.
     default: Any
@@ -1822,7 +1822,7 @@ class BaseApplicationCommand(CallbackMixin, CallbackWrapperMixin):
         description_localizations: Dict[Union[:class:`Locale`, :class:`str`], :class:`str`]
             Description(s) of the command for users of specific locales. The locale code should be the key, with the
             localized description as the value.
-        callback: Callable
+        callback: :data:`~typing.Callable`
             Callback to make the application command from, and to run when the application command is called.
         guild_ids: Iterable[:class:`int`]
             An iterable list/set/whatever of guild ID's that the application command should register to.
@@ -2633,7 +2633,7 @@ class SlashApplicationCommand(SlashCommandMixin, BaseApplicationCommand, Autocom
         description_localizations: Dict[Union[:class:`Locale`, :class:`str`], :class:`str`]
             Description(s) of the subcommand for users of specific locales. The locale code should be the key, with the
             localized description as the value.
-        callback: Callable
+        callback: :data:`~typing.Callable`
             Callback to make the application command from, and to run when the application command is called.
         guild_ids: Iterable[:class:`int`]
             An iterable list of guild ID's that the application command should register to.
@@ -2790,7 +2790,7 @@ class UserApplicationCommand(BaseApplicationCommand):
         name_localizations: Dict[Union[:class:`Locale`, :class:`str`], :class:`str`]
             Name(s) of the subcommand for users of specific locales. The locale code should be the key, with the
             localized name as the value.
-        callback: Callable
+        callback: :data:`~typing.Callable`
             Callback to run with the application command is called.
         guild_ids: Iterable[:class:`int`]
             An iterable list of guild ID's that the application command should register to.
@@ -2864,7 +2864,7 @@ class MessageApplicationCommand(BaseApplicationCommand):
         name_localizations: Dict[Union[:class:`Locale`, :class:`str`], :class:`str`]
             Name(s) of the subcommand for users of specific locales. The locale code should be the key, with the
             localized name as the value.
-        callback: Callable
+        callback: :data:`~typing.Callable`
             Callback to run with the application command is called.
         guild_ids: Iterable[:class:`int`]
             An iterable list of guild ID's that the application command should register to.

--- a/nextcord/application_command.py
+++ b/nextcord/application_command.py
@@ -593,7 +593,7 @@ class CallbackMixin:
 
         Parameters
         ----------
-        callback: Optional[Callable]
+        callback: Optional[:class:`Callable`]
             Callback to create options from and invoke. If provided, it must be a coroutine function.
         parent_cog: Optional[:class:`ClientCog`]
             Class that the callback resides on. Will be passed into the callback if provided.
@@ -709,7 +709,7 @@ class CallbackMixin:
         callback: Optional[Callable] = None,
         option_class: Optional[Type[BaseCommandOption]] = BaseCommandOption,
     ) -> None:
-        """Creates objects of type `option_class` with the parameters of the function, and stores them in
+        """Creates objects of type ``option_class`` with the parameters of the function, and stores them in
         the options attribute.
 
         Parameters
@@ -970,7 +970,7 @@ class AutocompleteOptionMixin:
 
         Parameters
         ----------
-        autocomplete_callback: `Callable`
+        autocomplete_callback: Optional[:class:`Callable`]
             Callback to create options from and invoke. If provided, it must be a coroutine function.
         parent_cog: Optional[:class:`ClientCog`]
             Class that the callback resides on. Will be passed into the callback if provided.
@@ -1183,11 +1183,11 @@ class SlashOption(ApplicationCommandOption, _CustomTypingMetaBase):
         A list of choices that a user must choose.
         If a :class:`dict` is given, the keys are what the users are able to see, the values are what is sent back
         to the bot.
-        Otherwise, it is treated as an `Iterable` where what the user sees and is sent back to the bot are the same.
+        Otherwise, it is treated as an :class:`~collections.abc.Iterable` where what the user sees and is sent back to the bot are the same.
     choice_localizations: Dict[:class:`str`, Dict[Union[:class:`Locale`, :class:`str`], :class:`str`]]
         A dictionary of choice display names as the keys, and dictionaries of locale: localized name as the values.
     channel_types: List[:class:`ChannelType`]
-        List of `ChannelType` enums, limiting the users choice to only those channel types. The parameter must be
+        List of :class:`ChannelType` enums, limiting the users choice to only those channel types. The parameter must be
         typed as :class:`GuildChannel` for this to function.
     min_value: Union[:class:`int`, :class:`float`]
         Minimum integer or floating point value the user is allowed to input. The parameter must be typed as an
@@ -1206,9 +1206,9 @@ class SlashOption(ApplicationCommandOption, _CustomTypingMetaBase):
 
         .. versionadded:: 2.1
     autocomplete: :class:`bool`
-        If this parameter has an autocomplete function decorated for it. If unset, it will automatically be `True`
+        If this parameter has an autocomplete function decorated for it. If unset, it will automatically be ``True``
         if an autocomplete function for it is found.
-    autocomplete_callback: Optional[:class:`Callable`]
+    autocomplete_callback: Optional[:class:`~typing.Callable`]
         The function that will be used to autocomplete this parameter. If not specified, it will be looked for
         using the :meth:`~SlashApplicationSubcommand.on_autocomplete` decorator.
     default: Any
@@ -2217,7 +2217,7 @@ class BaseApplicationCommand(CallbackMixin, CallbackWrapperMixin):
 
             Parameters
             ----------
-            inter_options: :class`dict`
+            inter_options: :class:`dict`
                 Command option data from the interaction.
             cmd_options: :class:`dict`
                 Command option data from the local command.
@@ -2952,8 +2952,8 @@ def slash_command(
         example will only allow Administrators to use the command. If set to 0, nobody will be able to use it by
         default. Server owners CAN override the permission requirements.
     force_global: :class:`bool`
-        If True, will force this command to register as a global command, even if `guild_ids` is set. Will still
-        register to guilds. Has no effect if `guild_ids` are never set or added to.
+        If True, will force this command to register as a global command, even if ``guild_ids`` is set. Will still
+        register to guilds. Has no effect if ``guild_ids`` are never set or added to.
     """
 
     def decorator(func: Callable) -> SlashApplicationCommand:
@@ -3005,8 +3005,8 @@ def message_command(
         example will only allow Administrators to use the command. If set to 0, nobody will be able to use it by
         default. Server owners CAN override the permission requirements.
     force_global: :class:`bool`
-        If True, will force this command to register as a global command, even if `guild_ids` is set. Will still
-        register to guilds. Has no effect if `guild_ids` are never set or added to.
+        If True, will force this command to register as a global command, even if ``guild_ids`` is set. Will still
+        register to guilds. Has no effect if ``guild_ids`` are never set or added to.
     """
 
     def decorator(func: Callable) -> MessageApplicationCommand:
@@ -3056,8 +3056,8 @@ def user_command(
         example will only allow Administrators to use the command. If set to 0, nobody will be able to use it by
         default. Server owners CAN override the permission requirements.
     force_global: :class:`bool`
-        If True, will force this command to register as a global command, even if `guild_ids` is set. Will still
-        register to guilds. Has no effect if `guild_ids` are never set or added to.
+        If True, will force this command to register as a global command, even if ``guild_ids`` is set. Will still
+        register to guilds. Has no effect if ``guild_ids`` are never set or added to.
     """
 
     def decorator(func: Callable) -> UserApplicationCommand:

--- a/nextcord/application_command.py
+++ b/nextcord/application_command.py
@@ -1208,7 +1208,7 @@ class SlashOption(ApplicationCommandOption, _CustomTypingMetaBase):
     autocomplete: :class:`bool`
         If this parameter has an autocomplete function decorated for it. If unset, it will automatically be ``True``
         if an autocomplete function for it is found.
-    autocomplete_callback: Optional[:class:`~typing.Callable`]
+    autocomplete_callback: Optional[:class:`Callable`]
         The function that will be used to autocomplete this parameter. If not specified, it will be looked for
         using the :meth:`~SlashApplicationSubcommand.on_autocomplete` decorator.
     default: Any

--- a/nextcord/auto_moderation.py
+++ b/nextcord/auto_moderation.py
@@ -162,7 +162,7 @@ class AutoModerationActionMetadata:
 
         .. note::
 
-            The maximum value that can be used is `2419200` seconds (4 weeks)
+            The maximum value that can be used is ``2419200`` seconds (4 weeks)
     """
 
     __slots__ = ("channel_id", "duration_seconds")

--- a/nextcord/channel.py
+++ b/nextcord/channel.py
@@ -141,7 +141,7 @@ class TextChannel(abc.Messageable, abc.GuildChannel, Hashable, PinsMixin):
         *not* point to an existing or valid message.
     slowmode_delay: :class:`int`
         The number of seconds a member must wait between sending messages
-        in this channel. A value of `0` denotes that it is disabled.
+        in this channel. A value of ``0`` denotes that it is disabled.
         Bots and users with :attr:`~Permissions.manage_channels` or
         :attr:`~Permissions.manage_messages` bypass slowmode.
     flags: :class:`ChannelFlags`
@@ -333,7 +333,7 @@ class TextChannel(abc.Messageable, abc.GuildChannel, Hashable, PinsMixin):
             category.
         slowmode_delay: :class:`int`
             Specifies the slowmode rate limit for user in this channel, in seconds.
-            A value of `0` disables slowmode. The maximum value possible is `21600`.
+            A value of ``0`` disables slowmode. The maximum value possible is ``21600``.
         type: :class:`ChannelType`
             Change the type of this text channel. Currently, only conversion between
             :attr:`ChannelType.text` and :attr:`ChannelType.news` is supported. This
@@ -1021,7 +1021,7 @@ class ForumChannel(abc.GuildChannel, Hashable):
             category.
         slowmode_delay: :class:`int`
             Specifies the slowmode rate limit for user in this channel, in seconds.
-            A value of `0` disables slowmode. The maximum value possible is `21600`.
+            A value of ``0`` disables slowmode. The maximum value possible is ``21600``.
         reason: Optional[:class:`str`]
             The reason for editing this channel. Shows up on the audit log.
         overwrites: :class:`Mapping`

--- a/nextcord/client.py
+++ b/nextcord/client.py
@@ -1416,12 +1416,12 @@ class Client:
     async def fetch_template(self, code: Union[Template, str]) -> Template:
         """|coro|
 
-        Gets a :class:`.Template` from a nextcord.new URL or code.
+        Gets a :class:`.Template` from a discord.new URL or code.
 
         Parameters
         ----------
         code: Union[:class:`.Template`, :class:`str`]
-            The Discord Template Code or URL (must be a nextcord.new URL).
+            The Discord Template Code or URL (must be a discord.new URL).
 
         Raises
         ------

--- a/nextcord/client.py
+++ b/nextcord/client.py
@@ -564,7 +564,7 @@ class Client:
 
         The default error handler provided by the client.
 
-        By default this prints to :data:`sys.stderr` however it could be
+        By default this prints to :data:`~sys.stderr` however it could be
         overridden to have a different implementation.
         Check :func:`~nextcord.on_error` for more details.
         """
@@ -578,7 +578,7 @@ class Client:
 
         The default application command error handler provided by the bot.
 
-        By default this prints to :data:`sys.stderr` however it could be
+        By default this prints to :data:`~sys.stderr` however it could be
         overridden to have a different implementation.
 
         This only fires if you do not specify any listeners for command error.
@@ -2190,27 +2190,27 @@ class Client:
     ) -> None:
         """|coro|
         Syncs the locally added application commands with the Guild corresponding to the given ID, or syncs
-        global commands if the guild_id is `None`.
+        global commands if the guild_id is ``None``.
 
         Parameters
         ----------
         data: Optional[List[:class:`dict`]]
             Data to use when comparing local application commands to what Discord has. Should be a list of application
-            command data from Discord. If left as `None`, it will be fetched if needed. Defaults to `None`.
+            command data from Discord. If left as ``None``, it will be fetched if needed. Defaults to ``None``.
         guild_id: Optional[:class:`int`]
-            ID of the guild to sync application commands with. If set to `None`, global commands will be synced instead.
-            Defaults to `None`.
+            ID of the guild to sync application commands with. If set to ``None``, global commands will be synced instead.
+            Defaults to ``None``.
         associate_known: :class:`bool`
             If local commands that match a command already on Discord should be associated with each other.
-            Defaults to `True`
+            Defaults to ``True``.
         delete_unknown: :class:`bool`
-            If commands on Discord that don't match a local command should be deleted. Defaults to `True`
+            If commands on Discord that don't match a local command should be deleted. Defaults to ``True``.
         update_known: :class:`bool`
             If commands on Discord have a basic match with a local command, but don't fully match, should be updated.
-            Defaults to `True`
+            Defaults to ``True``.
         register_new: :class:`bool`
             If a local command that doesn't have a basic match on Discord should be added to Discord.
-            Defaults to `True`
+            Defaults to ``True``.
         """
         # All this does is passthrough to connection state. All documentation updates should also be updated
         # there, and vice versa.
@@ -2241,18 +2241,18 @@ class Client:
         Parameters
         ----------
         data: Optional[List[:class:`dict`]]
-            Payload from `HTTPClient.get_guild_commands` or `HTTPClient.get_global_commands` to deploy with. If None,
+            Payload from ``HTTPClient.get_guild_commands`` or ``HTTPClient.get_global_commands`` to deploy with. If None,
             the payload will be retrieved from Discord.
         guild_id: Optional[:class:`int`]
-            Guild ID to deploy application commands to. If `None`, global commands are deployed to.
+            Guild ID to deploy application commands to. If ``None``, global commands are deployed to.
         associate_known: :class:`bool`
             If True, commands on Discord that pass a signature check and a deep check will be associated with locally
             added ApplicationCommand objects.
         delete_unknown: :class:`bool`
-            If `True`, commands on Discord that fail a signature check will be removed. If `update_known` is False,
+            If ``True``, commands on Discord that fail a signature check will be removed. If ``update_known`` is ``False``,
             commands that pass the signature check but fail the deep check will also be removed.
         update_known: :class:`bool`
-            If `True`, commands on Discord that pass a signature check but fail the deep check will be updated.
+            If ``True``, commands on Discord that pass a signature check but fail the deep check will be updated.
         """
         # All this does is passthrough to connection state. All documentation updates should also be updated
         # there, and vice versa.
@@ -2333,10 +2333,10 @@ class Client:
         ----------
         data: Optional[List[:class:`dict`]]
             Data to use when comparing local application commands to what Discord has. Should be a list of application
-            command data from Discord. If left as `None`, it will be fetched if needed. Defaults to `None`
+            command data from Discord. If left as ``None``, it will be fetched if needed. Defaults to ``None``
         guild_id: Optional[:class:`int`]
-            ID of the guild to sync application commands with. If set to `None`, global commands will be synced instead.
-            Defaults to `None`.
+            ID of the guild to sync application commands with. If set to ``None``, global commands will be synced instead.
+            Defaults to ``None``.
         """
         # All this does is passthrough to connection state. All documentation updates should also be updated
         # there, and vice versa.
@@ -2354,8 +2354,8 @@ class Client:
         commands: :class:`BaseApplicationCommand`
             Application command to register. Multiple args are accepted.
         guild_id: Optional[:class:`int`]
-            ID of the guild to register the application commands to. If set to `None`, the commands will be registered
-            as global commands instead. Defaults to `None`.
+            ID of the guild to register the application commands to. If set to ``None``, the commands will be registered
+            as global commands instead. Defaults to ``None``.
         """
         for command in commands:
             await self._connection.register_application_command(command, guild_id=guild_id)
@@ -2372,8 +2372,8 @@ class Client:
         commands: :class:`BaseApplicationCommand`
             Application command to delete. Multiple args are accepted.
         guild_id: Optional[:class:`int`]
-            ID of the guild to delete the application commands from. If set to `None`, the commands will be deleted
-            from global commands instead. Defaults to `None`.
+            ID of the guild to delete the application commands from. If set to ``None``, the commands will be deleted
+            from global commands instead. Defaults to ``None``.
         """
         for command in commands:
             await self._connection.delete_application_command(command, guild_id=guild_id)
@@ -2531,8 +2531,8 @@ class Client:
             example will only allow Administrators to use the command. If set to 0, nobody will be able to use it by
             default. Server owners CAN override the permission requirements.
         force_global: :class:`bool`
-            If True, will force this command to register as a global command, even if `guild_ids` is set. Will still
-            register to guilds. Has no effect if `guild_ids` are never set or added to.
+            If True, will force this command to register as a global command, even if ``guild_ids`` is set. Will still
+            register to guilds. Has no effect if ``guild_ids`` are never set or added to.
         """
 
         def decorator(func: Callable):
@@ -2578,8 +2578,8 @@ class Client:
             example will only allow Administrators to use the command. If set to 0, nobody will be able to use it by
             default. Server owners CAN override the permission requirements.
         force_global: :class:`bool`
-            If True, will force this command to register as a global command, even if `guild_ids` is set. Will still
-            register to guilds. Has no effect if `guild_ids` are never set or added to.
+            If True, will force this command to register as a global command, even if ``guild_ids`` is set. Will still
+            register to guilds. Has no effect if ``guild_ids`` are never set or added to.
         """
 
         def decorator(func: Callable):
@@ -2633,8 +2633,8 @@ class Client:
             example will only allow Administrators to use the command. If set to 0, nobody will be able to use it by
             default. Server owners CAN override the permission requirements.
         force_global: :class:`bool`
-            If True, will force this command to register as a global command, even if `guild_ids` is set. Will still
-            register to guilds. Has no effect if `guild_ids` are never set or added to.
+            If True, will force this command to register as a global command, even if ``guild_ids`` is set. Will still
+            register to guilds. Has no effect if ``guild_ids`` are never set or added to.
         """
 
         def decorator(func: Callable):

--- a/nextcord/embeds.py
+++ b/nextcord/embeds.py
@@ -114,7 +114,7 @@ class Embed:
 
     .. versionchanged:: 2.2
         ``Embed.Empty`` is now an alias for ``None`` for a non-breaking change, every field uses ``None``
-            and is typed as `Optional[]` over ``Embed.Empty``.
+            and is typed as ``Optional[...]`` over ``Embed.Empty``.
             This also means that you can no longer use ``len()`` on an empty field.
 
     Attributes

--- a/nextcord/ext/application_checks/core.py
+++ b/nextcord/ext/application_checks/core.py
@@ -316,7 +316,7 @@ def has_role(item: Union[int, str]) -> AC:
 def has_any_role(*items: Union[int, str]) -> AC:
     r"""A :func:`.check` that is added that checks if the member invoking the
     command has **any** of the roles specified. This means that if they have
-    one out of the three roles specified, then this check will return `True`.
+    one out of the three roles specified, then this check will return ``True``.
 
     Similar to :func:`.has_role`\, the names or IDs passed in must be exact.
 

--- a/nextcord/ext/commands/bot.py
+++ b/nextcord/ext/commands/bot.py
@@ -265,7 +265,7 @@ class BotBase(GroupMixin):
 
         The default command error handler provided by the bot.
 
-        By default this prints to :data:`sys.stderr` however it could be
+        By default this prints to :data:`~sys.stderr` however it could be
         overridden to have a different implementation.
 
         This only fires if you do not specify any listeners for command error.
@@ -1004,7 +1004,7 @@ class BotBase(GroupMixin):
 
         .. note::
 
-            By default, any exceptions found while loading will not be raised but will be printed to console (standard error/`stderr`).
+            By default, any exceptions found while loading will not be raised but will be printed to console (standard error/:data:`~sys.stderr`).
 
         .. versionadded:: 2.1
 
@@ -1158,7 +1158,7 @@ class BotBase(GroupMixin):
 
         .. note::
 
-            By default, any exceptions found while loading will not be raised but will be printed to console (standard error/`stderr`).
+            By default, any exceptions found while loading will not be raised but will be printed to console (standard error/:data:`~sys.stderr`).
 
         .. versionadded:: 2.1
 

--- a/nextcord/ext/commands/converter.py
+++ b/nextcord/ext/commands/converter.py
@@ -153,7 +153,7 @@ class IDConverter(Converter[T_co]):
 class ObjectConverter(IDConverter[nextcord.Object]):
     """Converts to a :class:`~nextcord.Object`.
 
-    The argument must follow the valid ID or mention formats (e.g. `<@80088516616269824>`).
+    The argument must follow the valid ID or mention formats (e.g. ``<@80088516616269824>``).
 
     .. versionadded:: 2.0
 

--- a/nextcord/ext/commands/core.py
+++ b/nextcord/ext/commands/core.py
@@ -1933,7 +1933,7 @@ def has_role(item: Union[int, str]) -> Callable[[T], T]:
 def has_any_role(*items: Union[int, str]) -> Callable[[T], T]:
     r"""A :func:`.check` that is added that checks if the member invoking the
     command has **any** of the roles specified. This means that if they have
-    one out of the three roles specified, then this check will return `True`.
+    one out of the three roles specified, then this check will return ``True``.
 
     Similar to :func:`.has_role`\, the names or IDs passed in must be exact.
 

--- a/nextcord/ext/tasks/__init__.py
+++ b/nextcord/ext/tasks/__init__.py
@@ -520,7 +520,7 @@ class Loop(Generic[LF]):
 
         The coroutine must take only one argument the exception raised (except ``self`` in a class context).
 
-        By default this prints to :data:`sys.stderr` however it could be
+        By default this prints to :data:`~sys.stderr` however it could be
         overridden to have a different implementation.
 
         .. versionadded:: 1.4

--- a/nextcord/guild.py
+++ b/nextcord/guild.py
@@ -1179,7 +1179,7 @@ class Guild(Hashable):
             The new channel's topic.
         slowmode_delay: :class:`int`
             Specifies the slowmode rate limit for user in this channel, in seconds.
-            The maximum value possible is `21600`.
+            The maximum value possible is ``21600``.
         nsfw: :class:`bool`
             To mark the channel as NSFW or not.
         reason: Optional[:class:`str`]
@@ -1578,10 +1578,10 @@ class Guild(Hashable):
         to edit the guild.
 
         .. versionchanged:: 1.4
-            The `rules_channel` and `public_updates_channel` keyword-only parameters were added.
+            The ``rules_channel`` and ``public_updates_channel`` keyword-only parameters were added.
 
         .. versionchanged:: 2.0
-            The `discovery_splash` and `community` keyword-only parameters were added.
+            The ``discovery_splash`` and ``community`` keyword-only parameters were added.
 
         .. versionchanged:: 2.0
             The newly updated guild is returned.
@@ -3490,18 +3490,18 @@ class Guild(Hashable):
         ----------
         data: Optional[List[:class:`dict`]]
             Data to use when comparing local application commands to what Discord has. Should be a list of application
-            command data from Discord. If left as `None`, it will be fetched if needed. Defaults to `None`.
+            command data from Discord. If left as ``None``, it will be fetched if needed. Defaults to ``None``.
         associate_known: :class:`bool`
             If local commands that match a command already on Discord should be associated with each other.
-            Defaults to `True`
+            Defaults to ``True``.
         delete_unknown: :class:`bool`
-            If commands on Discord that don't match a local command should be deleted. Defaults to `True`
+            If commands on Discord that don't match a local command should be deleted. Defaults to ``True``.
         update_known: :class:`bool`
             If commands on Discord have a basic match with a local command, but don't fully match, should be updated.
-            Defaults to `True`
+            Defaults to ``True``.
         register_new: :class:`bool`
             If a local command that doesn't have a basic match on Discord should be added to Discord.
-            Defaults to `True`
+            Defaults to ``True``.
         """
         # All this does is passthrough to connection state. All documentation updates should also be updated
         # there, and vice versa.

--- a/nextcord/invite.py
+++ b/nextcord/invite.py
@@ -244,25 +244,25 @@ class Invite(Hashable):
 
     The following table illustrates what methods will obtain the attributes:
 
-    +------------------------------------+------------------------------------------------------------+
-    |             Attribute              |                          Method                            |
-    +====================================+============================================================+
-    | :attr:`max_age`                    | :meth:`abc.GuildChannel.invites`\, :meth:`Guild.invites`   |
-    +------------------------------------+------------------------------------------------------------+
-    | :attr:`max_uses`                   | :meth:`abc.GuildChannel.invites`\, :meth:`Guild.invites`   |
-    +------------------------------------+------------------------------------------------------------+
-    | :attr:`created_at`                 | :meth:`abc.GuildChannel.invites`\, :meth:`Guild.invites`   |
-    +------------------------------------+------------------------------------------------------------+
-    | :attr:`temporary`                  | :meth:`abc.GuildChannel.invites`\, :meth:`Guild.invites`   |
-    +------------------------------------+------------------------------------------------------------+
-    | :attr:`uses`                       | :meth:`abc.GuildChannel.invites`\, :meth:`Guild.invites`   |
-    +------------------------------------+------------------------------------------------------------+
-    | :attr:`approximate_member_count`   | :meth:`Client.fetch_invite` with `with_counts` enabled     |
-    +------------------------------------+------------------------------------------------------------+
-    | :attr:`approximate_presence_count` | :meth:`Client.fetch_invite` with `with_counts` enabled     |
-    +------------------------------------+------------------------------------------------------------+
-    | :attr:`expires_at`                 | :meth:`Client.fetch_invite` with `with_expiration` enabled |
-    +------------------------------------+------------------------------------------------------------+
+    +------------------------------------+--------------------------------------------------------------+
+    |             Attribute              |                          Method                              |
+    +====================================+==============================================================+
+    | :attr:`max_age`                    | :meth:`abc.GuildChannel.invites`\, :meth:`Guild.invites`     |
+    +------------------------------------+--------------------------------------------------------------+
+    | :attr:`max_uses`                   | :meth:`abc.GuildChannel.invites`\, :meth:`Guild.invites`     |
+    +------------------------------------+--------------------------------------------------------------+
+    | :attr:`created_at`                 | :meth:`abc.GuildChannel.invites`\, :meth:`Guild.invites`     |
+    +------------------------------------+--------------------------------------------------------------+
+    | :attr:`temporary`                  | :meth:`abc.GuildChannel.invites`\, :meth:`Guild.invites`     |
+    +------------------------------------+--------------------------------------------------------------+
+    | :attr:`uses`                       | :meth:`abc.GuildChannel.invites`\, :meth:`Guild.invites`     |
+    +------------------------------------+--------------------------------------------------------------+
+    | :attr:`approximate_member_count`   | :meth:`Client.fetch_invite` with ``with_counts`` enabled     |
+    +------------------------------------+--------------------------------------------------------------+
+    | :attr:`approximate_presence_count` | :meth:`Client.fetch_invite` with ``with_counts`` enabled     |
+    +------------------------------------+--------------------------------------------------------------+
+    | :attr:`expires_at`                 | :meth:`Client.fetch_invite` with ``with_expiration`` enabled |
+    +------------------------------------+--------------------------------------------------------------+
 
     If it's not in the table above then it is available by all methods.
 
@@ -296,7 +296,7 @@ class Invite(Hashable):
         This includes idle, dnd, online, and invisible members. Offline members are excluded.
     expires_at: Optional[:class:`datetime.datetime`]
         The expiration date of the invite. If the value is ``None`` when received through
-        `Client.fetch_invite` with `with_expiration` enabled, the invite will never expire.
+        :meth:`Client.fetch_invite` with ``with_expiration`` enabled, the invite will never expire.
 
         .. versionadded:: 2.0
 

--- a/nextcord/iterators.py
+++ b/nextcord/iterators.py
@@ -243,7 +243,7 @@ class HistoryIterator(_AsyncIterator["Message"]):
     """Iterator for receiving a channel's message history.
 
     The messages endpoint has two behaviours we care about here:
-    If ``before`` is specified, the messages endpoint returns the `limit`
+    If ``before`` is specified, the messages endpoint returns the ``limit``
     newest messages before ``before``, sorted with newest first. For filling over
     100 messages, update the ``before`` parameter to the oldest message received.
     Messages will be returned in order by time.
@@ -270,7 +270,7 @@ class HistoryIterator(_AsyncIterator["Message"]):
         limit is an even number, this will return at most limit+1 messages.
     oldest_first: Optional[:class:`bool`]
         If set to ``True``, return messages in oldest->newest order. Defaults to
-        ``True`` if `after` is specified, otherwise ``False``.
+        ``True`` if ``after`` is specified, otherwise ``False``.
     """
 
     def __init__(self, messageable, limit, before=None, after=None, around=None, oldest_first=None):
@@ -614,7 +614,7 @@ class GuildIterator(_AsyncIterator["Guild"]):
     newest guilds before ``before``, sorted with newest first. For filling over
     100 guilds, update the ``before`` parameter to the oldest guild received.
     Guilds will be returned in order by time.
-    If `after` is specified, it returns the ``limit`` oldest guilds after ``after``,
+    If ``after`` is specified, it returns the ``limit`` oldest guilds after ``after``,
     sorted with newest first. For filling over 100 guilds, update the ``after``
     parameter to the newest guild received, If guilds are not reversed, they
     will be out of order (99-0, 199-100, so on)

--- a/nextcord/raw_models.py
+++ b/nextcord/raw_models.py
@@ -175,7 +175,7 @@ class RawReactionActionEvent(_RawReprMixin):
     emoji: :class:`PartialEmoji`
         The custom or unicode emoji being used.
     member: Optional[:class:`Member`]
-        The member who added the reaction. Only available if `event_type` is `REACTION_ADD` and the reaction is inside a guild.
+        The member who added the reaction. Only available if ``event_type`` is ``REACTION_ADD`` and the reaction is inside a guild.
 
         .. versionadded:: 1.3
 

--- a/nextcord/state.py
+++ b/nextcord/state.py
@@ -609,7 +609,7 @@ class ConnectionState:
         command: :class:`BaseApplicationCommand`
             The command to add/update the state with.
         overwrite: :class:`bool`
-            If the library will let you add a command that overlaps with an existing command. Default `False`
+            If the library will let you add a command that overlaps with an existing command. Default ``False``.
         use_rollout: :class:`bool`
             If the command should be added to the state with its rollout guild IDs.
         pre_remove: :class:`bool`
@@ -708,7 +708,7 @@ class ConnectionState:
             If local commands that match a command already on Discord should be associated with each other.
             Defaults to ``True``
         delete_unknown: :class:`bool`
-            If commands on Discord that don't match a local command should be deleted. Defaults to `True`
+            If commands on Discord that don't match a local command should be deleted. Defaults to ``True``.
         update_known: :class:`bool`
             If commands on Discord have a basic match with a local command, but don't fully match, should be updated.
             Defaults to ``True``
@@ -780,27 +780,27 @@ class ConnectionState:
     ) -> None:
         """|coro|
         Syncs the locally added application commands with the Guild corresponding to the given ID, or syncs
-        global commands if the guild_id is `None`.
+        global commands if the guild_id is ``None``.
 
         Parameters
         ----------
         data: Optional[List[:class:`dict`]]
             Data to use when comparing local application commands to what Discord has. Should be a list of application
-            command data from Discord. If left as `None`, it will be fetched if needed. Defaults to `None`.
+            command data from Discord. If left as ``None``, it will be fetched if needed. Defaults to ``None``.
         guild_id: Optional[:class:`int`]
-            ID of the guild to sync application commands with. If set to `None`, global commands will be synced instead.
-            Defaults to `None`.
+            ID of the guild to sync application commands with. If set to ``None``, global commands will be synced instead.
+            Defaults to ``None``.
         associate_known: :class:`bool`
             If local commands that match a command already on Discord should be associated with each other.
-            Defaults to `True`
+            Defaults to ``True``.
         delete_unknown: :class:`bool`
-            If commands on Discord that don't match a local command should be deleted. Defaults to `True`
+            If commands on Discord that don't match a local command should be deleted. Defaults to ``True``.
         update_known: :class:`bool`
             If commands on Discord have a basic match with a local command, but don't fully match, should be updated.
-            Defaults to `True`
+            Defaults to ``True``.
         register_new: :class:`bool`
             If a local command that doesn't have a basic match on Discord should be added to Discord.
-            Defaults to `True`
+            Defaults to ``True``.
 
         """
         _log.debug("Syncing commands to %s", guild_id)
@@ -843,18 +843,18 @@ class ConnectionState:
         Parameters
         ----------
         data: Optional[List[:class:`dict]]
-            Payload from `HTTPClient.get_guild_commands` or `HTTPClient.get_global_commands` to deploy with. If None,
+            Payload from ``HTTPClient.get_guild_commands`` or ``HTTPClient.get_global_commands`` to deploy with. If None,
             the payload will be retrieved from Discord.
         guild_id: Optional[:class:`int`]
-            Guild ID to deploy application commands to. If `None`, global commands are deployed to.
+            Guild ID to deploy application commands to. If ``None``, global commands are deployed to.
         associate_known: :class:`bool`
             If True, commands on Discord that pass a signature check and a deep check will be associated with locally
             added ApplicationCommand objects.
         delete_unknown: :class:`bool`
-            If `True`, commands on Discord that fail a signature check will be removed. If `update_known` is False,
+            If ``True``, commands on Discord that fail a signature check will be removed. If ``update_known`` is False,
             commands that pass the signature check but fail the deep check will also be removed.
         update_known: :class:`bool`
-            If `True`, commands on Discord that pass a signature check but fail the deep check will be updated.
+            If ``True``, commands on Discord that pass a signature check but fail the deep check will be updated.
         """
         if not associate_known and not delete_unknown and not update_known:
             # If everything is disabled, there is no point in doing anything.
@@ -998,10 +998,10 @@ class ConnectionState:
         ----------
         data: Optional[List[:class:`dict`]]
             Data to use when comparing local application commands to what Discord has. Should be a list of application
-            command data from Discord. If left as `None`, it will be fetched if needed. Defaults to `None`
+            command data from Discord. If left as ``None``, it will be fetched if needed. Defaults to ``None``
         guild_id: Optional[:class:`int`]
-            ID of the guild to sync application commands with. If set to `None`, global commands will be synced instead.
-            Defaults to `None`.
+            ID of the guild to sync application commands with. If set to ``None``, global commands will be synced instead.
+            Defaults to ``None``.
         """
         if not data:
             if self.application_id is None:
@@ -1042,8 +1042,8 @@ class ConnectionState:
         command: :class:`BaseApplicationCommand`
             Application command to register.
         guild_id: Optional[:class:`int`]
-            ID of the guild to register the application commands to. If set to `None`, the commands will be registered
-            as global commands instead. Defaults to `None`.
+            ID of the guild to register the application commands to. If set to ``None``, the commands will be registered
+            as global commands instead. Defaults to ``None``.
         """
         payload: EditApplicationCommand = command.get_payload(guild_id)  # type: ignore
         _log.info(
@@ -1081,7 +1081,7 @@ class ConnectionState:
         command: :class:`ApplicationCommand`
             Application command to delete.
         guild_id: Optional[:class:`int`]
-            Guild ID to delete the application commands from. If `None`, the command is deleted from global.
+            Guild ID to delete the application commands from. If ``None``, the command is deleted from global.
         """
         if self.application_id is None:
             raise NotImplementedError("Could not get the current application id")

--- a/nextcord/threads.py
+++ b/nextcord/threads.py
@@ -101,7 +101,7 @@ class Thread(Messageable, Hashable, PinsMixin):
         *not* point to an existing or valid message.
     slowmode_delay: :class:`int`
         The number of seconds a member must wait between sending messages
-        in this thread. A value of `0` denotes that it is disabled.
+        in this thread. A value of ``0`` denotes that it is disabled.
         Bots and users with :attr:`~Permissions.manage_channels` or
         :attr:`~Permissions.manage_messages` bypass slowmode.
     message_count: :class:`int`

--- a/nextcord/utils.py
+++ b/nextcord/utils.py
@@ -1183,7 +1183,7 @@ def parse_docstring(func: Callable, max_chars: int = MISSING) -> Dict[str, Any]:
 
     Parameters
     ----------
-    func: :class:`Callable`
+    func: :data:`~typing.Callable`
         The function to parse the docstring of.
     max_chars: :class:`int`
         The maximum number of characters to allow in the descriptions.

--- a/nextcord/widget.py
+++ b/nextcord/widget.py
@@ -120,7 +120,7 @@ class WidgetMember(BaseUser):
 
         .. describe:: str(x)
 
-            Returns the widget member's `name#discriminator`.
+            Returns the widget member's ``name#discriminator``.
 
     Attributes
     ----------


### PR DESCRIPTION
## Summary

Made 100+ fixes to single-backtick words in rst files to double-backtick phrases or reference links depending on the case.

This helps with readability since single-backtick phrases are italicized rather than set in inline-codeblocks. 

A few additional small docs fixes were also made (eg. missing colon, etc.) in certain cases.

![image](https://user-images.githubusercontent.com/20955511/197374911-b61993d4-9dd6-4101-acfb-c9e5f6868ed7.png)

![image](https://user-images.githubusercontent.com/20955511/197374918-0ecce91b-b1ec-4311-95e2-60543aaf0552.png)

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
  - [ ] I have updated the documentation to reflect the changes.
  - [ ] I have run `task pyright` and fixed the relevant issues.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
