### PR TITLE
fix(app-cmds): Fix optional params causing error when lazy loading.

### DIFF
--- a/nextcord/application_command.py
+++ b/nextcord/application_command.py
@@ -2344,7 +2344,7 @@ class BaseApplicationCommand(CallbackMixin, CallbackWrapperMixin):
                 for (
                     inter_opt_name,
                     inter_opt,
-                ) in all_inter_options_copy:  # Should only contain optionals now.
+                ) in all_inter_options_copy.items():  # Should only contain optionals now.
                     if our_opt := all_our_options_copy.get(inter_opt_name):
                         if not (
                             inter_opt["name"] == our_opt["name"]


### PR DESCRIPTION
When lazy loading, if a command has at least one optional parameters and at least one of the optional parameters is included in the initial lazy load, Nextcord will error due to a missing `.items()` in a for loop. This PR fixes that.

Signed-off-by: Alex Schoenhofen <alexanderschoenhofen@gmail.com>

## Summary

<!-- What is this pull request for? Does it fix any issues? -->

To test:
1: Make a command with at least one optional argument.
2: Start up your bot with all rollout settings set to `False`.
3: Use the command, giving the optional argument a value.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [X] If code changes were made then they have been tested.
  - [ ] I have updated the documentation to reflect the changes.
  - [ ] I have run `task pyright` and fixed the relevant issues.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
