### PR TITLE
feat(audit-logs): `auto_moderation_flag_to_channel`, `auto_moderation_user_communication_disabled` types

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -2603,6 +2603,38 @@ of :class:`enum.Enum`.
 
         .. versionadded:: 2.1
 
+    .. attribute:: auto_moderation_flag_to_channel
+
+        A message was flagged by an auto moderation rule.
+
+        When this is the action, the type of :attr:`~AuditLogEntry.target` is
+        the :class:`Member` or :class:`User` whose message was flagged.
+
+        When this is the action, the type of :attr:`~AuditLogEntry.extra` is
+        set to an unspecified proxy object with these three attributes:
+
+        - ``channel``: A :class:`~abc.GuildChannel`, :class:`Thread` or :class:`Object` with the channel ID where the message was flagged.
+        - ``rule_name``: A :class:`str` with the name of the rule.
+        - ``rule_trigger_type``: A :class:`AutoModerationTriggerType` value with the trigger type of the rule.
+
+        .. versionadded:: 2.3
+
+    .. attribute:: auto_moderation_user_communication_disabled
+
+        A member was timed out by an auto moderation rule.
+
+        When this is the action, the type of :attr:`~AuditLogEntry.target` is
+        the :class:`Member` or :class:`User` who was timed out.
+
+        When this is the action, the type of :attr:`~AuditLogEntry.extra` is
+        set to an unspecified proxy object with these three attributes:
+
+        - ``channel``: A :class:`~abc.GuildChannel`, :class:`Thread` or :class:`Object` with the channel ID where the member was timed out.
+        - ``rule_name``: A :class:`str` with the name of the rule.
+        - ``rule_trigger_type``: A :class:`AutoModerationTriggerType` value with the trigger type of the rule.
+
+        .. versionadded:: 2.3
+
 .. class:: AuditLogActionCategory
 
     Represents the category that the :class:`AuditLogAction` belongs to.

--- a/nextcord/audit_logs.py
+++ b/nextcord/audit_logs.py
@@ -534,7 +534,11 @@ class AuditLogEntry(Hashable):
                 channel_id = int(self.extra["channel_id"])
                 elems = {"channel": self.guild.get_channel(channel_id) or Object(id=channel_id)}
                 self.extra = type("_AuditLogProxy", (), elems)()  # type: ignore
-            elif self.action is enums.AuditLogAction.auto_moderation_block_message:
+            elif (
+                self.action is enums.AuditLogAction.auto_moderation_block_message
+                or self.action is enums.AuditLogAction.auto_moderation_flag_to_channel
+                or self.action is enums.AuditLogAction.auto_moderation_user_communication_disabled
+            ):
                 channel_id = int(self.extra["channel_id"])
                 elems = {
                     "channel": (

--- a/nextcord/enums.py
+++ b/nextcord/enums.py
@@ -292,114 +292,118 @@ class AuditLogActionCategory(IntEnum):
 
 class AuditLogAction(IntEnum):
     # fmt: off
-    guild_update                  = 1
-    channel_create                = 10
-    channel_update                = 11
-    channel_delete                = 12
-    overwrite_create              = 13
-    overwrite_update              = 14
-    overwrite_delete              = 15
-    kick                          = 20
-    member_prune                  = 21
-    ban                           = 22
-    unban                         = 23
-    member_update                 = 24
-    member_role_update            = 25
-    member_move                   = 26
-    member_disconnect             = 27
-    bot_add                       = 28
-    role_create                   = 30
-    role_update                   = 31
-    role_delete                   = 32
-    invite_create                 = 40
-    invite_update                 = 41
-    invite_delete                 = 42
-    webhook_create                = 50
-    webhook_update                = 51
-    webhook_delete                = 52
-    emoji_create                  = 60
-    emoji_update                  = 61
-    emoji_delete                  = 62
-    message_delete                = 72
-    message_bulk_delete           = 73
-    message_pin                   = 74
-    message_unpin                 = 75
-    integration_create            = 80
-    integration_update            = 81
-    integration_delete            = 82
-    stage_instance_create         = 83
-    stage_instance_update         = 84
-    stage_instance_delete         = 85
-    sticker_create                = 90
-    sticker_update                = 91
-    sticker_delete                = 92
-    scheduled_event_create        = 100
-    scheduled_event_update        = 101
-    scheduled_event_delete        = 102
-    thread_create                 = 110
-    thread_update                 = 111
-    thread_delete                 = 112
-    auto_moderation_rule_create   = 140
-    auto_moderation_rule_update   = 141
-    auto_moderation_rule_delete   = 142
-    auto_moderation_block_message = 143
+    guild_update                                = 1
+    channel_create                              = 10
+    channel_update                              = 11
+    channel_delete                              = 12
+    overwrite_create                            = 13
+    overwrite_update                            = 14
+    overwrite_delete                            = 15
+    kick                                        = 20
+    member_prune                                = 21
+    ban                                         = 22
+    unban                                       = 23
+    member_update                               = 24
+    member_role_update                          = 25
+    member_move                                 = 26
+    member_disconnect                           = 27
+    bot_add                                     = 28
+    role_create                                 = 30
+    role_update                                 = 31
+    role_delete                                 = 32
+    invite_create                               = 40
+    invite_update                               = 41
+    invite_delete                               = 42
+    webhook_create                              = 50
+    webhook_update                              = 51
+    webhook_delete                              = 52
+    emoji_create                                = 60
+    emoji_update                                = 61
+    emoji_delete                                = 62
+    message_delete                              = 72
+    message_bulk_delete                         = 73
+    message_pin                                 = 74
+    message_unpin                               = 75
+    integration_create                          = 80
+    integration_update                          = 81
+    integration_delete                          = 82
+    stage_instance_create                       = 83
+    stage_instance_update                       = 84
+    stage_instance_delete                       = 85
+    sticker_create                              = 90
+    sticker_update                              = 91
+    sticker_delete                              = 92
+    scheduled_event_create                      = 100
+    scheduled_event_update                      = 101
+    scheduled_event_delete                      = 102
+    thread_create                               = 110
+    thread_update                               = 111
+    thread_delete                               = 112
+    auto_moderation_rule_create                 = 140
+    auto_moderation_rule_update                 = 141
+    auto_moderation_rule_delete                 = 142
+    auto_moderation_block_message               = 143
+    auto_moderation_flag_to_channel             = 144
+    auto_moderation_user_communication_disabled = 145
     # fmt: on
 
     @property
     def category(self) -> Optional[AuditLogActionCategory]:
         # fmt: off
         lookup: Dict[AuditLogAction, Optional[AuditLogActionCategory]] = {
-            AuditLogAction.guild_update:                  AuditLogActionCategory.update,
-            AuditLogAction.channel_create:                AuditLogActionCategory.create,
-            AuditLogAction.channel_update:                AuditLogActionCategory.update,
-            AuditLogAction.channel_delete:                AuditLogActionCategory.delete,
-            AuditLogAction.overwrite_create:              AuditLogActionCategory.create,
-            AuditLogAction.overwrite_update:              AuditLogActionCategory.update,
-            AuditLogAction.overwrite_delete:              AuditLogActionCategory.delete,
-            AuditLogAction.kick:                          None,
-            AuditLogAction.member_prune:                  None,
-            AuditLogAction.ban:                           None,
-            AuditLogAction.unban:                         None,
-            AuditLogAction.member_update:                 AuditLogActionCategory.update,
-            AuditLogAction.member_role_update:            AuditLogActionCategory.update,
-            AuditLogAction.member_move:                   None,
-            AuditLogAction.member_disconnect:             None,
-            AuditLogAction.bot_add:                       None,
-            AuditLogAction.role_create:                   AuditLogActionCategory.create,
-            AuditLogAction.role_update:                   AuditLogActionCategory.update,
-            AuditLogAction.role_delete:                   AuditLogActionCategory.delete,
-            AuditLogAction.invite_create:                 AuditLogActionCategory.create,
-            AuditLogAction.invite_update:                 AuditLogActionCategory.update,
-            AuditLogAction.invite_delete:                 AuditLogActionCategory.delete,
-            AuditLogAction.webhook_create:                AuditLogActionCategory.create,
-            AuditLogAction.webhook_update:                AuditLogActionCategory.update,
-            AuditLogAction.webhook_delete:                AuditLogActionCategory.delete,
-            AuditLogAction.emoji_create:                  AuditLogActionCategory.create,
-            AuditLogAction.emoji_update:                  AuditLogActionCategory.update,
-            AuditLogAction.emoji_delete:                  AuditLogActionCategory.delete,
-            AuditLogAction.message_delete:                AuditLogActionCategory.delete,
-            AuditLogAction.message_bulk_delete:           AuditLogActionCategory.delete,
-            AuditLogAction.message_pin:                   None,
-            AuditLogAction.message_unpin:                 None,
-            AuditLogAction.integration_create:            AuditLogActionCategory.create,
-            AuditLogAction.integration_update:            AuditLogActionCategory.update,
-            AuditLogAction.integration_delete:            AuditLogActionCategory.delete,
-            AuditLogAction.stage_instance_create:         AuditLogActionCategory.create,
-            AuditLogAction.stage_instance_update:         AuditLogActionCategory.update,
-            AuditLogAction.stage_instance_delete:         AuditLogActionCategory.delete,
-            AuditLogAction.sticker_create:                AuditLogActionCategory.create,
-            AuditLogAction.sticker_update:                AuditLogActionCategory.update,
-            AuditLogAction.sticker_delete:                AuditLogActionCategory.delete,
-            AuditLogAction.scheduled_event_create:        AuditLogActionCategory.create,
-            AuditLogAction.scheduled_event_update:        AuditLogActionCategory.update,
-            AuditLogAction.scheduled_event_delete:        AuditLogActionCategory.delete,
-            AuditLogAction.thread_create:                 AuditLogActionCategory.create,
-            AuditLogAction.thread_update:                 AuditLogActionCategory.update,
-            AuditLogAction.thread_delete:                 AuditLogActionCategory.delete,
-            AuditLogAction.auto_moderation_rule_create:   AuditLogActionCategory.create,
-            AuditLogAction.auto_moderation_rule_update:   AuditLogActionCategory.update,
-            AuditLogAction.auto_moderation_rule_delete:   AuditLogActionCategory.delete,
-            AuditLogAction.auto_moderation_block_message: None,
+            AuditLogAction.guild_update:                                AuditLogActionCategory.update,
+            AuditLogAction.channel_create:                              AuditLogActionCategory.create,
+            AuditLogAction.channel_update:                              AuditLogActionCategory.update,
+            AuditLogAction.channel_delete:                              AuditLogActionCategory.delete,
+            AuditLogAction.overwrite_create:                            AuditLogActionCategory.create,
+            AuditLogAction.overwrite_update:                            AuditLogActionCategory.update,
+            AuditLogAction.overwrite_delete:                            AuditLogActionCategory.delete,
+            AuditLogAction.kick:                                        None,
+            AuditLogAction.member_prune:                                None,
+            AuditLogAction.ban:                                         None,
+            AuditLogAction.unban:                                       None,
+            AuditLogAction.member_update:                               AuditLogActionCategory.update,
+            AuditLogAction.member_role_update:                          AuditLogActionCategory.update,
+            AuditLogAction.member_move:                                 None,
+            AuditLogAction.member_disconnect:                           None,
+            AuditLogAction.bot_add:                                     None,
+            AuditLogAction.role_create:                                 AuditLogActionCategory.create,
+            AuditLogAction.role_update:                                 AuditLogActionCategory.update,
+            AuditLogAction.role_delete:                                 AuditLogActionCategory.delete,
+            AuditLogAction.invite_create:                               AuditLogActionCategory.create,
+            AuditLogAction.invite_update:                               AuditLogActionCategory.update,
+            AuditLogAction.invite_delete:                               AuditLogActionCategory.delete,
+            AuditLogAction.webhook_create:                              AuditLogActionCategory.create,
+            AuditLogAction.webhook_update:                              AuditLogActionCategory.update,
+            AuditLogAction.webhook_delete:                              AuditLogActionCategory.delete,
+            AuditLogAction.emoji_create:                                AuditLogActionCategory.create,
+            AuditLogAction.emoji_update:                                AuditLogActionCategory.update,
+            AuditLogAction.emoji_delete:                                AuditLogActionCategory.delete,
+            AuditLogAction.message_delete:                              AuditLogActionCategory.delete,
+            AuditLogAction.message_bulk_delete:                         AuditLogActionCategory.delete,
+            AuditLogAction.message_pin:                                 None,
+            AuditLogAction.message_unpin:                               None,
+            AuditLogAction.integration_create:                          AuditLogActionCategory.create,
+            AuditLogAction.integration_update:                          AuditLogActionCategory.update,
+            AuditLogAction.integration_delete:                          AuditLogActionCategory.delete,
+            AuditLogAction.stage_instance_create:                       AuditLogActionCategory.create,
+            AuditLogAction.stage_instance_update:                       AuditLogActionCategory.update,
+            AuditLogAction.stage_instance_delete:                       AuditLogActionCategory.delete,
+            AuditLogAction.sticker_create:                              AuditLogActionCategory.create,
+            AuditLogAction.sticker_update:                              AuditLogActionCategory.update,
+            AuditLogAction.sticker_delete:                              AuditLogActionCategory.delete,
+            AuditLogAction.scheduled_event_create:                      AuditLogActionCategory.create,
+            AuditLogAction.scheduled_event_update:                      AuditLogActionCategory.update,
+            AuditLogAction.scheduled_event_delete:                      AuditLogActionCategory.delete,
+            AuditLogAction.thread_create:                               AuditLogActionCategory.create,
+            AuditLogAction.thread_update:                               AuditLogActionCategory.update,
+            AuditLogAction.thread_delete:                               AuditLogActionCategory.delete,
+            AuditLogAction.auto_moderation_rule_create:                 AuditLogActionCategory.create,
+            AuditLogAction.auto_moderation_rule_update:                 AuditLogActionCategory.update,
+            AuditLogAction.auto_moderation_rule_delete:                 AuditLogActionCategory.delete,
+            AuditLogAction.auto_moderation_block_message:               None,
+            AuditLogAction.auto_moderation_flag_to_channel:             None,
+            AuditLogAction.auto_moderation_user_communication_disabled: None,
         }
         # fmt: on
         return lookup[self]


### PR DESCRIPTION
## Summary

Closes #817 

Adds `auto_moderation_flag_to_channel` and `auto_moderation_user_communication_disabled` audit log event types

https://github.com/discord/discord-api-docs/blob/main/docs/resources/Audit_Log.md

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
  - [x] I have updated the documentation to reflect the changes.
  - [x] I have run `task pyright` and fixed the relevant issues.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
