### PR TITLE
fix(app-cmds): typing module is not imported

### DIFF
--- a/nextcord/application_command.py
+++ b/nextcord/application_command.py
@@ -765,7 +765,7 @@ class CallbackMixin:
                     # TODO: use typing.Self when 3.11 is standard
                     or param.annotation is typing_extensions.Self
                     # will always be a self parameter
-                    or isinstance(param.annotation, typing.TypeVar)
+                    or isinstance(param.annotation, TypeVar)
                     for param in list(callback_params.values())[:skip_counter]
                 )
 


### PR DESCRIPTION
## Summary

This is a CRUCIAL problem with #736 that was not spotted during the review phase.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
  - [ ] I have updated the documentation to reflect the changes.
  - [ ] I have run `task pyright` and fixed the relevant issues.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
