### PR TITLE
refactor(app-checks): correctly type ApplicationCheckAnyFailure

### DIFF
--- a/nextcord/ext/application_checks/errors.py
+++ b/nextcord/ext/application_checks/errors.py
@@ -61,11 +61,11 @@ class ApplicationCheckAnyFailure(ApplicationCheckFailure):
 
     def __init__(
         self,
-        checks: List[ApplicationCheckFailure],
-        errors: List[Callable[[Interaction], bool]],
+        checks: List[Callable[[Interaction], bool]],
+        errors: List[ApplicationCheckFailure],
     ) -> None:
-        self.checks: List[ApplicationCheckFailure] = checks
-        self.errors: List[Callable[[Interaction], bool]] = errors
+        self.checks: List[Callable[[Interaction], bool]] = checks
+        self.errors: List[ApplicationCheckFailure] = errors
         super().__init__("You do not have permission to run this command.")
 
 


### PR DESCRIPTION
## Summary

I just swapped the type hints, since they were the wrong way around. The doc string was right before, but the actual type hints were swapped for some reason. My linter was screaming at me, that's how I noticed.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
  - [X] I have updated the documentation to reflect the changes.
  - [ ] I have run `task pyright` and fixed the relevant issues.
- [X] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
