### PR TITLE
docs(guild): rename nitro server to premium tier

### DIFF
--- a/nextcord/guild.py
+++ b/nextcord/guild.py
@@ -248,7 +248,7 @@ class Guild(Hashable):
         - ``WELCOME_SCREEN_ENABLED``: Guild has enabled the welcome screen.
 
     premium_tier: :class:`int`
-        The premium tier for this guild. Corresponds to "Nitro Server" in the official UI.
+        The premium tier for this guild. Corresponds to "Boost Level" in the official UI.
         The number goes from 0 to 3 inclusive.
     premium_subscription_count: :class:`int`
         The number of "boosts" this guild currently has.


### PR DESCRIPTION
## Summary

<!-- What is this pull request for? Does it fix any issues? -->
premium_tier are no longer called Nitro Server anymore. so this change it to the official term used in the UI.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
  - [ ] I have updated the documentation to reflect the changes.
  - [ ] I have run `task pyright` and fixed the relevant issues.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
