### PR TITLE
typing(abc): type set_permissions parameters

### DIFF
--- a/nextcord/abc.py
+++ b/nextcord/abc.py
@@ -834,7 +834,7 @@ class GuildChannel:
         elif isinstance(overwrite, PermissionOverwrite):
             (allow, deny) = overwrite.pair()
             await http.edit_channel_permissions(
-                self.id, target.id, allow.value, deny.value, perm_type, reason=reason
+                self.id, target.id, str(allow.value), str(deny.value), perm_type, reason=reason
             )
         else:
             raise InvalidArgument("Invalid overwrite type provided.")

--- a/nextcord/abc.py
+++ b/nextcord/abc.py
@@ -731,10 +731,10 @@ class GuildChannel:
         ...
 
     async def set_permissions(
-        self, 
-        target: Union[Member, Role], 
-        *, 
-        reason: Optional[str] = None, 
+        self,
+        target: Union[Member, Role],
+        *,
+        reason: Optional[str] = None,
         **kwargs: Any,
     ):
         r"""|coro|

--- a/nextcord/abc.py
+++ b/nextcord/abc.py
@@ -730,7 +730,13 @@ class GuildChannel:
     ) -> None:
         ...
 
-    async def set_permissions(self, target, *, overwrite=MISSING, reason=None, **permissions):
+    async def set_permissions(
+        self, 
+        target: Union[Member, Role], 
+        *, 
+        reason: Optional[str] = None, 
+        **kwargs: Any,
+    ):
         r"""|coro|
 
         Sets the channel specific permission overwrites for a target in the
@@ -800,6 +806,8 @@ class GuildChannel:
         """
 
         http = self._state.http
+        overwrite: Optional[PermissionOverwrite] = kwargs.pop("overwrite", MISSING)
+        permissions: Dict[str, bool] = kwargs
 
         if isinstance(target, User):
             perm_type = _Overwrites.MEMBER


### PR DESCRIPTION
## Summary

This PR types the parameters of the actual implementation (aka not overloaded version) of `GuildChannel.set_permissions`. The actual implementation's parameters are changed slightly to include a catch-all variable keyword parameter because of how different the two other overloads are.

Closes #839. 

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
  - [ ] I have updated the documentation to reflect the changes.
  - [ ] I have run `task pyright` and fixed the relevant issues.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
