### PR TITLE
refactor(abc): remove the use of ** for GuildChannel.move

### DIFF
--- a/nextcord/abc.py
+++ b/nextcord/abc.py
@@ -1029,7 +1029,7 @@ class GuildChannel:
         bucket = self._sorting_bucket
         # fmt: off
         channels: List[GuildChannel]
-        if category not in (MISSING, None):
+        if category:
             parent_id = category.id
             channels = [
                 ch

--- a/nextcord/abc.py
+++ b/nextcord/abc.py
@@ -977,20 +977,24 @@ class GuildChannel:
 
         .. versionadded:: 1.7
 
+        .. versionchanged:: 2.4
+
+            ``beginning``, ``end``, ``before``, ``after`` and ``reason`` now accept ``None``.
+
         Parameters
         ----------
-        beginning: :class:`bool`
+        beginning: Optional[:class:`bool`]
             Whether to move the channel to the beginning of the
             channel list (or category if given).
             This is mutually exclusive with ``end``, ``before``, and ``after``.
-        end: :class:`bool`
+        end: Optional[:class:`bool`]
             Whether to move the channel to the end of the
             channel list (or category if given).
             This is mutually exclusive with ``beginning``, ``before``, and ``after``.
-        before: :class:`~nextcord.abc.Snowflake`
+        before: Optional[:class:`~nextcord.abc.Snowflake`]
             The channel that should be before our current channel.
             This is mutually exclusive with ``beginning``, ``end``, and ``after``.
-        after: :class:`~nextcord.abc.Snowflake`
+        after: Optional[:class:`~nextcord.abc.Snowflake`]
             The channel that should be after our current channel.
             This is mutually exclusive with ``beginning``, ``end``, and ``before``.
         offset: :class:`int`
@@ -1006,7 +1010,7 @@ class GuildChannel:
             This parameter is ignored if moving a category channel.
         sync_permissions: :class:`bool`
             Whether to sync the permissions with the category (if given).
-        reason: :class:`str`
+        reason: Optional[:class:`str`]
             The reason for the move.
 
         Raises

--- a/nextcord/abc.py
+++ b/nextcord/abc.py
@@ -1073,7 +1073,7 @@ class GuildChannel:
         payload = []
 
         for index, channel in enumerate(channels):
-            d: dict[str, Any] = {"id": channel.id, "position": index}
+            d: Dict[str, Any] = {"id": channel.id, "position": index}
             if category is not MISSING and channel.id == self.id:
                 d.update(parent_id=parent_id, lock_permissions=sync_permissions)
             payload.append(d)

--- a/nextcord/abc.py
+++ b/nextcord/abc.py
@@ -907,7 +907,7 @@ class GuildChannel:
         *,
         beginning: bool,
         offset: int = ...,
-        category: Optional[Snowflake] = None,
+        category: Optional[Snowflake] = ...,
         sync_permissions: bool = ...,
         reason: Optional[str] = None,
     ) -> None:
@@ -919,7 +919,7 @@ class GuildChannel:
         *,
         end: bool,
         offset: int = ...,
-        category: Optional[Snowflake] = None,
+        category: Optional[Snowflake] = ...,
         sync_permissions: bool = ...,
         reason: Optional[str] = None,
     ) -> None:
@@ -931,7 +931,7 @@ class GuildChannel:
         *,
         before: Snowflake,
         offset: int = ...,
-        category: Optional[Snowflake] = None,
+        category: Optional[Snowflake] = ...,
         sync_permissions: bool = ...,
         reason: Optional[str] = None,
     ) -> None:
@@ -943,7 +943,7 @@ class GuildChannel:
         *,
         after: Snowflake,
         offset: int = ...,
-        category: Optional[Snowflake] = None,
+        category: Optional[Snowflake] = ...,
         sync_permissions: bool = ...,
         reason: Optional[str] = None,
     ) -> None:
@@ -957,7 +957,7 @@ class GuildChannel:
         before: Optional[Snowflake] = None,
         after: Optional[Snowflake] = None,
         offset: int = 0,
-        category: Optional[Snowflake] = None,
+        category: Optional[Snowflake] = MISSING,
         sync_permissions: bool = False,
         reason: Optional[str] = None,
     ) -> None:
@@ -1029,7 +1029,7 @@ class GuildChannel:
         bucket = self._sorting_bucket
         # fmt: off
         channels: List[GuildChannel]
-        if category is not None:
+        if category not in (MISSING, None):
             parent_id = category.id
             channels = [
                 ch
@@ -1073,8 +1073,8 @@ class GuildChannel:
         payload = []
 
         for index, channel in enumerate(channels):
-            d = {"id": channel.id, "position": index}
-            if parent_id is not None and channel.id == self.id:
+            d: dict[str, Any] = {"id": channel.id, "position": index}
+            if category is not MISSING and channel.id == self.id:
                 d.update(parent_id=parent_id, lock_permissions=sync_permissions)
             payload.append(d)
 


### PR DESCRIPTION
## Summary

Similar to #695 and #719, this removes the use of `**` catchall options for `abc.GuildChannel.move`.
<!-- What is this pull request for? Does it fix any issues? -->

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
  - [x] I have updated the documentation to reflect the changes.
  - [x] I have run `task pyright` and fixed the relevant issues.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
