### PR TITLE
refactor: Remove duplicate imports and f-strings with no placeholders

### DIFF
--- a/nextcord/application_command.py
+++ b/nextcord/application_command.py
@@ -357,7 +357,7 @@ class ApplicationCommandOption:
     def payload(self) -> dict:
         """:class:`dict`: Returns a dict payload made of the attributes of the option to be sent to Discord."""
         if self.type is None:
-            raise ValueError(f"The option type must be set before obtaining the payload.")
+            raise ValueError("The option type must be set before obtaining the payload.")
 
         # noinspection PyUnresolvedReferences
         ret: Dict[str, Any] = {
@@ -769,7 +769,7 @@ class CallbackMixin:
                         self.options[arg.name] = arg
 
         except Exception as e:
-            _log.error(f"Error creating from callback %s: %s", self.error_name, e)
+            _log.error("Error creating from callback %s: %s", self.error_name, e)
             raise e
 
     async def can_run(self, interaction: Interaction) -> bool:

--- a/nextcord/client.py
+++ b/nextcord/client.py
@@ -1968,7 +1968,7 @@ class Client:
                 await app_cmd.call_from_interaction(interaction)
             elif self._lazy_load_commands:
                 _log.debug(
-                    f"nextcord.Client: Interaction command not found, attempting to lazy load."
+                    "nextcord.Client: Interaction command not found, attempting to lazy load."
                 )
                 # _log.debug(f"nextcord.Client: %s", interaction.data)
                 response_signature = (
@@ -1976,7 +1976,7 @@ class Client:
                     int(interaction.data["type"]),
                     interaction.guild_id,
                 )
-                _log.debug(f"nextcord.Client: %s", response_signature)
+                _log.debug("nextcord.Client: %s", response_signature)
                 do_deploy = False
                 if app_cmd := self._connection.get_application_command_from_signature(
                     interaction.data["name"],
@@ -1988,7 +1988,7 @@ class Client:
                     )
                     if app_cmd.is_interaction_valid(interaction):
                         _log.debug(
-                            f"nextcord.Client: Interaction seems to correspond to command %s, associating ID now.",
+                            "nextcord.Client: Interaction seems to correspond to command %s, associating ID now.",
                             app_cmd.error_name,
                         )
                         app_cmd.parse_discord_response(self._connection, interaction.data)
@@ -2020,7 +2020,7 @@ class Client:
             # TODO: Is it really worth trying to lazy load with this?
             _log.debug("nextcord.Client: Autocomplete interaction received.")
             if app_cmd := self.get_application_command(int(interaction.data["id"])):
-                _log.debug(f"nextcord.Client: Autocomplete for command %s received.", app_cmd.name)
+                _log.debug("nextcord.Client: Autocomplete for command %s received.", app_cmd.name)
                 await app_cmd.call_autocomplete_from_interaction(interaction)  # type: ignore
             else:
                 raise ValueError(

--- a/nextcord/ext/commands/bot.py
+++ b/nextcord/ext/commands/bot.py
@@ -790,7 +790,7 @@ class BotBase(GroupMixin):
                     asyncio.create_task(setup(self, **extras))
                 except RuntimeError:
                     raise RuntimeError(
-                        f"""
+                        """
                     Looks like you are attempting to load an asynchronous setup function incorrectly.
                     Please read our FAQ here:
                     https://docs.nextcord.dev/en/stable/faq.html#how-do-i-make-my-setup-function-a-coroutine-and-load-it

--- a/nextcord/http.py
+++ b/nextcord/http.py
@@ -71,7 +71,6 @@ if TYPE_CHECKING:
     from types import TracebackType
 
     from .enums import AuditLogAction, InteractionResponseType
-    from .file import File
     from .types import (
         appinfo,
         audit_log,

--- a/nextcord/interactions.py
+++ b/nextcord/interactions.py
@@ -59,7 +59,6 @@ if TYPE_CHECKING:
     from .channel import (
         CategoryChannel,
         ForumChannel,
-        PartialMessageable,
         StageChannel,
         TextChannel,
         VoiceChannel,

--- a/nextcord/interactions.py
+++ b/nextcord/interactions.py
@@ -56,13 +56,7 @@ if TYPE_CHECKING:
     from aiohttp import ClientSession
 
     from .application_command import BaseApplicationCommand, SlashApplicationSubcommand
-    from .channel import (
-        CategoryChannel,
-        ForumChannel,
-        StageChannel,
-        TextChannel,
-        VoiceChannel,
-    )
+    from .channel import CategoryChannel, ForumChannel, StageChannel, TextChannel, VoiceChannel
     from .client import Client
     from .guild import Guild
     from .message import AllowedMentions

--- a/nextcord/iterators.py
+++ b/nextcord/iterators.py
@@ -59,7 +59,6 @@ __all__ = (
 
 if TYPE_CHECKING:
     from .abc import Snowflake
-    from .audit_logs import AuditLogEntry
     from .guild import Guild
     from .member import Member
     from .message import Message

--- a/nextcord/member.py
+++ b/nextcord/member.py
@@ -50,7 +50,6 @@ __all__ = (
 
 if TYPE_CHECKING:
     from .abc import Snowflake
-    from .asset import Asset
     from .channel import DMChannel, StageChannel, VoiceChannel
     from .flags import PublicUserFlags
     from .guild import Guild

--- a/nextcord/shard.py
+++ b/nextcord/shard.py
@@ -47,7 +47,6 @@ from .utils import MISSING
 
 if TYPE_CHECKING:
     from .activity import BaseActivity
-    from .enums import Status
     from .flags import MemberCacheFlags
     from .gateway import DiscordWebSocket
     from .mentions import AllowedMentions

--- a/nextcord/state.py
+++ b/nextcord/state.py
@@ -86,7 +86,6 @@ if TYPE_CHECKING:
     from .gateway import DiscordWebSocket
     from .guild import GuildChannel, VocalGuildChannel
     from .http import HTTPClient
-    from .message import MessageableChannel
     from .types.activity import Activity as ActivityPayload
     from .types.channel import DMChannel as DMChannelPayload
     from .types.checks import ApplicationCheck, ApplicationHook
@@ -750,8 +749,8 @@ class ConnectionState:
                         except Forbidden as e:
                             if ignore_forbidden:
                                 _log.warning(
-                                    f"nextcord.Client: Forbidden error for %s, is the applications.commands "
-                                    f"Oauth scope enabled? %s",
+                                    "nextcord.Client: Forbidden error for %s, is the applications.commands "
+                                    "Oauth scope enabled? %s",
                                     guild_id,
                                     e,
                                 )
@@ -1047,7 +1046,7 @@ class ConnectionState:
         """
         payload: EditApplicationCommand = command.get_payload(guild_id)  # type: ignore
         _log.info(
-            f"nextcord.ConnectionState: Registering command with signature %s",
+            "nextcord.ConnectionState: Registering command with signature %s",
             command.get_signature(guild_id),
         )
 


### PR DESCRIPTION
## Summary

Some imports were duplicated in `TYPE_CHECKING` and were not necessary. These imports have been removed.

Additionally, some f-strings had no placeholders so did not need to use f-strings. These have been converted to regular strings.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
  - [ ] I have updated the documentation to reflect the changes.
  - [x] I have run `task pyright` and fixed the relevant issues.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
