### PR TITLE
feat(automod): regex patterns

### DIFF
--- a/nextcord/auto_moderation.py
+++ b/nextcord/auto_moderation.py
@@ -89,6 +89,7 @@ class AutoModerationTriggerMetadata:
 
             The flavor of regex used is Rust flavor and has no guarantees of working with
             the ``re`` module.
+            Each regex pattern must be 75 characters or less.
 
     presets: List[:class:`KeywordPresetType`]
         A list of Discord pre-defined wordsets which will be searched for in content.

--- a/nextcord/auto_moderation.py
+++ b/nextcord/auto_moderation.py
@@ -78,7 +78,7 @@ class AutoModerationTriggerMetadata:
             This is ``None`` and cannot be provided if the trigger type of the rule is not
             :attr:`AutoModerationTriggerType.keyword`.
     regex_patterns: Optional[List[:class:`str`]]
-        A list of regex patterns which will be matched with content.
+        A list of regex patterns which will be matched with content. Can only be up to 10 patterns.
 
         .. versionadded:: 2.4
 

--- a/nextcord/auto_moderation.py
+++ b/nextcord/auto_moderation.py
@@ -77,6 +77,19 @@ class AutoModerationTriggerMetadata:
 
             This is ``None`` and cannot be provided if the trigger type of the rule is not
             :attr:`AutoModerationTriggerType.keyword`.
+    regex_patterns: Optional[List[:class:`str`]]
+        A list of regex patterns which will be matched with content.
+
+        .. note::
+
+            This is ``None`` and cannot be provided if the trigger type of the rule is not
+            :attr:`AutoModerationTriggerType.keyword`.
+
+        .. warning::
+
+            The flavor of regex used is Rust flavor and has no guarantees of working with
+            the ``re`` module.
+
     presets: List[:class:`KeywordPresetType`]
         A list of Discord pre-defined wordsets which will be searched for in content.
 
@@ -105,17 +118,19 @@ class AutoModerationTriggerMetadata:
             This is ``None`` and cannot be provided if the trigger type of this rule is not :attr:`AutoModerationTriggerType.mention_spam`.
     """
 
-    __slots__ = ("keyword_filter", "presets", "allow_list", "mention_total_limit")
+    __slots__ = ("keyword_filter", "regex_patterns", "presets", "allow_list", "mention_total_limit")
 
     def __init__(
         self,
         *,
         keyword_filter: Optional[List[str]] = None,
+        regex_patterns: Optional[List[str]] = None,
         presets: Optional[List[KeywordPresetType]] = None,
         allow_list: Optional[List[str]] = None,
         mention_total_limit: Optional[int] = None,
     ) -> None:
         self.keyword_filter: Optional[List[str]] = keyword_filter
+        self.regex_patterns: Optional[List[str]] = regex_patterns
         self.presets: Optional[List[KeywordPresetType]] = presets
         self.allow_list: Optional[List[str]] = allow_list
         self.mention_total_limit: Optional[int] = mention_total_limit
@@ -123,6 +138,7 @@ class AutoModerationTriggerMetadata:
     @classmethod
     def from_data(cls, data: TriggerMetadataPayload):
         keyword_filter = data.get("keyword_filter")
+        regex_patterns = data.get("regex_patterns")
         presets = (
             [try_enum(KeywordPresetType, preset) for preset in data["presets"]]
             if "presets" in data
@@ -133,6 +149,7 @@ class AutoModerationTriggerMetadata:
 
         return cls(
             keyword_filter=keyword_filter,
+            regex_patterns=regex_patterns,
             presets=presets,
             allow_list=allow_list,
             mention_total_limit=mention_total_limit,
@@ -144,6 +161,9 @@ class AutoModerationTriggerMetadata:
 
         if self.keyword_filter is not None:
             payload["keyword_filter"] = self.keyword_filter
+
+        if self.regex_patterns is not None:
+            payload["regex_patterns"] = self.regex_patterns
 
         if self.presets is not None:
             payload["presets"] = [enum.value for enum in self.presets]

--- a/nextcord/auto_moderation.py
+++ b/nextcord/auto_moderation.py
@@ -80,6 +80,8 @@ class AutoModerationTriggerMetadata:
     regex_patterns: Optional[List[:class:`str`]]
         A list of regex patterns which will be matched with content.
 
+        .. versionadded:: 2.4
+
         .. note::
 
             This is ``None`` and cannot be provided if the trigger type of the rule is not

--- a/nextcord/auto_moderation.py
+++ b/nextcord/auto_moderation.py
@@ -90,7 +90,7 @@ class AutoModerationTriggerMetadata:
         .. warning::
 
             The flavor of regex used is Rust flavor and has no guarantees of working with
-            the ``re`` module.
+            the :mod:`re` module.
             Each regex pattern must be 75 characters or less.
 
     presets: List[:class:`KeywordPresetType`]

--- a/nextcord/types/auto_moderation.py
+++ b/nextcord/types/auto_moderation.py
@@ -36,6 +36,7 @@ AutoModerationActionType = Literal[1, 2, 3, 4]
 
 class AutoModerationTriggerMetadata(TypedDict, total=False):
     keyword_filter: List[str]
+    regex_patterns: List[str]
     presets: List[KeywordPresetType]
     allow_list: List[str]
     mention_total_limit: Optional[int]


### PR DESCRIPTION
## Summary

This PR adds support for regex patterns in automod trigger metadata. Closes #884.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
  - [x] I have updated the documentation to reflect the changes.
  - [ ] I have run `task pyright` and fixed the relevant issues.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
