### PR TITLE
feat(flags): add `ACTIVE_APPLICATION` & `ACTIVE_DEVELOPER` flags

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -1498,7 +1498,6 @@ of :class:`enum.Enum`.
     .. attribute:: known_spammer
 
         The user is a Known Spammer.
-
     .. attribute:: active_developer
 
         The user is an Active Developer.

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -1501,7 +1501,7 @@ of :class:`enum.Enum`.
 
     .. attribute:: active_developer
 
-        The user is an Acive Developer.
+        The user is an Active Developer.
 
 .. class:: ActivityType
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -1502,6 +1502,8 @@ of :class:`enum.Enum`.
 
         The user is an Active Developer.
 
+        .. versionadded:: 2.4
+
 .. class:: ActivityType
 
     Specifies the type of :class:`Activity`. This is used to check how to

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -1499,6 +1499,10 @@ of :class:`enum.Enum`.
 
         The user is a Known Spammer.
 
+    .. attribute:: active_developer
+
+        The user is an Acive Developer.
+
 .. class:: ActivityType
 
     Specifies the type of :class:`Activity`. This is used to check how to

--- a/nextcord/enums.py
+++ b/nextcord/enums.py
@@ -473,6 +473,7 @@ class UserFlags(IntEnum):
     verified_bot_developer = 131072
     discord_certified_moderator = 262144
     known_spammer = 1048576
+    active_developer = 4194304
 
 
 class ActivityType(IntEnum):

--- a/nextcord/flags.py
+++ b/nextcord/flags.py
@@ -488,9 +488,9 @@ class PublicUserFlags(BaseFlags):
 
     @flag_value
     def active_developer(self):
-        """:class:`bool`: Returns ``True`` if the user is a Known Spammer.
+        """:class:`bool`: Returns ``True`` if the user is a Active Developer
 
-        .. versionadded:: 2.0
+        .. versionadded:: 2.4
         """
         return UserFlags.active_developer.value
 

--- a/nextcord/flags.py
+++ b/nextcord/flags.py
@@ -488,7 +488,7 @@ class PublicUserFlags(BaseFlags):
 
     @flag_value
     def active_developer(self):
-        """:class:`bool`: Returns ``True`` if the user is a Active Developer
+        """:class:`bool`: Returns ``True`` if the user is a Active Developer.
 
         .. versionadded:: 2.4
         """

--- a/nextcord/flags.py
+++ b/nextcord/flags.py
@@ -488,7 +488,7 @@ class PublicUserFlags(BaseFlags):
 
     @flag_value
     def active_developer(self):
-        """:class:`bool`: Returns ``True`` if the user is a Active Developer.
+        """:class:`bool`: Returns ``True`` if the user is an Active Developer.
 
         .. versionadded:: 2.4
         """

--- a/nextcord/flags.py
+++ b/nextcord/flags.py
@@ -1257,5 +1257,8 @@ class ApplicationFlags(BaseFlags):
 
     @flag_value
     def active(self):
-        """:class:`bool`: Returns ``True`` if the application is considered active. This means that it has had any global command executed in the past 30 days."""
+        """:class:`bool`: Returns ``True`` if the application is considered active. This means that it has had any global command executed in the past 30 days.
+
+        .. versionadded:: 2.4
+        """
         return 1 << 24

--- a/nextcord/flags.py
+++ b/nextcord/flags.py
@@ -486,6 +486,14 @@ class PublicUserFlags(BaseFlags):
         """
         return UserFlags.known_spammer.value
 
+    @flag_value
+    def active_developer(self):
+        """:class:`bool`: Returns ``True`` if the user is a Known Spammer.
+
+        .. versionadded:: 2.0
+        """
+        return UserFlags.active_developer.value
+
     def all(self) -> List[UserFlags]:
         """List[:class:`UserFlags`]: Returns all public flags the user has."""
         return [public_flag for public_flag in UserFlags if self._has_flag(public_flag.value)]

--- a/nextcord/flags.py
+++ b/nextcord/flags.py
@@ -1254,3 +1254,8 @@ class ApplicationFlags(BaseFlags):
     def application_command_badge(self):
         """:class:`bool`: Returns ``True`` if the application has registered global application commands."""
         return 1 << 23
+
+    @flag_value
+    def active(self):
+        """:class:`bool`: Returns ``True`` if the application is considered active. This means that it has had any global command executed in the past 30 days."""
+        return 1 << 24


### PR DESCRIPTION
## Summary

This implements the `ACTIVE_DEVELOPER` flag from https://github.com/discord/discord-api-docs/pull/5619 and https://github.com/discord/discord-api-docs/pull/5620 (Not merged yet).

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
  - [ ] I have updated the documentation to reflect the changes.
  - [ ] I have run `task pyright` and fixed the relevant issues.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
