### PR TITLE
feat(View): add prevent_update param

### DIFF
--- a/nextcord/abc.py
+++ b/nextcord/abc.py
@@ -1554,7 +1554,7 @@ class Messageable:
             )
 
         ret = state.create_message(channel=channel, data=data)
-        if view:
+        if view and view.prevent_update:
             state.store_view(view, ret.id)
 
         if delete_after is not None:

--- a/nextcord/interactions.py
+++ b/nextcord/interactions.py
@@ -443,7 +443,7 @@ class Interaction(Hashable, Generic[ClientT]):
 
         # The message channel types should always match
         message = InteractionMessage(state=self._state, channel=self.channel, data=data)  # type: ignore
-        if view and not view.is_finished():
+        if view and not view.is_finished() and view.prevent_update:
             self._state.store_view(view, message.id)
         return message
 
@@ -906,7 +906,7 @@ class InteractionResponse:
                 for file in files:
                     file.close()
 
-        if view is not MISSING:
+        if view is not MISSING and view.prevent_update:
             if ephemeral and view.timeout is None:
                 view.timeout = 15 * 60.0
 
@@ -1077,7 +1077,7 @@ class InteractionResponse:
                 for file in files:
                     file.close()
 
-        if view and not view.is_finished() and message_id is not None:
+        if view and not view.is_finished() and message_id is not None and view.prevent_update:
             state.store_view(view, message_id)
 
         self._responded = True

--- a/nextcord/message.py
+++ b/nextcord/message.py
@@ -1508,7 +1508,7 @@ class Message(Hashable):
         data = await self._state.http.edit_message(self.channel.id, self.id, **payload)
         message = Message(state=self._state, channel=self.channel, data=data)
 
-        if view and not view.is_finished():
+        if view and not view.is_finished() and view.prevent_update:
             self._state.store_view(view, self.id)
 
         if delete_after is not None:
@@ -2060,6 +2060,6 @@ class PartialMessage(Hashable):
         if fields:
             # data isn't unbound
             msg = self._state.create_message(channel=self.channel, data=data)  # type: ignore
-            if view and not view.is_finished():
+            if view and not view.is_finished() and view.prevent_update:
                 self._state.store_view(view, self.id)
             return msg

--- a/nextcord/ui/view.py
+++ b/nextcord/ui/view.py
@@ -164,7 +164,13 @@ class View:
 
         cls.__view_children_items__ = children
 
-    def __init__(self, *, timeout: Optional[float] = 180.0, auto_defer: bool = True, prevent_update: bool = True) -> None:
+    def __init__(
+        self,
+        *,
+        timeout: Optional[float] = 180.0,
+        auto_defer: bool = True,
+        prevent_update: bool = True,
+    ) -> None:
         self.timeout = timeout
         self.auto_defer = auto_defer
         self.prevent_update = True if timeout else prevent_update

--- a/nextcord/ui/view.py
+++ b/nextcord/ui/view.py
@@ -138,6 +138,13 @@ class View:
         Whether or not to automatically defer the component interaction when the callback
         completes without responding to the interaction. Set this to ``False`` if you want to
         handle view interactions outside of the callback.
+    prevent_update: :class:`bool` = True
+        This option only affects persistent views.
+        Whether or not to store the view separately for each message.
+        The stored views are not automatically cleared, and can cause issues if
+        you run the bot continously for long periods of time if views are not properly stopped.
+        Setting this to False will force the client to find a persistent view added with
+        `Bot.add_view` and not store the view separately.
     """
 
     __discord_ui_view__: ClassVar[bool] = True
@@ -146,18 +153,21 @@ class View:
     def __init_subclass__(cls) -> None:
         children: List[ItemCallbackType] = []
         for base in reversed(cls.__mro__):
-            for member in base.__dict__.values():
-                if hasattr(member, "__discord_ui_model_type__"):
-                    children.append(member)
+            children.extend(
+                member
+                for member in base.__dict__.values()
+                if hasattr(member, "__discord_ui_model_type__")
+            )
 
         if len(children) > 25:
             raise TypeError("View cannot have more than 25 children")
 
         cls.__view_children_items__ = children
 
-    def __init__(self, *, timeout: Optional[float] = 180.0, auto_defer: bool = True) -> None:
+    def __init__(self, *, timeout: Optional[float] = 180.0, auto_defer: bool = True, prevent_update: bool = True) -> None:
         self.timeout = timeout
         self.auto_defer = auto_defer
+        self.prevent_update = True if timeout else prevent_update
         self.children: List[Item] = []
         for func in self.__view_children_items__:
             item: Item = func.__discord_ui_model_type__(**func.__discord_ui_model_kwargs__)


### PR DESCRIPTION
## Summary

Adding prevent_update to View. Option preventing storing permanent views for separate messages by default.
(since there's no limit to how many different buttons get stored, and if not stopped properly can cause issues over time when running a bot for long periods without reboot, and users are not notified of these being stored)

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
  - [x] I have updated the documentation to reflect the changes.
  - [x] I have run `task pyright` and fixed the relevant issues.
- [x] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
