### PR TITLE
fix(iterators): switch _MappedAsyncIterator inheritance order

### DIFF
--- a/nextcord/iterators.py
+++ b/nextcord/iterators.py
@@ -167,29 +167,15 @@ class _ChunkedAsyncIterator(_AsyncIterator[List[T]]):
         return ret
 
 
-if TYPE_CHECKING:
+class _MappedAsyncIterator(_AsyncIterator[OT], Generic[T, OT]):
+    def __init__(self, iterator: _AsyncIterator[T], func: _Func[T, OT]) -> None:
+        self.iterator: _AsyncIterator[T] = iterator
+        self.func: _Func[T, Any] = func
 
-    class _MappedAsyncIterator(Generic[T, OT], _AsyncIterator[OT]):
-        def __init__(self, iterator: _AsyncIterator[T], func: _Func[T, OT]) -> None:
-            self.iterator: _AsyncIterator[T] = iterator
-            self.func: _Func[T, Any] = func
-
-        async def next(self) -> OT:
-            # this raises NoMoreItems and will propagate appropriately
-            item = await self.iterator.next()
-            return await maybe_coroutine(self.func, item)
-
-else:
-
-    class _MappedAsyncIterator(_AsyncIterator):
-        def __init__(self, iterator, func):
-            self.iterator = iterator
-            self.func = func
-
-        async def next(self):
-            # this raises NoMoreItems and will propagate appropriately
-            item = await self.iterator.next()
-            return await maybe_coroutine(self.func, item)
+    async def next(self) -> OT:
+        # this raises NoMoreItems and will propagate appropriately
+        item = await self.iterator.next()
+        return await maybe_coroutine(self.func, item)
 
 
 class _FilteredAsyncIterator(_AsyncIterator[T]):

--- a/nextcord/iterators.py
+++ b/nextcord/iterators.py
@@ -166,7 +166,9 @@ class _ChunkedAsyncIterator(_AsyncIterator[List[T]]):
                 n += 1
         return ret
 
+
 if t.TYPE_CHECKING:
+
     class _MappedAsyncIterator(Generic[T, OT], _AsyncIterator[OT]):
         def __init__(self, iterator: _AsyncIterator[T], func: _Func[T, OT]) -> None:
             self.iterator: _AsyncIterator[T] = iterator
@@ -176,7 +178,9 @@ if t.TYPE_CHECKING:
             # this raises NoMoreItems and will propagate appropriately
             item = await self.iterator.next()
             return await maybe_coroutine(self.func, item)
+
 else:
+
     class _MappedAsyncIterator(_AsyncIterator):
         def __init__(self, iterator, func):
             self.iterator = iterator

--- a/nextcord/iterators.py
+++ b/nextcord/iterators.py
@@ -167,7 +167,7 @@ class _ChunkedAsyncIterator(_AsyncIterator[List[T]]):
         return ret
 
 
-if t.TYPE_CHECKING:
+if TYPE_CHECKING:
 
     class _MappedAsyncIterator(Generic[T, OT], _AsyncIterator[OT]):
         def __init__(self, iterator: _AsyncIterator[T], func: _Func[T, OT]) -> None:

--- a/nextcord/iterators.py
+++ b/nextcord/iterators.py
@@ -166,16 +166,26 @@ class _ChunkedAsyncIterator(_AsyncIterator[List[T]]):
                 n += 1
         return ret
 
+if t.TYPE_CHECKING:
+    class _MappedAsyncIterator(Generic[T, OT], _AsyncIterator[OT]):
+        def __init__(self, iterator: _AsyncIterator[T], func: _Func[T, OT]) -> None:
+            self.iterator: _AsyncIterator[T] = iterator
+            self.func: _Func[T, Any] = func
 
-class _MappedAsyncIterator(Generic[T, OT], _AsyncIterator[OT]):
-    def __init__(self, iterator: _AsyncIterator[T], func: _Func[T, OT]) -> None:
-        self.iterator: _AsyncIterator[T] = iterator
-        self.func: _Func[T, Any] = func
+        async def next(self) -> OT:
+            # this raises NoMoreItems and will propagate appropriately
+            item = await self.iterator.next()
+            return await maybe_coroutine(self.func, item)
+else:
+    class _MappedAsyncIterator(_AsyncIterator):
+        def __init__(self, iterator, func):
+            self.iterator = iterator
+            self.func = func
 
-    async def next(self) -> OT:
-        # this raises NoMoreItems and will propagate appropriately
-        item = await self.iterator.next()
-        return await maybe_coroutine(self.func, item)
+        async def next(self):
+            # this raises NoMoreItems and will propagate appropriately
+            item = await self.iterator.next()
+            return await maybe_coroutine(self.func, item)
 
 
 class _FilteredAsyncIterator(_AsyncIterator[T]):


### PR DESCRIPTION
## Summary

This PR fixes a crucial bug with #872 in 3.9+ where it throws the following runtime error when the `nextcord` module is imported:
```python
Traceback (most recent call last):                                                        
File "/root/k", line 1, in <module>
    import nextcord
  File "/usr/local/lib/python3.10/dist-packages/nextcord-2.4.0a4182+gbb812e66-py3.10.egg/nextcord/__init__.py", line 24, in <module>
    from . import abc, opus, ui, utils
  File "/usr/local/lib/python3.10/dist-packages/nextcord-2.4.0a4182+gbb812e66-py3.10.egg/nextcord/abc.py", line 52, in <module>
    from .iterators import HistoryIterator
  File "/usr/local/lib/python3.10/dist-packages/nextcord-2.4.0a4182+gbb812e66-py3.10.egg/nextcord/iterators.py", line 170, in <module>
    class _MappedAsyncIterator(Generic[T, OT], _AsyncIterator[OT]):
  File "/usr/lib/python3.10/abc.py", line 106, in __new__
    cls = super().__new__(mcls, name, bases, namespace, **kwargs)
TypeError: Cannot create a consistent method resolution
order (MRO) for bases Generic, _AsyncIterator
```

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
  - [ ] I have updated the documentation to reflect the changes.
  - [ ] I have run `task pyright` and fixed the relevant issues.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
