### PR TITLE
refactor: use typing_extensions.Self over typevars

### DIFF
--- a/nextcord/abc.py
+++ b/nextcord/abc.py
@@ -72,6 +72,8 @@ T = TypeVar("T", bound=VoiceProtocol)
 if TYPE_CHECKING:
     from datetime import datetime
 
+    from typing_extensions import Self
+
     from .asset import Asset
     from .channel import CategoryChannel, DMChannel, GroupChannel, PartialMessageable, TextChannel
     from .client import Client
@@ -848,12 +850,12 @@ class GuildChannel:
             raise InvalidArgument("Invalid overwrite type provided.")
 
     async def _clone_impl(
-        self: GCH,
+        self,
         base_attrs: Dict[str, Any],
         *,
         name: Optional[str] = None,
         reason: Optional[str] = None,
-    ) -> GCH:
+    ) -> Self:
         base_attrs["permission_overwrites"] = [x._asdict() for x in self._overwrites]
         base_attrs["parent_id"] = self.category_id
         base_attrs["name"] = name or self.name
@@ -868,7 +870,7 @@ class GuildChannel:
         self.guild._channels[obj.id] = obj  # type: ignore
         return obj
 
-    async def clone(self: GCH, *, name: Optional[str] = None, reason: Optional[str] = None) -> GCH:
+    async def clone(self, *, name: Optional[str] = None, reason: Optional[str] = None) -> Self:
         """|coro|
 
         Clones this channel. This creates a channel with the same properties

--- a/nextcord/channel.py
+++ b/nextcord/channel.py
@@ -39,7 +39,6 @@ from typing import (
     Optional,
     Sequence,
     Tuple,
-    Type,
     TypeVar,
     Union,
     overload,
@@ -79,6 +78,8 @@ __all__ = (
 )
 
 if TYPE_CHECKING:
+    from typing_extensions import Self
+
     from .abc import Snowflake, SnowflakeTime
     from .embeds import Embed
     from .guild import Guild, GuildChannel as GuildChannelType
@@ -2408,8 +2409,8 @@ class DMChannel(abc.Messageable, abc.PrivateChannel, Hashable, PinsMixin):
         return f"<DMChannel id={self.id} recipient={self.recipient!r}>"
 
     @classmethod
-    def _from_message(cls: Type[DMC], state: ConnectionState, channel_id: int) -> DMC:
-        self: DMC = cls.__new__(cls)
+    def _from_message(cls, state: ConnectionState, channel_id: int) -> Self:
+        self = cls.__new__(cls)
         self._state = state
         self.id = channel_id
         self.recipient = None

--- a/nextcord/colour.py
+++ b/nextcord/colour.py
@@ -24,7 +24,10 @@ DEALINGS IN THE SOFTWARE.
 
 import colorsys
 import random
-from typing import Any, Optional, Tuple, Type, TypeVar, Union
+from typing import TYPE_CHECKING, Any, Optional, Tuple, TypeVar, Union
+
+if TYPE_CHECKING:
+    from typing_extensions import Self
 
 __all__ = (
     "Colour",
@@ -117,25 +120,23 @@ class Colour:
         return (self.r, self.g, self.b)
 
     @classmethod
-    def from_rgb(cls: Type[CT], r: int, g: int, b: int) -> CT:
+    def from_rgb(cls, r: int, g: int, b: int) -> Self:
         """Constructs a :class:`Colour` from an RGB tuple."""
         return cls((r << 16) + (g << 8) + b)
 
     @classmethod
-    def from_hsv(cls: Type[CT], h: float, s: float, v: float) -> CT:
+    def from_hsv(cls, h: float, s: float, v: float) -> Self:
         """Constructs a :class:`Colour` from an HSV tuple."""
         rgb = colorsys.hsv_to_rgb(h, s, v)
         return cls.from_rgb(*(int(x * 255) for x in rgb))
 
     @classmethod
-    def default(cls: Type[CT]) -> CT:
+    def default(cls) -> Self:
         """A factory method that returns a :class:`Colour` with a value of ``0``."""
         return cls(0)
 
     @classmethod
-    def random(
-        cls: Type[CT], *, seed: Optional[Union[int, str, float, bytes, bytearray]] = None
-    ) -> CT:
+    def random(cls, *, seed: Optional[Union[int, str, float, bytes, bytearray]] = None) -> Self:
         """A factory method that returns a :class:`Colour` with a random hue.
 
         .. note::
@@ -156,17 +157,17 @@ class Colour:
         return cls.from_hsv(rand.random(), 1, 1)
 
     @classmethod
-    def teal(cls: Type[CT]) -> CT:
+    def teal(cls) -> Self:
         """A factory method that returns a :class:`Colour` with a value of ``0x1abc9c``."""
         return cls(0x1ABC9C)
 
     @classmethod
-    def dark_teal(cls: Type[CT]) -> CT:
+    def dark_teal(cls) -> Self:
         """A factory method that returns a :class:`Colour` with a value of ``0x11806a``."""
         return cls(0x11806A)
 
     @classmethod
-    def brand_green(cls: Type[CT]) -> CT:
+    def brand_green(cls) -> Self:
         """A factory method that returns a :class:`Colour` with a value of ``0x57F287``.
 
         .. versionadded:: 2.0
@@ -174,67 +175,67 @@ class Colour:
         return cls(0x57F287)
 
     @classmethod
-    def green(cls: Type[CT]) -> CT:
+    def green(cls) -> Self:
         """A factory method that returns a :class:`Colour` with a value of ``0x2ecc71``."""
         return cls(0x2ECC71)
 
     @classmethod
-    def dark_green(cls: Type[CT]) -> CT:
+    def dark_green(cls) -> Self:
         """A factory method that returns a :class:`Colour` with a value of ``0x1f8b4c``."""
         return cls(0x1F8B4C)
 
     @classmethod
-    def blue(cls: Type[CT]) -> CT:
+    def blue(cls) -> Self:
         """A factory method that returns a :class:`Colour` with a value of ``0x3498db``."""
         return cls(0x3498DB)
 
     @classmethod
-    def dark_blue(cls: Type[CT]) -> CT:
+    def dark_blue(cls) -> Self:
         """A factory method that returns a :class:`Colour` with a value of ``0x206694``."""
         return cls(0x206694)
 
     @classmethod
-    def purple(cls: Type[CT]) -> CT:
+    def purple(cls) -> Self:
         """A factory method that returns a :class:`Colour` with a value of ``0x9b59b6``."""
         return cls(0x9B59B6)
 
     @classmethod
-    def dark_purple(cls: Type[CT]) -> CT:
+    def dark_purple(cls) -> Self:
         """A factory method that returns a :class:`Colour` with a value of ``0x71368a``."""
         return cls(0x71368A)
 
     @classmethod
-    def magenta(cls: Type[CT]) -> CT:
+    def magenta(cls) -> Self:
         """A factory method that returns a :class:`Colour` with a value of ``0xe91e63``."""
         return cls(0xE91E63)
 
     @classmethod
-    def dark_magenta(cls: Type[CT]) -> CT:
+    def dark_magenta(cls) -> Self:
         """A factory method that returns a :class:`Colour` with a value of ``0xad1457``."""
         return cls(0xAD1457)
 
     @classmethod
-    def gold(cls: Type[CT]) -> CT:
+    def gold(cls) -> Self:
         """A factory method that returns a :class:`Colour` with a value of ``0xf1c40f``."""
         return cls(0xF1C40F)
 
     @classmethod
-    def dark_gold(cls: Type[CT]) -> CT:
+    def dark_gold(cls) -> Self:
         """A factory method that returns a :class:`Colour` with a value of ``0xc27c0e``."""
         return cls(0xC27C0E)
 
     @classmethod
-    def orange(cls: Type[CT]) -> CT:
+    def orange(cls) -> Self:
         """A factory method that returns a :class:`Colour` with a value of ``0xe67e22``."""
         return cls(0xE67E22)
 
     @classmethod
-    def dark_orange(cls: Type[CT]) -> CT:
+    def dark_orange(cls) -> Self:
         """A factory method that returns a :class:`Colour` with a value of ``0xa84300``."""
         return cls(0xA84300)
 
     @classmethod
-    def brand_red(cls: Type[CT]) -> CT:
+    def brand_red(cls) -> Self:
         """A factory method that returns a :class:`Colour` with a value of ``0xED4245``.
 
         .. versionadded:: 2.0
@@ -242,60 +243,60 @@ class Colour:
         return cls(0xED4245)
 
     @classmethod
-    def red(cls: Type[CT]) -> CT:
+    def red(cls) -> Self:
         """A factory method that returns a :class:`Colour` with a value of ``0xe74c3c``."""
         return cls(0xE74C3C)
 
     @classmethod
-    def dark_red(cls: Type[CT]) -> CT:
+    def dark_red(cls) -> Self:
         """A factory method that returns a :class:`Colour` with a value of ``0x992d22``."""
         return cls(0x992D22)
 
     @classmethod
-    def lighter_grey(cls: Type[CT]) -> CT:
+    def lighter_grey(cls) -> Self:
         """A factory method that returns a :class:`Colour` with a value of ``0x95a5a6``."""
         return cls(0x95A5A6)
 
     lighter_gray = lighter_grey
 
     @classmethod
-    def dark_grey(cls: Type[CT]) -> CT:
+    def dark_grey(cls) -> Self:
         """A factory method that returns a :class:`Colour` with a value of ``0x607d8b``."""
         return cls(0x607D8B)
 
     dark_gray = dark_grey
 
     @classmethod
-    def light_grey(cls: Type[CT]) -> CT:
+    def light_grey(cls) -> Self:
         """A factory method that returns a :class:`Colour` with a value of ``0x979c9f``."""
         return cls(0x979C9F)
 
     light_gray = light_grey
 
     @classmethod
-    def darker_grey(cls: Type[CT]) -> CT:
+    def darker_grey(cls) -> Self:
         """A factory method that returns a :class:`Colour` with a value of ``0x546e7a``."""
         return cls(0x546E7A)
 
     darker_gray = darker_grey
 
     @classmethod
-    def og_blurple(cls: Type[CT]) -> CT:
+    def og_blurple(cls) -> Self:
         """A factory method that returns a :class:`Colour` with a value of ``0x7289da``."""
         return cls(0x7289DA)
 
     @classmethod
-    def blurple(cls: Type[CT]) -> CT:
+    def blurple(cls) -> Self:
         """A factory method that returns a :class:`Colour` with a value of ``0x5865F2``."""
         return cls(0x5865F2)
 
     @classmethod
-    def greyple(cls: Type[CT]) -> CT:
+    def greyple(cls) -> Self:
         """A factory method that returns a :class:`Colour` with a value of ``0x99aab5``."""
         return cls(0x99AAB5)
 
     @classmethod
-    def dark_theme(cls: Type[CT]) -> CT:
+    def dark_theme(cls) -> Self:
         """A factory method that returns a :class:`Colour` with a value of ``0x36393F``.
         This will appear transparent on Discord's dark theme.
 
@@ -304,7 +305,7 @@ class Colour:
         return cls(0x36393F)
 
     @classmethod
-    def fuchsia(cls: Type[CT]) -> CT:
+    def fuchsia(cls) -> Self:
         """A factory method that returns a :class:`Colour` with a value of ``0xEB459E``.
 
         .. versionadded:: 2.0
@@ -312,7 +313,7 @@ class Colour:
         return cls(0xEB459E)
 
     @classmethod
-    def yellow(cls: Type[CT]) -> CT:
+    def yellow(cls) -> Self:
         """A factory method that returns a :class:`Colour` with a value of ``0xFEE75C``.
 
         .. versionadded:: 2.0

--- a/nextcord/components.py
+++ b/nextcord/components.py
@@ -24,13 +24,15 @@ DEALINGS IN THE SOFTWARE.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, ClassVar, Dict, List, Optional, Tuple, Type, TypeVar, Union
+from typing import TYPE_CHECKING, Any, ClassVar, Dict, List, Optional, Tuple, TypeVar, Union
 
 from .enums import ButtonStyle, ComponentType, TextInputStyle, try_enum
 from .partial_emoji import PartialEmoji, _EmojiTag
 from .utils import MISSING, get_slots
 
 if TYPE_CHECKING:
+    from typing_extensions import Self
+
     from .channel import ChannelType
     from .emoji import Emoji
     from .types.components import (
@@ -94,8 +96,8 @@ class Component:
         return f"<{self.__class__.__name__} {attrs}>"
 
     @classmethod
-    def _raw_construct(cls: Type[C], **kwargs) -> C:
-        self: C = cls.__new__(cls)
+    def _raw_construct(cls, **kwargs) -> Self:
+        self = cls.__new__(cls)
         for slot in get_slots(cls):
             try:
                 value = kwargs[slot]

--- a/nextcord/context_managers.py
+++ b/nextcord/context_managers.py
@@ -30,6 +30,8 @@ from typing import TYPE_CHECKING, Optional, Type, TypeVar
 if TYPE_CHECKING:
     from types import TracebackType
 
+    from typing_extensions import Self
+
     from .abc import Messageable
 
     TypingT = TypeVar("TypingT", bound="Typing")
@@ -62,7 +64,7 @@ class Typing:
             await typing(channel.id)
             await asyncio.sleep(5)
 
-    def __enter__(self: TypingT) -> TypingT:
+    def __enter__(self) -> Self:
         self.task: asyncio.Task = self.loop.create_task(self.do_typing())
         self.task.add_done_callback(_typing_done_callback)
         return self
@@ -75,7 +77,7 @@ class Typing:
     ) -> None:
         self.task.cancel()
 
-    async def __aenter__(self: TypingT) -> TypingT:
+    async def __aenter__(self) -> Self:
         self._channel = channel = await self.messageable._get_channel()
         await channel._state.http.send_typing(channel.id)
         return self.__enter__()

--- a/nextcord/embeds.py
+++ b/nextcord/embeds.py
@@ -26,10 +26,13 @@ from __future__ import annotations
 
 import datetime
 import warnings
-from typing import TYPE_CHECKING, Any, Dict, List, Mapping, Optional, Protocol, Type, TypeVar, Union
+from typing import TYPE_CHECKING, Any, Dict, List, Mapping, Optional, Protocol, Union
 
 from . import utils
 from .colour import Colour
+
+if TYPE_CHECKING:
+    from typing_extensions import Self
 
 __all__ = ("Embed",)
 
@@ -51,8 +54,6 @@ class EmbedProxy:
     def __getattr__(self, _: str) -> None:
         return None
 
-
-E = TypeVar("E", bound="Embed")
 
 if TYPE_CHECKING:
     from nextcord.types.embed import Embed as EmbedData, EmbedType
@@ -200,7 +201,7 @@ class Embed:
         return None
 
     @classmethod
-    def from_dict(cls: Type[E], data: Mapping[str, Any]) -> E:
+    def from_dict(cls, data: Mapping[str, Any]) -> Self:
         """Converts a :class:`dict` to a :class:`Embed` provided it is in the
         format that Discord expects it to be in.
 
@@ -216,7 +217,7 @@ class Embed:
             The dictionary to convert into an embed.
         """
         # we are bypassing __init__ here since it doesn't apply here
-        self: E = cls.__new__(cls)
+        self = cls.__new__(cls)
 
         # fill in the basic fields
 
@@ -256,7 +257,7 @@ class Embed:
 
         return self
 
-    def copy(self: E) -> E:
+    def copy(self) -> Self:
         """Returns a shallow copy of the embed."""
         return self.__class__.from_dict(self.to_dict())
 
@@ -343,7 +344,7 @@ class Embed:
         """
         return EmbedProxy(getattr(self, "_footer", {}))  # type: ignore
 
-    def set_footer(self: E, *, text: Optional[Any] = None, icon_url: Optional[Any] = None) -> E:
+    def set_footer(self, *, text: Optional[Any] = None, icon_url: Optional[Any] = None) -> Self:
         """Sets the footer for the embed content.
 
         This function returns the class instance to allow for fluent-style
@@ -366,7 +367,7 @@ class Embed:
 
         return self
 
-    def remove_footer(self: E) -> E:
+    def remove_footer(self) -> Self:
         """Clears embed's footer information.
 
         This function returns the class instance to allow for fluent-style
@@ -396,7 +397,7 @@ class Embed:
         """
         return EmbedProxy(getattr(self, "_image", {}))  # type: ignore
 
-    def set_image(self: E, url: Optional[Any]) -> E:
+    def set_image(self, url: Optional[Any]) -> Self:
         """Sets the image for the embed content.
 
         This function returns the class instance to allow for fluent-style
@@ -438,7 +439,7 @@ class Embed:
         """
         return EmbedProxy(getattr(self, "_thumbnail", {}))  # type: ignore
 
-    def set_thumbnail(self: E, url: Optional[Any]) -> E:
+    def set_thumbnail(self, url: Optional[Any]) -> Self:
         """Sets the thumbnail for the embed content.
 
         This function returns the class instance to allow for fluent-style
@@ -500,12 +501,12 @@ class Embed:
         return EmbedProxy(getattr(self, "_author", {}))  # type: ignore
 
     def set_author(
-        self: E,
+        self,
         *,
         name: Any,
         url: Optional[Any] = None,
         icon_url: Optional[Any] = None,
-    ) -> E:
+    ) -> Self:
         """Sets the author for the embed content.
 
         This function returns the class instance to allow for fluent-style
@@ -533,7 +534,7 @@ class Embed:
 
         return self
 
-    def remove_author(self: E) -> E:
+    def remove_author(self) -> Self:
         """Clears embed's author information.
 
         This function returns the class instance to allow for fluent-style
@@ -558,7 +559,7 @@ class Embed:
         """
         return [EmbedProxy(d) for d in getattr(self, "_fields", [])]  # type: ignore
 
-    def add_field(self: E, *, name: Any, value: Any, inline: bool = True) -> E:
+    def add_field(self, *, name: Any, value: Any, inline: bool = True) -> Self:
         """Adds a field to the embed object.
 
         This function returns the class instance to allow for fluent-style
@@ -587,7 +588,7 @@ class Embed:
 
         return self
 
-    def insert_field_at(self: E, index: int, *, name: Any, value: Any, inline: bool = True) -> E:
+    def insert_field_at(self, index: int, *, name: Any, value: Any, inline: bool = True) -> Self:
         """Inserts a field before a specified index to the embed.
 
         This function returns the class instance to allow for fluent-style
@@ -620,7 +621,7 @@ class Embed:
 
         return self
 
-    def clear_fields(self: E) -> E:
+    def clear_fields(self) -> Self:
         """Removes all fields from this embed.
 
         This function returns the class instance to allow for fluent-style
@@ -633,7 +634,7 @@ class Embed:
 
         return self
 
-    def remove_field(self: E, index: int) -> E:
+    def remove_field(self, index: int) -> Self:
         """Removes a field at a specified index.
 
         If the index is invalid or out of bounds then the error is
@@ -659,7 +660,7 @@ class Embed:
 
         return self
 
-    def set_field_at(self: E, index: int, *, name: Any, value: Any, inline: bool = True) -> E:
+    def set_field_at(self, index: int, *, name: Any, value: Any, inline: bool = True) -> Self:
         """Modifies a field to the embed object.
 
         The index must point to a valid pre-existing field.

--- a/nextcord/ext/commands/cog.py
+++ b/nextcord/ext/commands/cog.py
@@ -25,18 +25,7 @@ from __future__ import annotations
 
 import asyncio
 import inspect
-from typing import (
-    TYPE_CHECKING,
-    Any,
-    Callable,
-    ClassVar,
-    Dict,
-    Generator,
-    List,
-    Tuple,
-    Type,
-    TypeVar,
-)
+from typing import TYPE_CHECKING, Any, Callable, ClassVar, Dict, Generator, List, Tuple, TypeVar
 
 import nextcord.utils
 from nextcord.application_command import ClientCog, _cog_special_method
@@ -44,6 +33,8 @@ from nextcord.application_command import ClientCog, _cog_special_method
 from ._types import _BaseCommand
 
 if TYPE_CHECKING:
+    from typing_extensions import Self
+
     from .bot import BotBase
     from .context import Context
     from .core import Command
@@ -124,7 +115,7 @@ class CogMeta(type):
     __cog_commands__: List[Command]
     __cog_listeners__: List[Tuple[str, str]]
 
-    def __new__(cls: Type[CogMeta], *args: Any, **kwargs: Any) -> CogMeta:
+    def __new__(cls, *args: Any, **kwargs: Any) -> Self:
         name, bases, attrs = args
         attrs["__cog_name__"] = kwargs.pop("name", name)
         attrs["__cog_settings__"] = kwargs.pop("command_attrs", {})
@@ -205,7 +196,7 @@ class Cog(ClientCog, metaclass=CogMeta):
     __cog_commands__: ClassVar[List[Command]]
     __cog_listeners__: ClassVar[List[Tuple[str, str]]]
 
-    def __new__(cls: Type[CogT], *args: Any, **kwargs: Any) -> CogT:
+    def __new__(cls, *args: Any, **kwargs: Any) -> Self:
         # For issue 426, we need to store a copy of the command objects
         # since we modify them to inject `self` to them.
         # To do this, we need to interfere with the Cog creation process.
@@ -234,7 +225,7 @@ class Cog(ClientCog, metaclass=CogMeta):
                 parent.remove_command(command.name)  # type: ignore
                 parent.add_command(command)  # type: ignore
 
-        return self  # type: ignore
+        return self
 
     def get_commands(self) -> List[Command]:
         r"""
@@ -435,7 +426,7 @@ class Cog(ClientCog, metaclass=CogMeta):
         """
         pass
 
-    def _inject(self: CogT, bot: BotBase) -> CogT:
+    def _inject(self, bot: BotBase) -> Self:
         cls = self.__class__
 
         # realistically, the only thing that can cause loading errors

--- a/nextcord/ext/commands/cooldowns.py
+++ b/nextcord/ext/commands/cooldowns.py
@@ -27,7 +27,7 @@ from __future__ import annotations
 import asyncio
 import time
 from collections import deque
-from typing import TYPE_CHECKING, Any, Callable, Deque, Dict, Optional, Type, TypeVar
+from typing import TYPE_CHECKING, Any, Callable, Deque, Dict, Optional, TypeVar
 
 from nextcord.enums import IntEnum
 
@@ -35,6 +35,8 @@ from ...abc import PrivateChannel
 from .errors import MaxConcurrencyReached
 
 if TYPE_CHECKING:
+    from typing_extensions import Self
+
     from ...message import Message
 
 __all__ = (
@@ -46,7 +48,6 @@ __all__ = (
 )
 
 C = TypeVar("C", bound="CooldownMapping")
-MC = TypeVar("MC", bound="MaxConcurrency")
 
 
 class BucketType(IntEnum):
@@ -221,7 +222,7 @@ class CooldownMapping:
         return self._type
 
     @classmethod
-    def from_cooldown(cls: Type[C], rate, per, type) -> C:
+    def from_cooldown(cls, rate, per, type) -> Self:
         return cls(Cooldown(rate, per), type)
 
     def _bucket_key(self, msg: Message) -> Any:
@@ -364,7 +365,7 @@ class MaxConcurrency:
         if not isinstance(per, BucketType):
             raise TypeError(f"max_concurrency 'per' must be of type BucketType not {type(per)!r}")
 
-    def copy(self: MC) -> MC:
+    def copy(self) -> Self:
         return self.__class__(self.number, per=self.per, wait=self.wait)
 
     def __repr__(self) -> str:

--- a/nextcord/ext/commands/core.py
+++ b/nextcord/ext/commands/core.py
@@ -55,7 +55,7 @@ from .cooldowns import BucketType, Cooldown, CooldownMapping, DynamicCooldownMap
 from .errors import *
 
 if TYPE_CHECKING:
-    from typing_extensions import Concatenate, ParamSpec, TypeGuard
+    from typing_extensions import Concatenate, ParamSpec, Self, TypeGuard
 
     from nextcord.message import Message
 
@@ -288,7 +288,7 @@ class Command(_BaseCommand, Generic[CogT, P, T]):
     """
     __original_kwargs__: Dict[str, Any]
 
-    def __new__(cls: Type[CommandT], *args: Any, **kwargs: Any) -> CommandT:
+    def __new__(cls, *args: Any, **kwargs: Any) -> Self:
         # if you're wondering why this is done, it's because we need to ensure
         # we have a complete original copy of **kwargs even for classes that
         # mess with it by popping before delegating to the subclass __init__.
@@ -532,7 +532,7 @@ class Command(_BaseCommand, Generic[CogT, P, T]):
             pass
         return other
 
-    def copy(self: CommandT) -> CommandT:
+    def copy(self) -> Self:
         """Creates a copy of this command.
 
         Returns
@@ -543,7 +543,7 @@ class Command(_BaseCommand, Generic[CogT, P, T]):
         ret = self.__class__(self.callback, **self.__original_kwargs__)
         return self._ensure_assignment_on_copy(ret)
 
-    def _update_copy(self: CommandT, kwargs: Dict[str, Any]) -> CommandT:
+    def _update_copy(self, kwargs: Dict[str, Any]) -> Self:
         if kwargs:
             kw = kwargs.copy()
             kw.update(self.__original_kwargs__)
@@ -1484,7 +1484,7 @@ class Group(GroupMixin[CogT], Command[CogT, P, T]):
         GroupMixin.__init__(self, *args, **attrs)
         Command.__init__(self, *args, **attrs)  # type: ignore
 
-    def copy(self: GroupT) -> GroupT:
+    def copy(self) -> Self:
         """Creates a copy of this :class:`Group`.
 
         Returns

--- a/nextcord/ext/commands/flags.py
+++ b/nextcord/ext/commands/flags.py
@@ -40,7 +40,6 @@ from typing import (
     Set,
     Tuple,
     Type,
-    TypeVar,
     Union,
 )
 
@@ -64,6 +63,8 @@ __all__ = (
 
 
 if TYPE_CHECKING:
+    from typing_extensions import Self
+
     from .context import Context
 
 
@@ -451,9 +452,6 @@ async def convert_flag(ctx, argument: str, flag: Flag, annotation: Any = None) -
         raise BadFlagArgument(flag) from e
 
 
-F = TypeVar("F", bound="FlagConverter")
-
-
 class FlagConverter(metaclass=FlagsMeta):
     """A converter that allows for a user-friendly flag syntax.
 
@@ -500,8 +498,8 @@ class FlagConverter(metaclass=FlagsMeta):
             yield (flag.name, getattr(self, flag.attribute))
 
     @classmethod
-    async def _construct_default(cls: Type[F], ctx: Context) -> F:
-        self: F = cls.__new__(cls)
+    async def _construct_default(cls, ctx: Context) -> Self:
+        self = cls.__new__(cls)
         flags = cls.__commands_flags__
         for flag in flags.values():
             if callable(flag.default):
@@ -571,7 +569,7 @@ class FlagConverter(metaclass=FlagsMeta):
         return result
 
     @classmethod
-    async def convert(cls: Type[F], ctx: Context, argument: str) -> F:
+    async def convert(cls, ctx: Context, argument: str) -> Self:
         """|coro|
 
         The method that actually converters an argument to the flag mapping.
@@ -600,7 +598,7 @@ class FlagConverter(metaclass=FlagsMeta):
         arguments = cls.parse_flags(argument)
         flags = cls.__commands_flags__
 
-        self: F = cls.__new__(cls)
+        self = cls.__new__(cls)
         for name, flag in flags.items():
             try:
                 values = arguments[name]

--- a/nextcord/flags.py
+++ b/nextcord/flags.py
@@ -27,6 +27,7 @@ from __future__ import annotations
 
 from functools import reduce
 from typing import (
+    TYPE_CHECKING,
     Any,
     Callable,
     ClassVar,
@@ -42,6 +43,9 @@ from typing import (
 
 from .enums import UserFlags
 
+if TYPE_CHECKING:
+    from typing_extensions import Self
+
 __all__ = (
     "SystemChannelFlags",
     "MessageFlags",
@@ -52,7 +56,6 @@ __all__ = (
     "ChannelFlags",
 )
 
-FV = TypeVar("FV", bound="flag_value")
 BF = TypeVar("BF", bound="BaseFlags")
 
 
@@ -62,7 +65,7 @@ class flag_value:
         self.__doc__ = func.__doc__
 
     @overload
-    def __get__(self: FV, instance: None, owner: Type[BF]) -> FV:
+    def __get__(self, instance: None, owner: Type[BF]) -> Self:
         ...
 
     @overload
@@ -541,7 +544,7 @@ class Intents(BaseFlags):
             setattr(self, key, value)
 
     @classmethod
-    def all(cls: Type[Intents]) -> Intents:
+    def all(cls) -> Self:
         """A factory method that creates a :class:`Intents` with everything enabled."""
         self = cls.__new__(cls)
         add_bits: Callable[[int, int], int] = lambda a, b: a | b
@@ -549,14 +552,14 @@ class Intents(BaseFlags):
         return self
 
     @classmethod
-    def none(cls: Type[Intents]) -> Intents:
+    def none(cls) -> Self:
         """A factory method that creates a :class:`Intents` with everything disabled."""
         self = cls.__new__(cls)
         self.value = self.DEFAULT_VALUE
         return self
 
     @classmethod
-    def default(cls: Type[Intents]) -> Intents:
+    def default(cls) -> Self:
         """A factory method that creates a :class:`Intents` with everything enabled
         except :attr:`presences`, :attr:`members`, and :attr:`message_content`.
         """
@@ -1082,7 +1085,7 @@ class MemberCacheFlags(BaseFlags):
             setattr(self, key, value)
 
     @classmethod
-    def all(cls: Type[MemberCacheFlags]) -> MemberCacheFlags:
+    def all(cls) -> Self:
         """A factory method that creates a :class:`MemberCacheFlags` with everything enabled."""
         bits = max(cls.VALID_FLAGS.values()).bit_length()
         value = (1 << bits) - 1
@@ -1091,7 +1094,7 @@ class MemberCacheFlags(BaseFlags):
         return self
 
     @classmethod
-    def none(cls: Type[MemberCacheFlags]) -> MemberCacheFlags:
+    def none(cls) -> Self:
         """A factory method that creates a :class:`MemberCacheFlags` with everything disabled."""
         self = cls.__new__(cls)
         self.value = self.DEFAULT_VALUE
@@ -1123,7 +1126,7 @@ class MemberCacheFlags(BaseFlags):
         return 2
 
     @classmethod
-    def from_intents(cls: Type[MemberCacheFlags], intents: Intents) -> MemberCacheFlags:
+    def from_intents(cls, intents: Intents) -> Self:
         """A factory method that creates a :class:`MemberCacheFlags` based on
         the currently selected :class:`Intents`.
 

--- a/nextcord/http.py
+++ b/nextcord/http.py
@@ -69,6 +69,8 @@ _log = logging.getLogger(__name__)
 if TYPE_CHECKING:
     from types import TracebackType
 
+    from typing_extensions import Self
+
     from .enums import AuditLogAction, InteractionResponseType
     from .types import (
         appinfo,
@@ -97,7 +99,6 @@ if TYPE_CHECKING:
 
     T = TypeVar("T")
     BE = TypeVar("BE", bound=BaseException)
-    MU = TypeVar("MU", bound="MaybeUnlock")
     Response = Coroutine[Any, Any, T]
 
 
@@ -180,7 +181,7 @@ class MaybeUnlock:
         self.lock: asyncio.Lock = lock
         self._unlock: bool = True
 
-    def __enter__(self: MU) -> MU:
+    def __enter__(self) -> Self:
         return self
 
     def defer(self) -> None:

--- a/nextcord/invite.py
+++ b/nextcord/invite.py
@@ -24,7 +24,7 @@ DEALINGS IN THE SOFTWARE.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, List, Optional, Type, TypeVar, Union
+from typing import TYPE_CHECKING, List, Optional, Union
 
 from .appinfo import PartialAppInfo
 from .asset import Asset
@@ -40,6 +40,8 @@ __all__ = (
 )
 
 if TYPE_CHECKING:
+    from typing_extensions import Self
+
     from .abc import GuildChannel
     from .guild import Guild
     from .state import ConnectionState
@@ -215,9 +217,6 @@ class PartialInviteGuild:
         return Asset._from_guild_image(self._state, self.id, self._splash, path="splashes")
 
 
-I = TypeVar("I", bound="Invite")
-
-
 class Invite(Hashable):
     r"""Represents a Discord :class:`Guild` or :class:`abc.GuildChannel` invite.
 
@@ -387,7 +386,7 @@ class Invite(Hashable):
         )
 
     @classmethod
-    def from_incomplete(cls: Type[I], *, state: ConnectionState, data: InvitePayload) -> I:
+    def from_incomplete(cls, *, state: ConnectionState, data: InvitePayload) -> Self:
         guild: Optional[Union[Guild, PartialInviteGuild]]
         try:
             guild_data = data["guild"]
@@ -411,7 +410,7 @@ class Invite(Hashable):
         return cls(state=state, data=data, guild=guild, channel=channel)
 
     @classmethod
-    def from_gateway(cls: Type[I], *, state: ConnectionState, data: GatewayInvitePayload) -> I:
+    def from_gateway(cls, *, state: ConnectionState, data: GatewayInvitePayload) -> Self:
         guild_id: Optional[int] = get_as_snowflake(data, "guild_id")
         guild: Optional[Union[Guild, Object]] = state._get_guild(guild_id)
         channel_id = int(data["channel_id"])

--- a/nextcord/member.py
+++ b/nextcord/member.py
@@ -30,7 +30,7 @@ import datetime
 import itertools
 import sys
 from operator import attrgetter
-from typing import TYPE_CHECKING, Any, Dict, List, Literal, Optional, Tuple, Type, TypeVar, Union
+from typing import TYPE_CHECKING, Any, Dict, List, Literal, Optional, Tuple, Union
 
 from . import abc, utils
 from .activity import ActivityTypes, create_activity
@@ -48,6 +48,8 @@ __all__ = (
 )
 
 if TYPE_CHECKING:
+    from typing_extensions import Self
+
     from .abc import Snowflake
     from .channel import DMChannel, StageChannel, VoiceChannel
     from .flags import PublicUserFlags
@@ -197,9 +199,6 @@ def flatten_user(cls):
     return cls
 
 
-M = TypeVar("M", bound="Member")
-
-
 @flatten_user
 class Member(abc.Messageable, _UserTag):
     """Represents a Discord member to a :class:`Guild`.
@@ -322,7 +321,7 @@ class Member(abc.Messageable, _UserTag):
         return hash(self._user)
 
     @classmethod
-    def _from_message(cls: Type[M], *, message: Message, data: MemberPayload) -> M:
+    def _from_message(cls, *, message: Message, data: MemberPayload) -> Self:
         author = message.author
         data["user"] = author._to_minimal_user_json()  # type: ignore
         return cls(data=data, guild=message.guild, state=message._state)  # type: ignore
@@ -337,8 +336,8 @@ class Member(abc.Messageable, _UserTag):
 
     @classmethod
     def _try_upgrade(
-        cls: Type[M], *, data: UserWithMemberPayload, guild: Guild, state: ConnectionState
-    ) -> Union[User, M]:
+        cls, *, data: UserWithMemberPayload, guild: Guild, state: ConnectionState
+    ) -> Union[User, Member]:
         # A User object with a 'member' key
         try:
             member_data = data.pop("member")
@@ -349,8 +348,8 @@ class Member(abc.Messageable, _UserTag):
             return cls(data=member_data, guild=guild, state=state)  # type: ignore
 
     @classmethod
-    def _copy(cls: Type[M], member: M) -> M:
-        self: M = cls.__new__(cls)  # to bypass __init__
+    def _copy(cls, member: Self) -> Self:
+        self = cls.__new__(cls)  # to bypass __init__
 
         self._roles = utils.SnowflakeList(member._roles, is_sorted=True)
         self.joined_at = member.joined_at

--- a/nextcord/mentions.py
+++ b/nextcord/mentions.py
@@ -24,11 +24,13 @@ DEALINGS IN THE SOFTWARE.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, List, Type, TypeVar, Union
+from typing import TYPE_CHECKING, Any, List, Union
 
 __all__ = ("AllowedMentions",)
 
 if TYPE_CHECKING:
+    from typing_extensions import Self
+
     from .abc import Snowflake
     from .types.message import AllowedMentions as AllowedMentionsPayload
 
@@ -45,8 +47,6 @@ class _FakeBool:
 
 
 default: Any = _FakeBool()
-
-A = TypeVar("A", bound="AllowedMentions")
 
 
 class AllowedMentions:
@@ -95,7 +95,7 @@ class AllowedMentions:
         self.replied_user = replied_user
 
     @classmethod
-    def all(cls: Type[A]) -> A:
+    def all(cls) -> Self:
         """A factory method that returns a :class:`AllowedMentions` with all fields explicitly set to ``True``
 
         .. versionadded:: 1.5
@@ -103,7 +103,7 @@ class AllowedMentions:
         return cls(everyone=True, users=True, roles=True, replied_user=True)
 
     @classmethod
-    def none(cls: Type[A]) -> A:
+    def none(cls) -> Self:
         """A factory method that returns a :class:`AllowedMentions` with all fields set to ``False``
 
         .. versionadded:: 1.5

--- a/nextcord/message.py
+++ b/nextcord/message.py
@@ -38,8 +38,6 @@ from typing import (
     List,
     Optional,
     Tuple,
-    Type,
-    TypeVar,
     Union,
     overload,
 )
@@ -62,6 +60,8 @@ from .threads import Thread
 from .utils import MISSING, escape_mentions
 
 if TYPE_CHECKING:
+    from typing_extensions import Self
+
     from .abc import GuildChannel, MessageableChannel, PartialMessageableChannel, Snowflake
     from .channel import TextChannel
     from .components import Component
@@ -85,7 +85,6 @@ if TYPE_CHECKING:
     from .ui.view import View
     from .user import User
 
-    MR = TypeVar("MR", bound="MessageReference")
     EmojiInputType = Union[Emoji, PartialEmoji, str]
 
 __all__ = (
@@ -472,7 +471,7 @@ class MessageReference:
         self.fail_if_not_exists: bool = fail_if_not_exists
 
     @classmethod
-    def with_state(cls: Type[MR], state: ConnectionState, data: MessageReferencePayload) -> MR:
+    def with_state(cls, state: ConnectionState, data: MessageReferencePayload) -> Self:
         self = cls.__new__(cls)
         self.message_id = utils.get_as_snowflake(data, "message_id")
         self.channel_id = int(data.pop("channel_id"))
@@ -483,7 +482,7 @@ class MessageReference:
         return self
 
     @classmethod
-    def from_message(cls: Type[MR], message: Message, *, fail_if_not_exists: bool = True) -> MR:
+    def from_message(cls, message: Message, *, fail_if_not_exists: bool = True) -> Self:
         """Creates a :class:`MessageReference` from an existing :class:`~nextcord.Message`.
 
         .. versionadded:: 1.6

--- a/nextcord/partial_emoji.py
+++ b/nextcord/partial_emoji.py
@@ -25,7 +25,7 @@ DEALINGS IN THE SOFTWARE.
 from __future__ import annotations
 
 import re
-from typing import TYPE_CHECKING, Any, Dict, Optional, Type, TypeVar, Union
+from typing import TYPE_CHECKING, Any, Dict, Optional, Union
 
 from . import utils
 from .asset import Asset, AssetMixin
@@ -35,6 +35,8 @@ __all__ = ("PartialEmoji",)
 
 if TYPE_CHECKING:
     from datetime import datetime
+
+    from typing_extensions import Self
 
     from .state import ConnectionState
     from .types.message import PartialEmoji as PartialEmojiPayload
@@ -47,9 +49,6 @@ class _EmojiTag:
 
     def _to_partial(self) -> PartialEmoji:
         raise NotImplementedError
-
-
-PE = TypeVar("PE", bound="PartialEmoji")
 
 
 class PartialEmoji(_EmojiTag, AssetMixin):
@@ -106,7 +105,7 @@ class PartialEmoji(_EmojiTag, AssetMixin):
         self._state: Optional[ConnectionState] = None
 
     @classmethod
-    def from_dict(cls: Type[PE], data: Union[PartialEmojiPayload, Dict[str, Any]]) -> PE:
+    def from_dict(cls, data: Union[PartialEmojiPayload, Dict[str, Any]]) -> Self:
         return cls(
             animated=data.get("animated", False),
             id=utils.get_as_snowflake(data, "id"),
@@ -114,7 +113,7 @@ class PartialEmoji(_EmojiTag, AssetMixin):
         )
 
     @classmethod
-    def from_str(cls: Type[PE], value: str) -> PE:
+    def from_str(cls, value: str) -> Self:
         """Converts a Discord string representation of an emoji to a :class:`PartialEmoji`.
 
         The formats accepted are:
@@ -161,13 +160,13 @@ class PartialEmoji(_EmojiTag, AssetMixin):
 
     @classmethod
     def with_state(
-        cls: Type[PE],
+        cls,
         state: ConnectionState,
         *,
         name: str,
         animated: bool = False,
         id: Optional[int] = None,
-    ) -> PE:
+    ) -> Self:
         self = cls(name=name, animated=animated, id=id)
         self._state = state
         return self

--- a/nextcord/permissions.py
+++ b/nextcord/permissions.py
@@ -25,21 +25,12 @@ DEALINGS IN THE SOFTWARE.
 
 from __future__ import annotations
 
-from typing import (
-    TYPE_CHECKING,
-    Any,
-    Callable,
-    ClassVar,
-    Dict,
-    Iterator,
-    Optional,
-    Set,
-    Tuple,
-    Type,
-    TypeVar,
-)
+from typing import TYPE_CHECKING, Any, Callable, ClassVar, Dict, Iterator, Optional, Set, Tuple
 
 from .flags import BaseFlags, alias_flag_value, fill_with_flags, flag_value
+
+if TYPE_CHECKING:
+    from typing_extensions import Self
 
 __all__ = (
     "Permissions",
@@ -59,9 +50,6 @@ def make_permission_alias(alias: str) -> Callable[[Callable[[Any], int]], permis
         return ret
 
     return decorator
-
-
-P = TypeVar("P", bound="Permissions")
 
 
 @fill_with_flags()
@@ -159,20 +147,20 @@ class Permissions(BaseFlags):
     __gt__ = is_strict_superset
 
     @classmethod
-    def none(cls: Type[P]) -> P:
+    def none(cls) -> Self:
         """A factory method that creates a :class:`Permissions` with all
         permissions set to ``False``."""
         return cls(0)
 
     @classmethod
-    def all(cls: Type[P]) -> P:
+    def all(cls) -> Self:
         """A factory method that creates a :class:`Permissions` with all
         permissions set to ``True``.
         """
         return cls(-1)
 
     @classmethod
-    def all_channel(cls: Type[P]) -> P:
+    def all_channel(cls) -> Self:
         """A :class:`Permissions` with all channel-specific permissions set to
         ``True`` and the guild-specific ones set to ``False``. The guild-specific
         permissions are currently:
@@ -198,7 +186,7 @@ class Permissions(BaseFlags):
         return cls(0b111110110110011111101111111111101010001)
 
     @classmethod
-    def general(cls: Type[P]) -> P:
+    def general(cls) -> Self:
         """A factory method that creates a :class:`Permissions` with all
         "General" permissions from the official Discord UI set to ``True``.
 
@@ -211,7 +199,7 @@ class Permissions(BaseFlags):
         return cls(0b01110000000010000000010010110000)
 
     @classmethod
-    def membership(cls: Type[P]) -> P:
+    def membership(cls) -> Self:
         """A factory method that creates a :class:`Permissions` with all
         "Membership" permissions from the official Discord UI set to ``True``.
 
@@ -220,7 +208,7 @@ class Permissions(BaseFlags):
         return cls(0b00001100000000000000000000000111)
 
     @classmethod
-    def text(cls: Type[P]) -> P:
+    def text(cls) -> Self:
         """A factory method that creates a :class:`Permissions` with all
         "Text" permissions from the official Discord UI set to ``True``.
 
@@ -235,13 +223,13 @@ class Permissions(BaseFlags):
         return cls(0b111110010000000000001111111100001000000)
 
     @classmethod
-    def voice(cls: Type[P]) -> P:
+    def voice(cls) -> Self:
         """A factory method that creates a :class:`Permissions` with all
         "Voice" permissions from the official Discord UI set to ``True``."""
         return cls(0b00000011111100000000001100000000)
 
     @classmethod
-    def stage(cls: Type[P]) -> P:
+    def stage(cls) -> Self:
         """A factory method that creates a :class:`Permissions` with all
         "Stage Channel" permissions from the official Discord UI set to ``True``.
 
@@ -250,7 +238,7 @@ class Permissions(BaseFlags):
         return cls(1 << 32)
 
     @classmethod
-    def stage_moderator(cls: Type[P]) -> P:
+    def stage_moderator(cls) -> Self:
         """A factory method that creates a :class:`Permissions` with all
         "Stage Moderator" permissions from the official Discord UI set to ``True``.
 
@@ -259,7 +247,7 @@ class Permissions(BaseFlags):
         return cls(0b100000001010000000000000000000000)
 
     @classmethod
-    def advanced(cls: Type[P]) -> P:
+    def advanced(cls) -> Self:
         """A factory method that creates a :class:`Permissions` with all
         "Advanced" permissions from the official Discord UI set to ``True``.
 
@@ -592,9 +580,6 @@ class Permissions(BaseFlags):
         return 1 << 40
 
 
-PO = TypeVar("PO", bound="PermissionOverwrite")
-
-
 def _augment_from_permissions(cls):
     cls.VALID_NAMES = set(Permissions.VALID_FLAGS)
     aliases = set()
@@ -745,7 +730,7 @@ class PermissionOverwrite:
         return allow, deny
 
     @classmethod
-    def from_pair(cls: Type[PO], allow: Permissions, deny: Permissions) -> PO:
+    def from_pair(cls, allow: Permissions, deny: Permissions) -> Self:
         """Creates an overwrite from an allow/deny pair of :class:`Permissions`."""
         ret = cls()
         for key, value in allow:

--- a/nextcord/player.py
+++ b/nextcord/player.py
@@ -35,7 +35,7 @@ import sys
 import threading
 import time
 import traceback
-from typing import IO, TYPE_CHECKING, Any, Callable, Generic, Optional, Tuple, Type, TypeVar, Union
+from typing import IO, TYPE_CHECKING, Any, Callable, Generic, Optional, Tuple, TypeVar, Union
 
 from .enums import SpeakingState
 from .errors import ClientException
@@ -44,11 +44,12 @@ from .opus import Encoder as OpusEncoder
 from .utils import MISSING
 
 if TYPE_CHECKING:
+    from typing_extensions import Self
+
     from .voice_client import VoiceClient
 
 
 AT = TypeVar("AT", bound="AudioSource")
-FT = TypeVar("FT", bound="FFmpegOpusAudio")
 
 _log = logging.getLogger(__name__)
 
@@ -428,14 +429,14 @@ class FFmpegOpusAudio(FFmpegAudio):
 
     @classmethod
     async def from_probe(
-        cls: Type[FT],
+        cls,
         source: str,
         *,
         method: Optional[
             Union[str, Callable[[str, str], Tuple[Optional[str], Optional[int]]]]
         ] = None,
         **kwargs: Any,
-    ) -> FT:
+    ) -> Self:
         """|coro|
 
         A factory method that creates a :class:`FFmpegOpusAudio` after probing

--- a/nextcord/role.py
+++ b/nextcord/role.py
@@ -24,7 +24,7 @@ DEALINGS IN THE SOFTWARE.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, TypeVar, Union
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
 
 from .asset import Asset
 from .colour import Colour
@@ -40,6 +40,8 @@ __all__ = (
 
 if TYPE_CHECKING:
     import datetime
+
+    from typing_extensions import Self
 
     from .file import File
     from .guild import Guild
@@ -101,9 +103,6 @@ class RoleTags:
             f"<RoleTags bot_id={self.bot_id} integration_id={self.integration_id} "
             f"premium_subscriber={self.is_premium_subscriber()}>"
         )
-
-
-R = TypeVar("R", bound="Role")
 
 
 class Role(Hashable):
@@ -201,7 +200,7 @@ class Role(Hashable):
     def __repr__(self) -> str:
         return f"<Role id={self.id} name={self.name!r}>"
 
-    def __lt__(self: R, other: R) -> bool:
+    def __lt__(self, other: Self) -> bool:
         if not isinstance(other, Role) or not isinstance(self, Role):
             return NotImplemented
 
@@ -222,16 +221,16 @@ class Role(Hashable):
 
         return False
 
-    def __le__(self: R, other: R) -> bool:
+    def __le__(self, other: Self) -> bool:
         r = Role.__lt__(other, self)
         if r is NotImplemented:
             return NotImplemented
         return not r
 
-    def __gt__(self: R, other: R) -> bool:
+    def __gt__(self, other: Self) -> bool:
         return Role.__lt__(other, self)
 
-    def __ge__(self: R, other: R) -> bool:
+    def __ge__(self, other: Self) -> bool:
         r = Role.__lt__(self, other)
         if r is NotImplemented:
             return NotImplemented

--- a/nextcord/shard.py
+++ b/nextcord/shard.py
@@ -26,7 +26,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
-from typing import TYPE_CHECKING, Callable, Dict, List, Optional, Tuple, Type, TypeVar
+from typing import TYPE_CHECKING, Callable, Dict, List, Optional, Tuple, Type
 
 import aiohttp
 
@@ -46,12 +46,12 @@ from .state import AutoShardedConnectionState
 from .utils import MISSING
 
 if TYPE_CHECKING:
+    from typing_extensions import Self
+
     from .activity import BaseActivity
     from .flags import MemberCacheFlags
     from .gateway import DiscordWebSocket
     from .mentions import AllowedMentions
-
-    EI = TypeVar("EI", bound="EventItem")
 
 __all__ = (
     "AutoShardedClient",
@@ -78,12 +78,12 @@ class EventItem:
         self.shard: Optional["Shard"] = shard
         self.error: Optional[Exception] = error
 
-    def __lt__(self: EI, other: EI) -> bool:
+    def __lt__(self, other: Self) -> bool:
         if not isinstance(other, EventItem):
             return NotImplemented
         return self.type < other.type
 
-    def __eq__(self: EI, other: EI) -> bool:
+    def __eq__(self, other: Self) -> bool:
         if not isinstance(other, EventItem):
             return NotImplemented
         return self.type == other.type

--- a/nextcord/ui/button.py
+++ b/nextcord/ui/button.py
@@ -26,7 +26,7 @@ from __future__ import annotations
 
 import asyncio
 import os
-from typing import TYPE_CHECKING, Callable, Optional, Tuple, Type, TypeVar, Union
+from typing import TYPE_CHECKING, Callable, Optional, Tuple, TypeVar, Union
 
 from ..components import Button as ButtonComponent
 from ..enums import ButtonStyle, ComponentType
@@ -39,12 +39,13 @@ __all__ = (
 )
 
 if TYPE_CHECKING:
+    from typing_extensions import Self
+
     from ..emoji import Emoji
     from ..interactions import ClientT
     from ..types.components import ButtonComponent as ButtonComponentPayload
     from .view import View
 
-B = TypeVar("B", bound="Button")
 V = TypeVar("V", bound="View", covariant=True)
 
 
@@ -201,7 +202,7 @@ class Button(Item[V]):
             self._underlying.emoji = None
 
     @classmethod
-    def from_component(cls: Type[B], button: ButtonComponent) -> B:
+    def from_component(cls, button: ButtonComponent) -> Self:
         return cls(
             style=button.style,
             label=button.label,

--- a/nextcord/ui/item.py
+++ b/nextcord/ui/item.py
@@ -24,13 +24,15 @@ DEALINGS IN THE SOFTWARE.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Callable, Coroutine, Generic, Optional, Tuple, Type, TypeVar
+from typing import TYPE_CHECKING, Any, Callable, Coroutine, Generic, Optional, Tuple, TypeVar
 
 from ..interactions import ClientT, Interaction
 
 __all__ = ("Item",)
 
 if TYPE_CHECKING:
+    from typing_extensions import Self
+
     from ..components import Component
     from ..enums import ComponentType
     from ..guild import Guild
@@ -86,7 +88,7 @@ class Item(Generic[V]):
         return None
 
     @classmethod
-    def from_component(cls: Type[I], component: Component) -> I:
+    def from_component(cls, component: Component) -> Self:
         return cls()
 
     @property

--- a/nextcord/ui/select/base.py
+++ b/nextcord/ui/select/base.py
@@ -27,7 +27,7 @@ from __future__ import annotations
 
 import os
 from collections import UserList
-from typing import TYPE_CHECKING, List, Optional, Tuple, Type, TypeVar, Union
+from typing import TYPE_CHECKING, List, Optional, Tuple, TypeVar, Union
 
 from ...components import SelectMenu
 from ...enums import ComponentType
@@ -42,12 +42,13 @@ from ..item import Item
 __all__ = ("SelectBase",)
 
 if TYPE_CHECKING:
+    from typing_extensions import Self
+
     from ...abc import GuildChannel
     from ...types.components import SelectMenu as SelectMenuPayload
     from ...types.interactions import ComponentInteractionData, ComponentInteractionResolved
     from ..view import View
 
-S = TypeVar("S", bound="SelectBase")
 V = TypeVar("V", bound="View", covariant=True)
 
 
@@ -224,7 +225,7 @@ class SelectBase(Item[V]):
         self._selected_values = data.get("values", [])
 
     @classmethod
-    def from_component(cls: Type[S], component: SelectMenu) -> S:
+    def from_component(cls, component: SelectMenu) -> Self:
         return cls(
             custom_id=component.custom_id,
             placeholder=component.placeholder,

--- a/nextcord/ui/select/channel.py
+++ b/nextcord/ui/select/channel.py
@@ -25,7 +25,7 @@ DEALINGS IN THE SOFTWARE.
 from __future__ import annotations
 
 import asyncio
-from typing import TYPE_CHECKING, Callable, Generic, List, Optional, Tuple, Type, TypeVar
+from typing import TYPE_CHECKING, Callable, Generic, List, Optional, Tuple, TypeVar
 
 from ...components import ChannelSelectMenu
 from ...enums import ComponentType
@@ -36,6 +36,8 @@ from ..view import View
 from .base import SelectBase, SelectValuesBase
 
 if TYPE_CHECKING:
+    from typing_extensions import Self
+
     from ...abc import GuildChannel
     from ...enums import ChannelType
     from ...guild import Guild
@@ -45,7 +47,6 @@ if TYPE_CHECKING:
 
 __all__ = ("ChannelSelect", "channel_select", "ChannelSelectValues")
 
-S = TypeVar("S", bound="ChannelSelect")
 V = TypeVar("V", bound="View", covariant=True)
 
 
@@ -142,7 +143,7 @@ class ChannelSelect(SelectBase, Generic[V]):
         return self._underlying.to_dict()
 
     @classmethod
-    def from_component(cls: Type[S], component: ChannelSelectMenu) -> S:
+    def from_component(cls, component: ChannelSelectMenu) -> Self:
         return cls(
             custom_id=component.custom_id,
             placeholder=component.placeholder,

--- a/nextcord/ui/select/mentionable.py
+++ b/nextcord/ui/select/mentionable.py
@@ -25,7 +25,7 @@ DEALINGS IN THE SOFTWARE.
 from __future__ import annotations
 
 import asyncio
-from typing import TYPE_CHECKING, Callable, Generic, List, Optional, Tuple, Type, TypeVar
+from typing import TYPE_CHECKING, Callable, Generic, List, Optional, Tuple, TypeVar
 
 from ...components import MentionableSelectMenu
 from ...enums import ComponentType
@@ -36,6 +36,8 @@ from ..view import View
 from .base import SelectBase, SelectValuesBase
 
 if TYPE_CHECKING:
+    from typing_extensions import Self
+
     from ...guild import Guild
     from ...member import Member
     from ...role import Role
@@ -46,7 +48,6 @@ if TYPE_CHECKING:
 
 __all__ = ("MentionableSelect", "mentionable_select", "MentionableSelectValues")
 
-S = TypeVar("S", bound="MentionableSelect")
 V = TypeVar("V", bound="View", covariant=True)
 
 
@@ -147,7 +148,7 @@ class MentionableSelect(SelectBase, Generic[V]):
         return self._underlying.to_dict()
 
     @classmethod
-    def from_component(cls: Type[S], component: MentionableSelectMenu) -> S:
+    def from_component(cls, component: MentionableSelectMenu) -> Self:
         return cls(
             custom_id=component.custom_id,
             placeholder=component.placeholder,

--- a/nextcord/ui/select/role.py
+++ b/nextcord/ui/select/role.py
@@ -25,7 +25,7 @@ DEALINGS IN THE SOFTWARE.
 from __future__ import annotations
 
 import asyncio
-from typing import TYPE_CHECKING, Callable, Generic, List, Optional, Tuple, Type, TypeVar
+from typing import TYPE_CHECKING, Callable, Generic, List, Optional, Tuple, TypeVar
 
 from ...components import RoleSelectMenu
 from ...enums import ComponentType
@@ -37,6 +37,8 @@ from ..view import View
 from .base import SelectBase, SelectValuesBase
 
 if TYPE_CHECKING:
+    from typing_extensions import Self
+
     from ...guild import Guild
     from ...role import Role
     from ...types.components import RoleSelectMenu as RoleSelectMenuPayload
@@ -44,7 +46,6 @@ if TYPE_CHECKING:
 
 __all__ = ("RoleSelect", "role_select", "RoleSelectValues")
 
-S = TypeVar("S", bound="RoleSelect")
 V = TypeVar("V", bound="View", covariant=True)
 
 
@@ -135,7 +136,7 @@ class RoleSelect(SelectBase, Generic[V]):
         return self._underlying.to_dict()
 
     @classmethod
-    def from_component(cls: Type[S], component: RoleSelectMenu) -> S:
+    def from_component(cls, component: RoleSelectMenu) -> Self:
         return cls(
             custom_id=component.custom_id,
             placeholder=component.placeholder,

--- a/nextcord/ui/select/string.py
+++ b/nextcord/ui/select/string.py
@@ -25,7 +25,7 @@ DEALINGS IN THE SOFTWARE.
 from __future__ import annotations
 
 import asyncio
-from typing import Callable, Generic, List, Optional, Tuple, Type, TypeVar, Union
+from typing import TYPE_CHECKING, Callable, Generic, List, Optional, Tuple, TypeVar, Union
 
 from ...components import SelectOption, StringSelectMenu
 from ...emoji import Emoji
@@ -37,6 +37,9 @@ from ..item import ItemCallbackType
 from ..view import View
 from .base import SelectBase
 
+if TYPE_CHECKING:
+    from typing_extensions import Self
+
 __all__ = (
     "Select",
     "select",
@@ -44,7 +47,6 @@ __all__ = (
     "string_select",
 )
 
-S = TypeVar("S", bound="StringSelect")
 V = TypeVar("V", bound="View", covariant=True)
 
 
@@ -204,7 +206,7 @@ class StringSelect(SelectBase, Generic[V]):
         self._underlying.options.append(option)
 
     @classmethod
-    def from_component(cls: Type[S], component: StringSelectMenu) -> S:
+    def from_component(cls, component: StringSelectMenu) -> Self:
         return cls(
             custom_id=component.custom_id,
             placeholder=component.placeholder,

--- a/nextcord/ui/select/user.py
+++ b/nextcord/ui/select/user.py
@@ -25,7 +25,7 @@ DEALINGS IN THE SOFTWARE.
 from __future__ import annotations
 
 import asyncio
-from typing import TYPE_CHECKING, Callable, Generic, List, Optional, Tuple, Type, TypeVar
+from typing import TYPE_CHECKING, Callable, Generic, List, Optional, Tuple, TypeVar
 
 from ...components import UserSelectMenu
 from ...enums import ComponentType
@@ -38,6 +38,8 @@ from ..view import View
 from .base import SelectBase, SelectValuesBase
 
 if TYPE_CHECKING:
+    from typing_extensions import Self
+
     from ...guild import Guild
     from ...state import ConnectionState
     from ...types.components import UserSelectMenu as UserSelectMenuPayload
@@ -45,7 +47,6 @@ if TYPE_CHECKING:
 
 __all__ = ("UserSelect", "user_select", "UserSelectValues")
 
-S = TypeVar("S", bound="UserSelect")
 V = TypeVar("V", bound="View", covariant=True)
 
 
@@ -139,7 +140,7 @@ class UserSelect(SelectBase, Generic[V]):
         return self._underlying.to_dict()
 
     @classmethod
-    def from_component(cls: Type[S], component: UserSelectMenu) -> S:
+    def from_component(cls, component: UserSelectMenu) -> Self:
         return cls(
             custom_id=component.custom_id,
             placeholder=component.placeholder,

--- a/nextcord/ui/text_input.py
+++ b/nextcord/ui/text_input.py
@@ -25,7 +25,7 @@ DEALINGS IN THE SOFTWARE.
 from __future__ import annotations
 
 import os
-from typing import TYPE_CHECKING, Optional, Tuple, Type, TypeVar
+from typing import TYPE_CHECKING, Optional, Tuple, TypeVar
 
 from ..components import TextInput as TextInputComponent
 from ..enums import ComponentType, TextInputStyle
@@ -37,12 +37,13 @@ from .item import Item
 __all__ = ("TextInput",)
 
 if TYPE_CHECKING:
+    from typing_extensions import Self
+
     from ..types.components import TextInputComponent as TextInputComponentPayload
     from ..types.interactions import ComponentInteractionData
     from .view import View
 
 
-T = TypeVar("T", bound="TextInput")
 V = TypeVar("V", bound="View", covariant=True)
 
 
@@ -220,7 +221,7 @@ class TextInput(Item[V]):
         return 5
 
     @classmethod
-    def from_component(cls: Type[T], text_input: TextInputComponent) -> T:
+    def from_component(cls, text_input: TextInputComponent) -> Self:
         return cls(
             style=text_input.style,
             custom_id=text_input.custom_id,

--- a/nextcord/user.py
+++ b/nextcord/user.py
@@ -24,7 +24,7 @@ DEALINGS IN THE SOFTWARE.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Type, TypeVar, Union
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
 
 from . import abc
 from .asset import Asset
@@ -35,6 +35,8 @@ from .utils import MISSING, obj_to_base64_data, snowflake_time
 
 if TYPE_CHECKING:
     from datetime import datetime
+
+    from typing_extensions import Self
 
     from .channel import DMChannel
     from .file import File
@@ -49,8 +51,6 @@ __all__ = (
     "User",
     "ClientUser",
 )
-
-BU = TypeVar("BU", bound="BaseUser")
 
 
 class _UserTag:
@@ -118,7 +118,7 @@ class BaseUser(_UserTag):
         self.system = data.get("system", False)
 
     @classmethod
-    def _copy(cls: Type[BU], user: BU) -> BU:
+    def _copy(cls, user: Self) -> Self:
         self = cls.__new__(cls)  # bypass __init__
 
         self.name = user.name


### PR DESCRIPTION

## Summary

This reduces the repetition of creating bound (why) TypeVars.
<!-- What is this pull request for? Does it fix any issues? -->

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
  - [x] I have updated the documentation to reflect the changes.
  - [x] I have run `task pyright` and fixed the relevant issues.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
