### PR TITLE
refactor: use explicit union[str, int] with *HasRole errors

### DIFF
--- a/nextcord/ext/application_checks/errors.py
+++ b/nextcord/ext/application_checks/errors.py
@@ -28,7 +28,6 @@ from nextcord.channel import PartialMessageable
 from nextcord.errors import ApplicationCheckFailure
 from nextcord.interactions import Interaction
 from nextcord.threads import Thread
-from nextcord.types.snowflake import Snowflake, SnowflakeList
 
 __all__ = (
     "ApplicationCheckAnyFailure",
@@ -94,8 +93,8 @@ class ApplicationMissingRole(ApplicationCheckFailure):
         This is the parameter passed to :func:`~.application_checks.has_role`.
     """
 
-    def __init__(self, missing_role: Snowflake) -> None:
-        self.missing_role: Snowflake = missing_role
+    def __init__(self, missing_role: Union[str, int]) -> None:
+        self.missing_role: Union[str, int] = missing_role
         message = f"Role {missing_role!r} is required to run this command."
         super().__init__(message)
 
@@ -113,8 +112,8 @@ class ApplicationMissingAnyRole(ApplicationCheckFailure):
         These are the parameters passed to :func:`has_any_role`.
     """
 
-    def __init__(self, missing_roles: SnowflakeList) -> None:
-        self.missing_roles: SnowflakeList = missing_roles
+    def __init__(self, missing_roles: List[Union[str, int]]) -> None:
+        self.missing_roles: List[Union[str, int]] = missing_roles
 
         missing = [f"'{role}'" for role in missing_roles]
 
@@ -141,8 +140,8 @@ class ApplicationBotMissingRole(ApplicationCheckFailure):
         This is the parameter passed to :func:`has_role`.
     """
 
-    def __init__(self, missing_role: Snowflake) -> None:
-        self.missing_role: Snowflake = missing_role
+    def __init__(self, missing_role: Union[str, int]) -> None:
+        self.missing_role: Union[str, int] = missing_role
         message = f"Bot requires the role {missing_role!r} to run this command"
         super().__init__(message)
 
@@ -163,8 +162,8 @@ class ApplicationBotMissingAnyRole(ApplicationCheckFailure):
 
     """
 
-    def __init__(self, missing_roles: SnowflakeList) -> None:
-        self.missing_roles: SnowflakeList = missing_roles
+    def __init__(self, missing_roles: List[Union[str, int]]) -> None:
+        self.missing_roles: List[Union[str, int]] = missing_roles
 
         missing = [f"'{role}'" for role in missing_roles]
 
@@ -265,7 +264,7 @@ class ApplicationNSFWChannelRequired(ApplicationCheckFailure):
     """
 
     def __init__(self, channel: Optional[Union[GuildChannel, Thread, PartialMessageable]]) -> None:
-        self.channel = channel
+        self.channel: Optional[Union[GuildChannel, Thread, PartialMessageable]] = channel
         super().__init__(f"Channel '{channel}' needs to be NSFW for this command to work.")
 
 

--- a/nextcord/ext/commands/errors.py
+++ b/nextcord/ext/commands/errors.py
@@ -33,7 +33,6 @@ if TYPE_CHECKING:
 
     from nextcord.abc import GuildChannel
     from nextcord.threads import Thread
-    from nextcord.types.snowflake import Snowflake, SnowflakeList
 
     from .context import Context
     from .converter import Converter
@@ -652,8 +651,8 @@ class MissingRole(CheckFailure):
         This is the parameter passed to :func:`~.commands.has_role`.
     """
 
-    def __init__(self, missing_role: Snowflake) -> None:
-        self.missing_role: Snowflake = missing_role
+    def __init__(self, missing_role: Union[str, int]) -> None:
+        self.missing_role: Union[str, int] = missing_role
         message = f"Role {missing_role!r} is required to run this command."
         super().__init__(message)
 
@@ -672,8 +671,8 @@ class BotMissingRole(CheckFailure):
         This is the parameter passed to :func:`~.commands.has_role`.
     """
 
-    def __init__(self, missing_role: Snowflake) -> None:
-        self.missing_role: Snowflake = missing_role
+    def __init__(self, missing_role: Union[str, int]) -> None:
+        self.missing_role: Union[str, int] = missing_role
         message = f"Bot requires the role {missing_role!r} to run this command"
         super().__init__(message)
 
@@ -693,8 +692,8 @@ class MissingAnyRole(CheckFailure):
         These are the parameters passed to :func:`~.commands.has_any_role`.
     """
 
-    def __init__(self, missing_roles: SnowflakeList) -> None:
-        self.missing_roles: SnowflakeList = missing_roles
+    def __init__(self, missing_roles: List[Union[str, int]]) -> None:
+        self.missing_roles: List[Union[str, int]] = missing_roles
 
         missing = [f"'{role}'" for role in missing_roles]
 
@@ -723,8 +722,8 @@ class BotMissingAnyRole(CheckFailure):
 
     """
 
-    def __init__(self, missing_roles: SnowflakeList) -> None:
-        self.missing_roles: SnowflakeList = missing_roles
+    def __init__(self, missing_roles: List[Union[str, int]]) -> None:
+        self.missing_roles: List[Union[str, int]] = missing_roles
 
         missing = [f"'{role}'" for role in missing_roles]
 


### PR DESCRIPTION
## Summary

Removes the use of Snowflake and SnowflakeList, since they are used wrongly. Also makes that super explicit type hinting a consistent thing over the whole file.

Testing not needed, just type hinting for already used things.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
  - [X] I have updated the documentation to reflect the changes.
  - [ ] I have run `task pyright` and fixed the relevant issues.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
