### PR TITLE
fix: last_message_id not updating on VoiceChannel

### DIFF
--- a/nextcord/state.py
+++ b/nextcord/state.py
@@ -1273,8 +1273,8 @@ class ConnectionState:
         self.dispatch("message", message)
         if self._messages is not None:
             self._messages.append(message)
-        # we ensure that the channel is either a TextChannel, ForumChannel or Thread
-        if channel and channel.__class__ in (TextChannel, ForumChannel, Thread):
+        # we ensure that the channel is either a TextChannel, ForumChannel, Thread or VoiceChannel
+        if channel and channel.__class__ in (TextChannel, ForumChannel, Thread, VoiceChannel):
             channel.last_message_id = message.id  # type: ignore
 
     def parse_message_delete(self, data) -> None:


### PR DESCRIPTION
## Summary

<!-- What is this pull request for? Does it fix any issues? -->
Fixing last_message_id not being updated for VoiceChannel 

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
  - [ ] I have updated the documentation to reflect the changes.
  - [x] I have run `task pyright` and fixed the relevant issues.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
