### PR TITLE
build: use aiohttp[speedups] so cchardet isnt installed >=3.10

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ extras_require = {
         "sphinxcontrib-websupport",
         "typing_extensions>=4.2.0, <5",
     ],
-    "speed": ["orjson>=3.5.4", "aiodns>=1.1", "Brotli", "cchardet"],
+    "speed": ["orjson>=3.5.4", "aiohttp[speedups]"],
 }
 
 packages = [


### PR DESCRIPTION
## Summary

Use `aiohttp[speedups]` to depend on aiohttp's list, instead of defining them ourselves.
This means that aiohttp's qualifier to not install `cchardet` since it is not maintained, and so `nextcord[speed]` works on 3.11.
<!-- What is this pull request for? Does it fix any issues? -->

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
  - [ ] I have updated the documentation to reflect the changes.
  - [ ] I have run `task pyright` and fixed the relevant issues.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
