### PR TITLE
fix(app-cmds): issubclass check failed w/ normal objects

### DIFF
--- a/nextcord/application_command.py
+++ b/nextcord/application_command.py
@@ -760,7 +760,8 @@ class CallbackMixin:
                     # could be a self or interaction parameter
                     param.annotation is param.empty
                     # will always be an interaction parameter
-                    or isinstance(param.annotation, type) and issubclass(param.annotation, Interaction)
+                    or isinstance(param.annotation, type)
+                    and issubclass(param.annotation, Interaction)
                     # will always be a self parameter
                     # TODO: use typing.Self when 3.11 is standard
                     or param.annotation is typing_extensions.Self

--- a/nextcord/application_command.py
+++ b/nextcord/application_command.py
@@ -756,12 +756,14 @@ class CallbackMixin:
                 # TODO: use typing.get_type_hints when 3.9 is standard
                 typehints = typing_extensions.get_type_hints(self.callback, include_extras=True)
                 callback_params = dict(signature(self.callback).parameters)
-                
+
                 for name, param in callback_params.copy().items():
                     if isinstance(param.annotation, str):
                         # Thank you Disnake for the guidance to use this.
-                        callback_params[name] = param.replace(annotation=typehints.get(name, param.empty))
-                
+                        callback_params[name] = param.replace(
+                            annotation=typehints.get(name, param.empty)
+                        )
+
                 non_option_params = sum(
                     # could be a self or interaction parameter
                     param.annotation is param.empty

--- a/nextcord/application_command.py
+++ b/nextcord/application_command.py
@@ -755,7 +755,13 @@ class CallbackMixin:
 
                 # TODO: use typing.get_type_hints when 3.9 is standard
                 typehints = typing_extensions.get_type_hints(self.callback, include_extras=True)
-                callback_params = signature(self.callback).parameters
+                callback_params = dict(signature(self.callback).parameters)
+                
+                for name, param in callback_params.copy().items():
+                    if isinstance(param.annotation, str):
+                        # Thank you Disnake for the guidance to use this.
+                        callback_params[name] = param.replace(annotation=typehints.get(name, param.empty))
+                
                 non_option_params = sum(
                     # could be a self or interaction parameter
                     param.annotation is param.empty
@@ -785,10 +791,6 @@ class CallbackMixin:
                     if skip_counter:
                         skip_counter -= 1
                     else:
-                        if isinstance(param.annotation, str):
-                            # Thank you Disnake for the guidance to use this.
-                            param = param.replace(annotation=typehints.get(name, param.empty))
-
                         arg = option_class(param, self, parent_cog=self.parent_cog)  # type: ignore
                         # this is a mixin, so `self` would be odd here
 

--- a/nextcord/application_command.py
+++ b/nextcord/application_command.py
@@ -760,8 +760,8 @@ class CallbackMixin:
                     # could be a self or interaction parameter
                     param.annotation is param.empty
                     # will always be an interaction parameter
-                    or isinstance(param.annotation, type)
-                    and issubclass(param.annotation, Interaction)
+                    or (isinstance(param.annotation, type)
+                    and issubclass(param.annotation, Interaction))
                     # will always be a self parameter
                     # TODO: use typing.Self when 3.11 is standard
                     or param.annotation is typing_extensions.Self

--- a/nextcord/application_command.py
+++ b/nextcord/application_command.py
@@ -760,7 +760,7 @@ class CallbackMixin:
                     # could be a self or interaction parameter
                     param.annotation is param.empty
                     # will always be an interaction parameter
-                    or issubclass(param.annotation, Interaction)
+                    or isinstance(param.annotation, type) and issubclass(param.annotation, Interaction)
                     # will always be a self parameter
                     # TODO: use typing.Self when 3.11 is standard
                     or param.annotation is typing_extensions.Self

--- a/nextcord/application_command.py
+++ b/nextcord/application_command.py
@@ -760,8 +760,10 @@ class CallbackMixin:
                     # could be a self or interaction parameter
                     param.annotation is param.empty
                     # will always be an interaction parameter
-                    or (isinstance(param.annotation, type)
-                    and issubclass(param.annotation, Interaction))
+                    or (
+                        isinstance(param.annotation, type)
+                        and issubclass(param.annotation, Interaction)
+                    )
                     # will always be a self parameter
                     # TODO: use typing.Self when 3.11 is standard
                     or param.annotation is typing_extensions.Self


### PR DESCRIPTION
## Summary

This PR fixes (yet) another problem with #736 where the `issubclass` clause did not first check if the annotation was even a class.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
  - [ ] I have updated the documentation to reflect the changes.
  - [ ] I have run `task pyright` and fixed the relevant issues.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
