### PR TITLE
fix(commands): stop setting private attribute directly

### DIFF
--- a/nextcord/ext/commands/core.py
+++ b/nextcord/ext/commands/core.py
@@ -433,19 +433,17 @@ class Command(_BaseCommand, Generic[CogT, P, T]):
         Callable[Concatenate[CogT, ContextT, P], Coro[T]],
         Callable[Concatenate[ContextT, P], Coro[T]],
     ]:
-        # May require adding ContextT to the Generic of Command
-        return self._callback  # type: ignore
+        return self._callback
 
     @callback.setter
     def callback(
         self,
         function: Union[
-            Callable[Concatenate[CogT, Context, P], Coro[T]],
-            Callable[Concatenate[Context, P], Coro[T]],
+            Callable[Concatenate[CogT, Context[Any], P], Coro[T]],
+            Callable[Concatenate[Context[Any], P], Coro[T]],
         ],
     ) -> None:
-        # pyright freaks out when I change the annotation above to use ContextT instead of Context
-        self._callback = function  # type: ignore
+        self._callback = function
         unwrap = unwrap_function(function)
         self.module = unwrap.__module__
 

--- a/nextcord/ext/commands/core.py
+++ b/nextcord/ext/commands/core.py
@@ -439,9 +439,9 @@ class Command(_BaseCommand, Generic[CogT, P, T]):
     @callback.setter
     def callback(
         self,
-        function: Union[
-            Callable[Concatenate[CogT, Context, P], Coro[T]],
-            Callable[Concatenate[Context, P], Coro[T]],
+        function: Union[t
+            Callable[Concatenate[CogT, ContextT, P], Coro[T]],
+            Callable[Concatenate[ContextT, P], Coro[T]],
         ],
     ) -> None:
         self._callback = function

--- a/nextcord/ext/commands/core.py
+++ b/nextcord/ext/commands/core.py
@@ -320,7 +320,7 @@ class Command(_BaseCommand, Generic[CogT, P, T]):
             raise TypeError("Name of a command must be a string.")
         self.name: str = name
 
-        # pyright complains that ContextT is incompatible with plain Context
+        # ContextT is incompatible with normal Context
         self.callback = func  # pyright: ignore
         self.enabled: bool = kwargs.get("enabled", True)
 

--- a/nextcord/ext/commands/core.py
+++ b/nextcord/ext/commands/core.py
@@ -440,11 +440,12 @@ class Command(_BaseCommand, Generic[CogT, P, T]):
     def callback(
         self,
         function: Union[t
-            Callable[Concatenate[CogT, ContextT, P], Coro[T]],
-            Callable[Concatenate[ContextT, P], Coro[T]],
+            Callable[Concatenate[CogT, Context, P], Coro[T]],
+            Callable[Concatenate[Context, P], Coro[T]],
         ],
     ) -> None:
-        self._callback = function
+        # pyright freaks out when I change the annotation above to use ContextT instead of Context
+        self._callback = function  # type: ignore
         unwrap = unwrap_function(function)
         self.module = unwrap.__module__
 

--- a/nextcord/ext/commands/core.py
+++ b/nextcord/ext/commands/core.py
@@ -320,7 +320,8 @@ class Command(_BaseCommand, Generic[CogT, P, T]):
             raise TypeError("Name of a command must be a string.")
         self.name: str = name
 
-        self.callback = func
+        # pyright complains that ContextT is incompatible with plain Context
+        self.callback = func  # pyright: ignore
         self.enabled: bool = kwargs.get("enabled", True)
 
         help_doc = kwargs.get("help")
@@ -439,8 +440,8 @@ class Command(_BaseCommand, Generic[CogT, P, T]):
     def callback(
         self,
         function: Union[
-            Callable[Concatenate[CogT, Context[Any], P], Coro[T]],
-            Callable[Concatenate[Context[Any], P], Coro[T]],
+            Callable[Concatenate[CogT, Context, P], Coro[T]],
+            Callable[Concatenate[Context, P], Coro[T]],
         ],
     ) -> None:
         self._callback = function

--- a/nextcord/ext/commands/core.py
+++ b/nextcord/ext/commands/core.py
@@ -320,7 +320,7 @@ class Command(_BaseCommand, Generic[CogT, P, T]):
             raise TypeError("Name of a command must be a string.")
         self.name: str = name
 
-        self._callback = func
+        self.callback = func
         self.enabled: bool = kwargs.get("enabled", True)
 
         help_doc = kwargs.get("help")

--- a/nextcord/ext/commands/core.py
+++ b/nextcord/ext/commands/core.py
@@ -439,7 +439,7 @@ class Command(_BaseCommand, Generic[CogT, P, T]):
     @callback.setter
     def callback(
         self,
-        function: Union[t
+        function: Union[
             Callable[Concatenate[CogT, Context, P], Coro[T]],
             Callable[Concatenate[Context, P], Coro[T]],
         ],


### PR DESCRIPTION
## Summary

This PR fixes a problem with #894 where an attribute in `Command` was changed to be set directly to the underlying private attribute which missed the property callback which sets another crucial attribute.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
  - [ ] I have updated the documentation to reflect the changes.
  - [ ] I have run `task pyright` and fixed the relevant issues.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
