### PR TITLE
refactor(ui): improve public annotations

### DIFF
--- a/nextcord/components.py
+++ b/nextcord/components.py
@@ -313,9 +313,9 @@ class SelectOption:
         emoji: Optional[Union[str, Emoji, PartialEmoji]] = None,
         default: bool = False,
     ) -> None:
-        self.label = label
-        self.value = label if value is MISSING else value
-        self.description = description
+        self.label: str = label
+        self.value: str = label if value is MISSING else value
+        self.description: Optional[str] = description
 
         if emoji is not None:
             if isinstance(emoji, str):
@@ -327,8 +327,8 @@ class SelectOption:
                     f"Expected emoji to be str, Emoji, or PartialEmoji not {emoji.__class__}"
                 )
 
-        self.emoji = emoji
-        self.default = default
+        self.emoji: Optional[PartialEmoji] = emoji
+        self.default: bool = default
 
     def __repr__(self) -> str:
         return (

--- a/nextcord/ui/button.py
+++ b/nextcord/ui/button.py
@@ -40,9 +40,9 @@ __all__ = (
 
 if TYPE_CHECKING:
     from ..emoji import Emoji
+    from ..interactions import ClientT
     from ..types.components import ButtonComponent as ButtonComponentPayload
     from .view import View
-
 
 B = TypeVar("B", bound="Button")
 V = TypeVar("V", bound="View", covariant=True)
@@ -134,7 +134,7 @@ class Button(Item[V]):
         return self._underlying.style
 
     @style.setter
-    def style(self, value: ButtonStyle):
+    def style(self, value: ButtonStyle) -> None:
         self._underlying.style = value
 
     @property
@@ -146,7 +146,7 @@ class Button(Item[V]):
         return self._underlying.custom_id
 
     @custom_id.setter
-    def custom_id(self, value: Optional[str]):
+    def custom_id(self, value: Optional[str]) -> None:
         if value is not None and not isinstance(value, str):
             raise TypeError("custom_id must be None or str")
 
@@ -158,7 +158,7 @@ class Button(Item[V]):
         return self._underlying.url
 
     @url.setter
-    def url(self, value: Optional[str]):
+    def url(self, value: Optional[str]) -> None:
         if value is not None and not isinstance(value, str):
             raise TypeError("url must be None or str")
         self._underlying.url = value
@@ -169,7 +169,7 @@ class Button(Item[V]):
         return self._underlying.disabled
 
     @disabled.setter
-    def disabled(self, value: bool):
+    def disabled(self, value: bool) -> None:
         self._underlying.disabled = bool(value)
 
     @property
@@ -178,7 +178,7 @@ class Button(Item[V]):
         return self._underlying.label
 
     @label.setter
-    def label(self, value: Optional[str]):
+    def label(self, value: Optional[str]) -> None:
         self._underlying.label = str(value) if value is not None else value
 
     @property
@@ -187,7 +187,7 @@ class Button(Item[V]):
         return self._underlying.emoji
 
     @emoji.setter
-    def emoji(self, value: Optional[Union[str, Emoji, PartialEmoji]]):  # type: ignore
+    def emoji(self, value: Optional[Union[str, Emoji, PartialEmoji]]) -> None:  # type: ignore
         if value is not None:
             if isinstance(value, str):
                 self._underlying.emoji = PartialEmoji.from_str(value)
@@ -239,7 +239,7 @@ def button(
     style: ButtonStyle = ButtonStyle.secondary,
     emoji: Optional[Union[str, Emoji, PartialEmoji]] = None,
     row: Optional[int] = None,
-) -> Callable[[ItemCallbackType], ItemCallbackType]:
+) -> Callable[[ItemCallbackType[Button[V], ClientT]], ItemCallbackType[Button[V], ClientT]]:
     """A decorator that attaches a button to a component.
 
     The function being decorated should have three parameters, ``self`` representing
@@ -276,7 +276,7 @@ def button(
         ordering. The row number must be between 0 and 4 (i.e. zero indexed).
     """
 
-    def decorator(func: ItemCallbackType) -> ItemCallbackType:
+    def decorator(func: ItemCallbackType[Button[V]]) -> ItemCallbackType[Button[V]]:
         if not asyncio.iscoroutinefunction(func):
             raise TypeError("Button function must be a coroutine function")
 

--- a/nextcord/ui/item.py
+++ b/nextcord/ui/item.py
@@ -26,7 +26,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any, Callable, Coroutine, Generic, Optional, Tuple, Type, TypeVar
 
-from ..interactions import Interaction
+from ..interactions import ClientT, Interaction
 
 __all__ = ("Item",)
 
@@ -39,7 +39,7 @@ if TYPE_CHECKING:
 
 I = TypeVar("I", bound="Item")
 V = TypeVar("V", bound="View", covariant=True)
-ItemCallbackType = Callable[[Any, I, Interaction], Coroutine[Any, Any, Any]]
+ItemCallbackType = Callable[[Any, I, Interaction[ClientT]], Coroutine[Any, Any, Any]]
 
 
 class Item(Generic[V]):
@@ -100,7 +100,7 @@ class Item(Generic[V]):
         return self._row
 
     @row.setter
-    def row(self, value: Optional[int]):
+    def row(self, value: Optional[int]) -> None:
         if value is None:
             self._row = None
         elif 5 > value >= 0:

--- a/nextcord/ui/modal.py
+++ b/nextcord/ui/modal.py
@@ -45,7 +45,7 @@ __all__ = (
 
 
 if TYPE_CHECKING:
-    from ..interactions import Interaction
+    from ..interactions import ClientT, Interaction
     from ..state import ConnectionState
     from ..types.components import ActionRow as ActionRowPayload
     from ..types.interactions import (
@@ -421,19 +421,19 @@ class ModalStore:
         for k in to_remove:
             del self._modals[k]
 
-    def add_modal(self, modal: Modal, user_id: Optional[int] = None):
+    def add_modal(self, modal: Modal, user_id: Optional[int] = None) -> None:
         self.__verify_integrity()
 
         modal._start_listening_from_store(self)
         self._modals[(user_id, modal.custom_id)] = modal
 
-    def remove_modal(self, modal: Modal):
+    def remove_modal(self, modal: Modal) -> None:
         _modals = self._modals.copy()
         for key, value in _modals.items():
             if value is modal:
                 del self._modals[key]
 
-    def dispatch(self, custom_id: str, interaction: Interaction):
+    def dispatch(self, custom_id: str, interaction: Interaction[ClientT]) -> None:
         self.__verify_integrity()
 
         key = (interaction.user.id, custom_id)  # type: ignore

--- a/nextcord/ui/select.py
+++ b/nextcord/ui/select.py
@@ -41,10 +41,10 @@ __all__ = (
 )
 
 if TYPE_CHECKING:
+    from ..interactions import ClientT
     from ..types.components import SelectMenu as SelectMenuPayload
     from ..types.interactions import ComponentInteractionData
     from .view import View
-    from ..interactions import ClientT
 
 S = TypeVar("S", bound="Select")
 V = TypeVar("V", bound="View", covariant=True)

--- a/nextcord/ui/select.py
+++ b/nextcord/ui/select.py
@@ -44,6 +44,7 @@ if TYPE_CHECKING:
     from ..types.components import SelectMenu as SelectMenuPayload
     from ..types.interactions import ComponentInteractionData
     from .view import View
+    from ..interactions import ClientT
 
 S = TypeVar("S", bound="Select")
 V = TypeVar("V", bound="View", covariant=True)
@@ -124,7 +125,7 @@ class Select(Item[V]):
         return self._underlying.custom_id
 
     @custom_id.setter
-    def custom_id(self, value: str):
+    def custom_id(self, value: str) -> None:
         if not isinstance(value, str):
             raise TypeError("custom_id must be None or str")
 
@@ -136,7 +137,7 @@ class Select(Item[V]):
         return self._underlying.placeholder
 
     @placeholder.setter
-    def placeholder(self, value: Optional[str]):
+    def placeholder(self, value: Optional[str]) -> None:
         if value is not None and not isinstance(value, str):
             raise TypeError("placeholder must be None or str")
 
@@ -148,7 +149,7 @@ class Select(Item[V]):
         return self._underlying.min_values
 
     @min_values.setter
-    def min_values(self, value: int):
+    def min_values(self, value: int) -> None:
         self._underlying.min_values = int(value)
 
     @property
@@ -157,7 +158,7 @@ class Select(Item[V]):
         return self._underlying.max_values
 
     @max_values.setter
-    def max_values(self, value: int):
+    def max_values(self, value: int) -> None:
         self._underlying.max_values = int(value)
 
     @property
@@ -166,7 +167,7 @@ class Select(Item[V]):
         return self._underlying.options
 
     @options.setter
-    def options(self, value: List[SelectOption]):
+    def options(self, value: List[SelectOption]) -> None:
         if not isinstance(value, list):
             raise TypeError("options must be a list of SelectOption")
         if not all(isinstance(obj, SelectOption) for obj in value):
@@ -182,7 +183,7 @@ class Select(Item[V]):
         description: Optional[str] = None,
         emoji: Optional[Union[str, Emoji, PartialEmoji]] = None,
         default: bool = False,
-    ):
+    ) -> None:
         """Adds an option to the select menu.
 
         To append a pre-existing :class:`nextcord.SelectOption` use the
@@ -221,7 +222,7 @@ class Select(Item[V]):
 
         self.append_option(option)
 
-    def append_option(self, option: SelectOption):
+    def append_option(self, option: SelectOption) -> None:
         """Appends an option to the select menu.
 
         Parameters
@@ -246,7 +247,7 @@ class Select(Item[V]):
         return self._underlying.disabled
 
     @disabled.setter
-    def disabled(self, value: bool):
+    def disabled(self, value: bool) -> None:
         self._underlying.disabled = bool(value)
 
     @property
@@ -296,7 +297,7 @@ def select(
     options: List[SelectOption] = MISSING,
     disabled: bool = False,
     row: Optional[int] = None,
-) -> Callable[[ItemCallbackType], ItemCallbackType]:
+) -> Callable[[ItemCallbackType[Select[V], ClientT]], ItemCallbackType[Select[V], ClientT]]:
     """A decorator that attaches a select menu to a component.
 
     The function being decorated should have three parameters, ``self`` representing
@@ -331,7 +332,7 @@ def select(
         Whether the select is disabled or not. Defaults to ``False``.
     """
 
-    def decorator(func: ItemCallbackType) -> ItemCallbackType:
+    def decorator(func: ItemCallbackType[Select[V]]) -> ItemCallbackType[Select[V]]:
         if not asyncio.iscoroutinefunction(func):
             raise TypeError("Select function must be a coroutine function")
 

--- a/nextcord/ui/text_input.py
+++ b/nextcord/ui/text_input.py
@@ -126,7 +126,7 @@ class TextInput(Item[V]):
         return self._underlying.style
 
     @style.setter
-    def style(self, value: TextInputStyle):
+    def style(self, value: TextInputStyle) -> None:
         self._underlying.style = value
 
     @property
@@ -135,7 +135,7 @@ class TextInput(Item[V]):
         return self._underlying.custom_id
 
     @custom_id.setter
-    def custom_id(self, value: Optional[str]):
+    def custom_id(self, value: Optional[str]) -> None:
         if value is not None and not isinstance(value, str):
             raise TypeError("custom_id must be None or str")
 
@@ -147,7 +147,7 @@ class TextInput(Item[V]):
         return self._underlying.label
 
     @label.setter
-    def label(self, value: str):
+    def label(self, value: str) -> None:
         if value is None:
             raise TypeError("label must cannot be None")
         self._underlying.label = str(value)
@@ -158,7 +158,7 @@ class TextInput(Item[V]):
         return self._underlying.min_length
 
     @min_length.setter
-    def min_length(self, value: int):
+    def min_length(self, value: int) -> None:
         self._underlying.min_length = value
 
     @property
@@ -167,7 +167,7 @@ class TextInput(Item[V]):
         return self._underlying.max_length
 
     @max_length.setter
-    def max_length(self, value: int):
+    def max_length(self, value: int) -> None:
         self._underlying.max_length = value
 
     @property
@@ -176,7 +176,7 @@ class TextInput(Item[V]):
         return self._underlying.required
 
     @required.setter
-    def required(self, value: Optional[bool]):
+    def required(self, value: Optional[bool]) -> None:
         if value is not None and not isinstance(value, bool):
             raise TypeError("required must be None or bool")
 
@@ -188,7 +188,7 @@ class TextInput(Item[V]):
         return self._underlying.value
 
     @default_value.setter
-    def default_value(self, value: Optional[str]):
+    def default_value(self, value: Optional[str]) -> None:
         if value is not None and not isinstance(value, str):
             raise TypeError("default_value must be None or str")
         self._underlying.value = value
@@ -207,7 +207,7 @@ class TextInput(Item[V]):
         return self._underlying.placeholder
 
     @placeholder.setter
-    def placeholder(self, value: Optional[str]):
+    def placeholder(self, value: Optional[str]) -> None:
         if value is not None and not isinstance(value, str):
             raise TypeError("placeholder must be None or str")
 

--- a/nextcord/ui/view.py
+++ b/nextcord/ui/view.py
@@ -60,7 +60,7 @@ from .item import Item, ItemCallbackType
 __all__ = ("View",)
 
 if TYPE_CHECKING:
-    from ..interactions import Interaction
+    from ..interactions import ClientT, Interaction
     from ..message import Message
     from ..state import ConnectionState
     from ..types.components import ActionRow as ActionRowPayload, Component as ComponentPayload
@@ -525,7 +525,7 @@ class ViewStore:
         for k in to_remove:
             del self._views[k]
 
-    def add_view(self, view: View, message_id: Optional[int] = None):
+    def add_view(self, view: View, message_id: Optional[int] = None) -> None:
         self.__verify_integrity()
 
         view._start_listening_from_store(self)
@@ -536,7 +536,7 @@ class ViewStore:
         if message_id is not None:
             self._synced_message_views[message_id] = view
 
-    def remove_view(self, view: View, message_id: Optional[int] = None):
+    def remove_view(self, view: View, message_id: Optional[int] = None) -> None:
         for item in view.children:
             if item.is_dispatchable():
                 self._views.pop((item.type.value, message_id, item.custom_id), None)  # type: ignore
@@ -546,7 +546,9 @@ class ViewStore:
                 del self._synced_message_views[key]
                 break
 
-    def dispatch(self, component_type: int, custom_id: str, interaction: Interaction):
+    def dispatch(
+        self, component_type: int, custom_id: str, interaction: Interaction[ClientT]
+    ) -> None:
         self.__verify_integrity()
         message_id: Optional[int] = interaction.message and interaction.message.id
         key = (component_type, message_id, custom_id)
@@ -560,13 +562,13 @@ class ViewStore:
         item.refresh_state(interaction.data)  # type: ignore
         view._dispatch_item(item, interaction)
 
-    def is_message_tracked(self, message_id: int):
+    def is_message_tracked(self, message_id: int) -> bool:
         return message_id in self._synced_message_views
 
     def remove_message_tracking(self, message_id: int) -> Optional[View]:
         return self._synced_message_views.pop(message_id, None)
 
-    def update_from_message(self, message_id: int, components: List[ComponentPayload]):
+    def update_from_message(self, message_id: int, components: List[ComponentPayload]) -> None:
         # pre-req: is_message_tracked == true
         view = self._synced_message_views[message_id]
         view.refresh([_component_factory(d) for d in components])


### PR DESCRIPTION
## Summary

This improves public-facing annotations in the ui module.
The overall pyright type completeness score increases by 2.3%.
Unlike #877, this does not use `pyright: strict`, since there are significant archtectual changes required to get strict to be happy, such as importing and using private members, and using raw `**kwargs` for 'underlying' objects.
<!-- What is this pull request for? Does it fix any issues? -->

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
  - [ ] I have updated the documentation to reflect the changes.
  - [x] I have run `task pyright` and fixed the relevant issues.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
