### PR TITLE
feat: add create_webhook in forum & voice channels

### DIFF
--- a/nextcord/channel.py
+++ b/nextcord/channel.py
@@ -1411,6 +1411,57 @@ class ForumChannel(abc.GuildChannel, Hashable):
             self.id, self.guild, limit=limit, joined=joined, private=private, before=before
         )
 
+    async def create_webhook(
+        self,
+        *,
+        name: str,
+        avatar: Optional[Union[bytes, Asset, Attachment, File]] = None,
+        reason: Optional[str] = None,
+    ) -> Webhook:
+        """|coro|
+
+        Creates a webhook for this channel.
+
+        Requires :attr:`~.Permissions.manage_webhooks` permissions.
+
+        .. versionchanged:: 1.1
+            Added the ``reason`` keyword-only parameter.
+
+        .. versionchanged:: 2.1
+            The ``avatar`` parameter now accepts :class:`File`, :class:`Attachment`, and :class:`Asset`.
+
+        Parameters
+        ----------
+        name: :class:`str`
+            The webhook's name.
+        avatar: Optional[Union[:class:`bytes`, :class:`Asset`, :class:`Attachment`, :class:`File`]]
+            A :term:`py:bytes-like object`, :class:`File`, :class:`Attachment`,
+            or :class:`Asset` representing the webhook's default avatar.
+            This operates similarly to :meth:`~ClientUser.edit`.
+        reason: Optional[:class:`str`]
+            The reason for creating this webhook. Shows up in the audit logs.
+
+        Raises
+        ------
+        HTTPException
+            Creating the webhook failed.
+        Forbidden
+            You do not have permissions to create a webhook.
+
+        Returns
+        -------
+        :class:`Webhook`
+            The created webhook.
+        """
+
+        from .webhook import Webhook
+
+        avatar_base64 = await utils.obj_to_base64_data(avatar)
+
+        data = await self._state.http.create_webhook(
+            self.id, name=str(name), avatar=avatar_base64, reason=reason
+        )
+        return Webhook.from_state(data, state=self._state)
 
 class VocalGuildChannel(abc.Connectable, abc.GuildChannel, Hashable):
     __slots__ = (
@@ -1901,6 +1952,58 @@ class VoiceChannel(VocalGuildChannel, abc.Messageable):
             await ret[-1].delete()
 
         return ret
+    
+    async def create_webhook(
+        self,
+        *,
+        name: str,
+        avatar: Optional[Union[bytes, Asset, Attachment, File]] = None,
+        reason: Optional[str] = None,
+    ) -> Webhook:
+        """|coro|
+
+        Creates a webhook for this channel.
+
+        Requires :attr:`~.Permissions.manage_webhooks` permissions.
+
+        .. versionchanged:: 1.1
+            Added the ``reason`` keyword-only parameter.
+
+        .. versionchanged:: 2.1
+            The ``avatar`` parameter now accepts :class:`File`, :class:`Attachment`, and :class:`Asset`.
+
+        Parameters
+        ----------
+        name: :class:`str`
+            The webhook's name.
+        avatar: Optional[Union[:class:`bytes`, :class:`Asset`, :class:`Attachment`, :class:`File`]]
+            A :term:`py:bytes-like object`, :class:`File`, :class:`Attachment`,
+            or :class:`Asset` representing the webhook's default avatar.
+            This operates similarly to :meth:`~ClientUser.edit`.
+        reason: Optional[:class:`str`]
+            The reason for creating this webhook. Shows up in the audit logs.
+
+        Raises
+        ------
+        HTTPException
+            Creating the webhook failed.
+        Forbidden
+            You do not have permissions to create a webhook.
+
+        Returns
+        -------
+        :class:`Webhook`
+            The created webhook.
+        """
+
+        from .webhook import Webhook
+
+        avatar_base64 = await utils.obj_to_base64_data(avatar)
+
+        data = await self._state.http.create_webhook(
+            self.id, name=str(name), avatar=avatar_base64, reason=reason
+        )
+        return Webhook.from_state(data, state=self._state)
 
 
 class StageChannel(VocalGuildChannel):

--- a/nextcord/channel.py
+++ b/nextcord/channel.py
@@ -1419,11 +1419,12 @@ class ForumChannel(abc.GuildChannel, Hashable):
         reason: Optional[str] = None,
     ) -> Webhook:
         """|coro|
+
         Creates a webhook for this channel.
 
         Requires :attr:`~.Permissions.manage_webhooks` permissions.
 
-        ..versionadded:: 2.4
+        .. versionadded:: 2.4
 
         Parameters
         ----------
@@ -1957,11 +1958,12 @@ class VoiceChannel(VocalGuildChannel, abc.Messageable):
         reason: Optional[str] = None,
     ) -> Webhook:
         """|coro|
+
         Creates a webhook for this channel.
 
         Requires :attr:`~.Permissions.manage_webhooks` permissions.
 
-        ..versionadded:: 2.4
+        .. versionadded:: 2.4
 
         Parameters
         ----------

--- a/nextcord/channel.py
+++ b/nextcord/channel.py
@@ -1463,6 +1463,7 @@ class ForumChannel(abc.GuildChannel, Hashable):
         )
         return Webhook.from_state(data, state=self._state)
 
+
 class VocalGuildChannel(abc.Connectable, abc.GuildChannel, Hashable):
     __slots__ = (
         "name",
@@ -1952,7 +1953,7 @@ class VoiceChannel(VocalGuildChannel, abc.Messageable):
             await ret[-1].delete()
 
         return ret
-    
+
     async def create_webhook(
         self,
         *,

--- a/nextcord/channel.py
+++ b/nextcord/channel.py
@@ -1419,6 +1419,7 @@ class ForumChannel(abc.GuildChannel, Hashable):
         reason: Optional[str] = None,
     ) -> Webhook:
         """|coro|
+        Creates a webhook for this channel.
 
         Requires :attr:`~.Permissions.manage_webhooks` permissions.
 

--- a/nextcord/channel.py
+++ b/nextcord/channel.py
@@ -1420,15 +1420,10 @@ class ForumChannel(abc.GuildChannel, Hashable):
     ) -> Webhook:
         """|coro|
 
-        Creates a webhook for this channel.
+        ..versionadded:: 2.3.2
+            Creates a webhook for this channel.
 
         Requires :attr:`~.Permissions.manage_webhooks` permissions.
-
-        .. versionchanged:: 1.1
-            Added the ``reason`` keyword-only parameter.
-
-        .. versionchanged:: 2.1
-            The ``avatar`` parameter now accepts :class:`File`, :class:`Attachment`, and :class:`Asset`.
 
         Parameters
         ----------
@@ -1462,7 +1457,6 @@ class ForumChannel(abc.GuildChannel, Hashable):
             self.id, name=str(name), avatar=avatar_base64, reason=reason
         )
         return Webhook.from_state(data, state=self._state)
-
 
 class VocalGuildChannel(abc.Connectable, abc.GuildChannel, Hashable):
     __slots__ = (
@@ -1953,7 +1947,7 @@ class VoiceChannel(VocalGuildChannel, abc.Messageable):
             await ret[-1].delete()
 
         return ret
-
+    
     async def create_webhook(
         self,
         *,
@@ -1963,15 +1957,10 @@ class VoiceChannel(VocalGuildChannel, abc.Messageable):
     ) -> Webhook:
         """|coro|
 
-        Creates a webhook for this channel.
+        ..versionadded:: 2.3.2
+            Creates a webhook for this channel.
 
         Requires :attr:`~.Permissions.manage_webhooks` permissions.
-
-        .. versionchanged:: 1.1
-            Added the ``reason`` keyword-only parameter.
-
-        .. versionchanged:: 2.1
-            The ``avatar`` parameter now accepts :class:`File`, :class:`Attachment`, and :class:`Asset`.
 
         Parameters
         ----------

--- a/nextcord/channel.py
+++ b/nextcord/channel.py
@@ -1420,10 +1420,9 @@ class ForumChannel(abc.GuildChannel, Hashable):
     ) -> Webhook:
         """|coro|
 
-        ..versionadded:: 2.3.2
-            Creates a webhook for this channel.
-
         Requires :attr:`~.Permissions.manage_webhooks` permissions.
+
+        ..versionadded:: 2.4
 
         Parameters
         ----------

--- a/nextcord/channel.py
+++ b/nextcord/channel.py
@@ -1957,6 +1957,7 @@ class VoiceChannel(VocalGuildChannel, abc.Messageable):
         reason: Optional[str] = None,
     ) -> Webhook:
         """|coro|
+        Creates a webhook for this channel.
 
         Requires :attr:`~.Permissions.manage_webhooks` permissions.
 

--- a/nextcord/channel.py
+++ b/nextcord/channel.py
@@ -1458,6 +1458,7 @@ class ForumChannel(abc.GuildChannel, Hashable):
         )
         return Webhook.from_state(data, state=self._state)
 
+
 class VocalGuildChannel(abc.Connectable, abc.GuildChannel, Hashable):
     __slots__ = (
         "name",
@@ -1947,7 +1948,7 @@ class VoiceChannel(VocalGuildChannel, abc.Messageable):
             await ret[-1].delete()
 
         return ret
-    
+
     async def create_webhook(
         self,
         *,

--- a/nextcord/channel.py
+++ b/nextcord/channel.py
@@ -1957,10 +1957,9 @@ class VoiceChannel(VocalGuildChannel, abc.Messageable):
     ) -> Webhook:
         """|coro|
 
-        ..versionadded:: 2.3.2
-            Creates a webhook for this channel.
-
         Requires :attr:`~.Permissions.manage_webhooks` permissions.
+
+        ..versionadded:: 2.4
 
         Parameters
         ----------


### PR DESCRIPTION

## Summary

<!-- What is this pull request for? Does it fix any issues? -->

Added In The Create_Webhook For Text Channels To Forums And Voice Channels.

Weirdly on the voice channel, the webhook comes back good and does work, but it doesn't show in the Integration tab when editing the channel.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
  - [ ] I have updated the documentation to reflect the changes.
  - [ ] I have run `task pyright` and fixed the relevant issues.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
