### PR TITLE
fix: Python3.11 dataclass changes

### DIFF
--- a/nextcord/ext/commands/flags.py
+++ b/nextcord/ext/commands/flags.py
@@ -94,13 +94,13 @@ class Flag:
         Whether multiple given values overrides the previous value.
     """
 
-    name: str = MISSING
+    name: str = field(default_factory=MISSING)
     aliases: List[str] = field(default_factory=list)
-    attribute: str = MISSING
-    annotation: Any = MISSING
-    default: Any = MISSING
-    max_args: int = MISSING
-    override: bool = MISSING
+    attribute: str = field(default_factory=MISSING)
+    annotation: Any = field(default_factory=MISSING)
+    default: Any = field(default_factory=MISSING)
+    max_args: int = field(default_factory=MISSING)
+    override: bool = field(default_factory=MISSING)
     cast_to_dict: bool = False
 
     @property

--- a/nextcord/ext/commands/flags.py
+++ b/nextcord/ext/commands/flags.py
@@ -94,13 +94,13 @@ class Flag:
         Whether multiple given values overrides the previous value.
     """
 
-    name: str = field(default_factory=MISSING)
+    name: str = MISSING
     aliases: List[str] = field(default_factory=list)
-    attribute: str = field(default_factory=MISSING)
-    annotation: Any = field(default_factory=MISSING)
-    default: Any = field(default_factory=MISSING)
-    max_args: int = field(default_factory=MISSING)
-    override: bool = field(default_factory=MISSING)
+    attribute: str = MISSING
+    annotation: Any = MISSING
+    default: Any = MISSING
+    max_args: int = MISSING
+    override: bool = MISSING
     cast_to_dict: bool = False
 
     @property

--- a/nextcord/utils.py
+++ b/nextcord/utils.py
@@ -365,7 +365,7 @@ def time_snowflake(dt: datetime.datetime, high: bool = False) -> int:
         The snowflake representing the time given.
     """
     discord_millis = int(dt.timestamp() * 1000 - DISCORD_EPOCH)
-    return (discord_millis << 22) + (2 ** 22 - 1 if high else 0)
+    return (discord_millis << 22) + (2**22 - 1 if high else 0)
 
 
 def find(predicate: Callable[[T], Any], seq: Iterable[T]) -> Optional[T]:

--- a/nextcord/utils.py
+++ b/nextcord/utils.py
@@ -97,7 +97,10 @@ DISCORD_EPOCH = 1420070400000
 
 class _MissingSentinel:
     def __eq__(self, other):
-        return False
+        return self is other
+
+    def __hash__(self):
+        return id(self)
 
     def __bool__(self):
         return False
@@ -362,7 +365,7 @@ def time_snowflake(dt: datetime.datetime, high: bool = False) -> int:
         The snowflake representing the time given.
     """
     discord_millis = int(dt.timestamp() * 1000 - DISCORD_EPOCH)
-    return (discord_millis << 22) + (2**22 - 1 if high else 0)
+    return (discord_millis << 22) + (2 ** 22 - 1 if high else 0)
 
 
 def find(predicate: Callable[[T], Any], seq: Iterable[T]) -> Optional[T]:


### PR DESCRIPTION
## Summary

This closes #866 by migrating the syntax for ``flags.py`` inline with changes to Python 3.11

## Checklist


- [x] If code changes were made then they have been tested.
  - [ ] I have updated the documentation to reflect the changes.
  - [x] I have run `task pyright` and fixed the relevant issues.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
