### PR TITLE
fix: Unable to import nextcord.types.checks

### DIFF
--- a/nextcord/types/checks.py
+++ b/nextcord/types/checks.py
@@ -36,7 +36,8 @@ if TYPE_CHECKING:
     MaybeCoro = Union[T, Coro[T]]
     CoroFunc = Callable[..., Coro[Any]]
     ApplicationCheck = Union[
-        Callable[[ClientCog, Interaction], MaybeCoro[bool]], Callable[[Interaction], MaybeCoro[bool]]
+        Callable[[ClientCog, Interaction], MaybeCoro[bool]],
+        Callable[[Interaction], MaybeCoro[bool]],
     ]
     ApplicationHook = Union[
         Callable[[ClientCog, Interaction], Coro[Any]], Callable[[Interaction], Coro[Any]]

--- a/nextcord/types/checks.py
+++ b/nextcord/types/checks.py
@@ -23,12 +23,11 @@ FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 """
 
-from typing import TYPE_CHECKING, Any, Callable, Coroutine, TypeVar, Union
+from typing import Any, Callable, Coroutine, TypeVar, Union
 
-if TYPE_CHECKING:
-    from nextcord.application_command import ClientCog
+from nextcord.application_command import ClientCog
 
-    from ..interactions import Interaction
+from ..interactions import Interaction
 
 T = TypeVar("T")
 

--- a/nextcord/types/checks.py
+++ b/nextcord/types/checks.py
@@ -23,24 +23,25 @@ FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 """
 
-from typing import Any, Callable, Coroutine, TypeVar, Union
+from typing import TYPE_CHECKING, Any, Callable, Coroutine, TypeVar, Union
 
-from nextcord.application_command import ClientCog
+if TYPE_CHECKING:
+    from nextcord.application_command import ClientCog
 
-from ..interactions import Interaction
+    from ..interactions import Interaction
 
-T = TypeVar("T")
+    T = TypeVar("T")
 
-Coro = Coroutine[Any, Any, T]
-MaybeCoro = Union[T, Coro[T]]
-CoroFunc = Callable[..., Coro[Any]]
-ApplicationCheck = Union[
-    Callable[[ClientCog, Interaction], MaybeCoro[bool]], Callable[[Interaction], MaybeCoro[bool]]
-]
-ApplicationHook = Union[
-    Callable[[ClientCog, Interaction], Coro[Any]], Callable[[Interaction], Coro[Any]]
-]
-ApplicationErrorCallback = Union[
-    Callable[[ClientCog, Interaction, Exception], Coro[Any]],
-    Callable[[Interaction, Exception], Coro[Any]],
-]
+    Coro = Coroutine[Any, Any, T]
+    MaybeCoro = Union[T, Coro[T]]
+    CoroFunc = Callable[..., Coro[Any]]
+    ApplicationCheck = Union[
+        Callable[[ClientCog, Interaction], MaybeCoro[bool]], Callable[[Interaction], MaybeCoro[bool]]
+    ]
+    ApplicationHook = Union[
+        Callable[[ClientCog, Interaction], Coro[Any]], Callable[[Interaction], Coro[Any]]
+    ]
+    ApplicationErrorCallback = Union[
+        Callable[[ClientCog, Interaction, Exception], Coro[Any]],
+        Callable[[Interaction, Exception], Coro[Any]],
+    ]


### PR DESCRIPTION
## Summary

This module contained imports in TYPE_CHECKING were used outside of annotations, causing the module to not import properly with a NameError.

```py
>>> import nextcord.types.checks
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "nextcord/types/checks.py", line 39, in <module>
    Callable[[ClientCog, Interaction], MaybeCoro[bool]], Callable[[Interaction], MaybeCoro[bool]]
NameError: name 'ClientCog' is not defined
```

Since all of the symbols in this file are only imported in TYPE_CHECKING, they don't need to be defined outside.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
  - [ ] I have updated the documentation to reflect the changes.
  - [ ] I have run `task pyright` and fixed the relevant issues.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
