### PR TITLE
docs: change mentions of nsfw to "age restricted"

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -2884,15 +2884,15 @@ of :class:`enum.Enum`.
 
     .. attribute:: explicit
 
-        The guild contains NSFW content.
+        The guild contains age restriced content.
 
     .. attribute:: safe
 
-        The guild does not contain any NSFW content.
+        The guild does not contain any age restriced content.
 
     .. attribute:: age_restricted
 
-        The guild may contain NSFW content.
+        The guild may contain age restriced content.
 
 .. class:: ScheduledEventEntityType
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -2930,16 +2930,16 @@ of :class:`enum.Enum`.
             Checks if two Age Restriction levels are not equal.
         .. describe:: x > y
 
-            Checks if a Age Restriction level is higher than another.
+            Checks if an Age Restriction level is higher than another.
         .. describe:: x < y
 
-            Checks if a Age Restriction level is lower than another.
+            Checks if an Age Restriction level is lower than another.
         .. describe:: x >= y
 
-            Checks if a Age Restriction level is higher or equal to another.
+            Checks if an Age Restriction level is higher or equal to another.
         .. describe:: x <= y
 
-            Checks if a Age Restriction level is lower or equal to another.
+            Checks if an Age Restriction level is lower or equal to another.
 
     .. attribute:: default
 
@@ -2947,15 +2947,15 @@ of :class:`enum.Enum`.
 
     .. attribute:: explicit
 
-        The guild contains age restriced content.
+        The guild contains age restricted content.
 
     .. attribute:: safe
 
-        The guild does not contain any age restriced content.
+        The guild does not contain any age restricted content.
 
     .. attribute:: age_restricted
 
-        The guild may contain age restriced content.
+        The guild may contain age restricted content.
 
 .. class:: ScheduledEventEntityType
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -2851,32 +2851,34 @@ of :class:`enum.Enum`.
 
         Alias for :attr:`.closed`
 
-.. class:: NSFWLevel
+.. class:: AgeRestrictionLevel
 
-    Represents the NSFW level of a guild.
+    Represents the Age Restriction level of a guild.
 
-    .. versionadded:: 2.0
+    There is an alias for this called ``NSFWLevel``.
+
+    .. versionadded:: 2.5
 
     .. container:: operations
 
         .. describe:: x == y
 
-            Checks if two NSFW levels are equal.
+            Checks if two Age Restriction levels are equal.
         .. describe:: x != y
 
-            Checks if two NSFW levels are not equal.
+            Checks if two Age Restriction levels are not equal.
         .. describe:: x > y
 
-            Checks if a NSFW level is higher than another.
+            Checks if a Age Restriction level is higher than another.
         .. describe:: x < y
 
-            Checks if a NSFW level is lower than another.
+            Checks if a Age Restriction level is lower than another.
         .. describe:: x >= y
 
-            Checks if a NSFW level is higher or equal to another.
+            Checks if a Age Restriction level is higher or equal to another.
         .. describe:: x <= y
 
-            Checks if a NSFW level is lower or equal to another.
+            Checks if a Age Restriction level is lower or equal to another.
 
     .. attribute:: default
 

--- a/docs/ext/application_checks/index.rst
+++ b/docs/ext/application_checks/index.rst
@@ -67,6 +67,9 @@ Other Checks
 .. autofunction:: is_nsfw
     :decorator:
 
+.. autofunction:: is_age_restricted
+    :decorator:
+
 Hooks
 -----
 
@@ -128,7 +131,7 @@ Exceptions
 .. autoexception:: ApplicationNotOwner
     :members:
 
-.. autoexception:: ApplicationNSFWChannelRequired
+.. autoexception:: ApplicationAgeRestrictedChannelRequired
     :members:
 
 .. autoexception:: ApplicationCheckForBotOnly
@@ -151,5 +154,5 @@ Exception Hierarchy
             - :exc:`~.ApplicationBotMissingPermissions`
             - :exc:`~.ApplicationPrivateMessageOnly`
             - :exc:`~.ApplicationNotOwner`
-            - :exc:`~.ApplicationNSFWChannelRequired`
+            - :exc:`~.ApplicationAgeRestrictedChannelRequired`
             - :exc:`~.ApplicationCheckForBotOnly`

--- a/docs/ext/commands/api.rst
+++ b/docs/ext/commands/api.rst
@@ -328,6 +328,9 @@ Checks
 .. autofunction:: nextcord.ext.commands.is_nsfw(,)
     :decorator:
 
+.. autofunction:: nextcord.ext.commands.is_age_restricted(,)
+    :decorator:
+
 .. _ext_commands_api_context:
 
 Cooldown
@@ -576,7 +579,7 @@ Exceptions
 .. autoexception:: nextcord.ext.commands.BotMissingAnyRole
     :members:
 
-.. autoexception:: nextcord.ext.commands.NSFWChannelRequired
+.. autoexception:: nextcord.ext.commands.AgeRestrictedChannelRequired
     :members:
 
 .. autoexception:: nextcord.ext.commands.FlagError
@@ -669,7 +672,7 @@ Exception Hierarchy
                 - :exc:`~.commands.BotMissingRole`
                 - :exc:`~.commands.MissingAnyRole`
                 - :exc:`~.commands.BotMissingAnyRole`
-                - :exc:`~.commands.NSFWChannelRequired`
+                - :exc:`~.commands.AgeRestrictedChannelRequired`
             - :exc:`~.commands.DisabledCommand`
             - :exc:`~.commands.CommandInvokeError`
             - :exc:`~.commands.CommandOnCooldown`

--- a/docs/migrating.rst
+++ b/docs/migrating.rst
@@ -408,7 +408,7 @@ They will be enumerated here.
 - :meth:`Guild.audit_logs` to fetch the guild's audit logs.
 - :attr:`Message.webhook_id` to fetch the message's webhook ID.
 - :attr:`Message.activity` and :attr:`Message.application` for Rich Presence-related information.
-- :meth:`TextChannel.is_nsfw` to check if a text channel is NSFW.
+- :meth:`TextChannel.is_nsfw` to check if a text channel is age restricted.
 - :meth:`Colour.from_rgb` to construct a :class:`Colour` from RGB tuple.
 - :meth:`Guild.get_role` to get a role by its ID.
 
@@ -916,7 +916,7 @@ Along with this change, a couple of new checks were added.
     - This is actually powered by a different function, :meth:`~ext.commands.Bot.is_owner`.
     - You can set the owner ID yourself by setting :attr:`.Bot.owner_id`.
 
-- :func:`~ext.commands.is_nsfw` checks if the channel the command is in is an NSFW channel.
+- :func:`~ext.commands.is_nsfw` checks if the channel the command is in is an age restricted channel.
 
     - This is powered by the new :meth:`TextChannel.is_nsfw` method.
 

--- a/docs/migrating.rst
+++ b/docs/migrating.rst
@@ -916,7 +916,7 @@ Along with this change, a couple of new checks were added.
     - This is actually powered by a different function, :meth:`~ext.commands.Bot.is_owner`.
     - You can set the owner ID yourself by setting :attr:`.Bot.owner_id`.
 
-- :func:`~ext.commands.is_nsfw` checks if the channel the command is in is an age restricted channel.
+- :func:`~ext.commands.is_nsfw` checks if the channel the command is in is age restricted.
 
     - This is powered by the new :meth:`TextChannel.is_nsfw` method.
 

--- a/docs/whats_new.rst
+++ b/docs/whats_new.rst
@@ -1158,7 +1158,7 @@ Bug Fixes
 - Use message creation time for reference time when computing cooldowns.
     - This prevents cooldowns from triggering during e.g. a RESUME session.
 - Fix the default :func:`on_command_error` to work with new-style cogs (:dpyissue:`2094`)
-- DM channels are now recognised as age restricted in :func:`~.commands.is_nsfw` check.
+- DM channels are now recognised as NSFW in :func:`~.commands.is_nsfw` check.
 - Fix race condition with help commands (:dpyissue:`2123`)
 - Fix cog descriptions not showing in :class:`~.commands.MinimalHelpCommand` (:dpyissue:`2139`)
 

--- a/docs/whats_new.rst
+++ b/docs/whats_new.rst
@@ -1053,7 +1053,7 @@ Bug Fixes
 - Use message creation time for reference time when computing cooldowns.
     - This prevents cooldowns from triggering during e.g. a RESUME session.
 - Fix the default :func:`on_command_error` to work with new-style cogs (:dpyissue:`2094`)
-- DM channels are now recognised as NSFW in :func:`~.commands.is_nsfw` check.
+- DM channels are now recognised as age restricted in :func:`~.commands.is_nsfw` check.
 - Fix race condition with help commands (:dpyissue:`2123`)
 - Fix cog descriptions not showing in :class:`~.commands.MinimalHelpCommand` (:dpyissue:`2139`)
 

--- a/nextcord/abc.py
+++ b/nextcord/abc.py
@@ -298,6 +298,13 @@ class GuildChannel:
     async def _edit(
         self, options: Dict[str, Any], reason: Optional[str]
     ) -> Optional[ChannelPayload]:
+        # API still calls it "nsfw" but we call it "age_restricted"
+        # so we need to convert it
+        try:
+            options["nsfw"] = options.pop("age_restricted")
+        except KeyError:
+            pass
+
         try:
             parent = options.pop("category")
         except KeyError:

--- a/nextcord/channel.py
+++ b/nextcord/channel.py
@@ -142,7 +142,7 @@ class TextChannel(abc.Messageable, abc.GuildChannel, Hashable, PinsMixin):
 
         .. note::
 
-            To check if the channel or the guild of that channel are marked as age restricted, consider :meth:`is_nsfw` instead.
+            To check if the channel or the guild of that channel are age restricted, consider :meth:`is_nsfw` instead.
     default_auto_archive_duration: :class:`int`
         The default auto archive duration in minutes for threads created in this channel.
 
@@ -1548,7 +1548,7 @@ class VoiceChannel(VocalGuildChannel, abc.Messageable):
 
         .. note::
 
-            To check if the channel or the guild of that channel are marked as age restricted, consider :meth:`is_nsfw` instead.
+            To check if the channel or the guild of that channel are age restricted, consider :meth:`is_nsfw` instead.
 
         .. versionadded:: 2.1
     flags: :class:`ChannelFlags`
@@ -2213,7 +2213,7 @@ class CategoryChannel(abc.GuildChannel, Hashable):
 
         .. note::
 
-            To check if the channel or the guild of that channel are marked as age restricted, consider :meth:`is_nsfw` instead.
+            To check if the channel or the guild of that channel are age restricted, consider :meth:`is_nsfw` instead.
     flags: :class:`ChannelFlags`
         Extra features of the channel.
 

--- a/nextcord/channel.py
+++ b/nextcord/channel.py
@@ -138,11 +138,19 @@ class TextChannel(abc.Messageable, abc.GuildChannel, Hashable, PinsMixin):
 
         ..versionadded:: 2.1
     nsfw: :class:`bool`
-        If the channel is marked as "not safe for work".
+        Alias for :attr:`.age_restricted`.
+
+        .. vesionchanged:: 2.5
+            This is now an alias for :attr:`.age_restricted`.
+    age_restricted: :class:`bool`
+        If the channel is age restricted.
 
         .. note::
 
-            To check if the channel or the guild of that channel are age restricted, consider :meth:`is_nsfw` instead.
+            To check if the channel or the guild of that channel are age restricted, consider :meth:`.is_age_restricted` instead.
+
+        .. versionadded:: 2.5
+
     default_auto_archive_duration: :class:`int`
         The default auto archive duration in minutes for threads created in this channel.
 
@@ -162,6 +170,7 @@ class TextChannel(abc.Messageable, abc.GuildChannel, Hashable, PinsMixin):
         "topic",
         "_state",
         "nsfw",
+        "age_restricted",
         "category_id",
         "position",
         "slowmode_delay",
@@ -184,7 +193,7 @@ class TextChannel(abc.Messageable, abc.GuildChannel, Hashable, PinsMixin):
             ("id", self.id),
             ("name", self.name),
             ("position", self.position),
-            ("nsfw", self.nsfw),
+            ("age_restricted", self.age_restricted),
             ("news", self.is_news()),
             ("category_id", self.category_id),
         ]
@@ -197,7 +206,9 @@ class TextChannel(abc.Messageable, abc.GuildChannel, Hashable, PinsMixin):
         self.category_id: Optional[int] = utils.get_as_snowflake(data, "parent_id")
         self.topic: Optional[str] = data.get("topic")
         self.position: int = data["position"]
-        self.nsfw: bool = data.get("nsfw", False)
+        self.age_restricted: bool = data.get("nsfw", False)
+        # Alias
+        self.nsfw: bool = self.age_restricted
         # Does this need coercion into `int`? No idea yet.
         self.slowmode_delay: int = data.get("rate_limit_per_user", 0)
         self.default_auto_archive_duration: ThreadArchiveDuration = data.get(
@@ -243,9 +254,20 @@ class TextChannel(abc.Messageable, abc.GuildChannel, Hashable, PinsMixin):
         """
         return [thread for thread in self.guild._threads.values() if thread.parent_id == self.id]
 
+    def is_age_restricted(self) -> bool:
+        """:class:`bool`: Checks if the channel is age restricted.
+
+        .. versionadded:: 2.5
+        """
+        return self.age_restricted
+
     def is_nsfw(self) -> bool:
-        """:class:`bool`: Checks if the channel is age restricted."""
-        return self.nsfw
+        """:class:`bool`: Alias for :attr:`.is_age_restricted`
+
+        .. vesionchanged:: 2.5
+            This is now an alias for :meth:`.is_age_restricted`.
+        """
+        return self.is_age_restricted()
 
     def is_news(self) -> bool:
         """:class:`bool`: Checks if the channel is a news channel."""
@@ -280,7 +302,27 @@ class TextChannel(abc.Messageable, abc.GuildChannel, Hashable, PinsMixin):
         name: str = ...,
         topic: str = ...,
         position: int = ...,
-        nsfw: bool = ...,
+        age_restricted: bool = ...,
+        sync_permissions: bool = ...,
+        category: Optional[CategoryChannel] = ...,
+        slowmode_delay: int = ...,
+        default_auto_archive_duration: ThreadArchiveDuration = ...,
+        type: ChannelType = ...,
+        overwrites: Mapping[Union[Role, Member, Snowflake], PermissionOverwrite] = ...,
+        flags: ChannelFlags = ...,
+        default_thread_slowmode_delay: int = ...,
+    ) -> Optional[TextChannel]:
+        ...
+
+    @overload
+    async def edit(
+        self,
+        *,
+        reason: Optional[str] = ...,
+        name: str = ...,
+        topic: str = ...,
+        position: int = ...,
+        nsfw: bool = ...,  # alias of age_restricted
         sync_permissions: bool = ...,
         category: Optional[CategoryChannel] = ...,
         slowmode_delay: int = ...,
@@ -322,7 +364,14 @@ class TextChannel(abc.Messageable, abc.GuildChannel, Hashable, PinsMixin):
         position: :class:`int`
             The new channel's position.
         nsfw: :class:`bool`
+            Alias for ``age_restricted``.
+
+            .. versionchanged:: 2.5
+                This is now an alias for ``age_restricted``.
+        age_restricted: :class:`bool`
             To mark the channel as age restricted or not.
+
+            .. versionadded:: 2.5
         sync_permissions: :class:`bool`
             Whether to sync permissions with the channel's new or pre-existing
             category. Defaults to ``False``.
@@ -366,7 +415,6 @@ class TextChannel(abc.Messageable, abc.GuildChannel, Hashable, PinsMixin):
             The newly edited text channel. If the edit was only positional
             then ``None`` is returned instead.
         """
-
         payload = await self._edit(options, reason=reason)
         if payload is not None:
             # the payload will always be the proper channel payload
@@ -377,7 +425,11 @@ class TextChannel(abc.Messageable, abc.GuildChannel, Hashable, PinsMixin):
         self, *, name: Optional[str] = None, reason: Optional[str] = None
     ) -> TextChannel:
         return await self._clone_impl(
-            {"topic": self.topic, "nsfw": self.nsfw, "rate_limit_per_user": self.slowmode_delay},
+            {
+                "topic": self.topic,
+                "nsfw": self.age_restricted,
+                "rate_limit_per_user": self.slowmode_delay,
+            },
             name=name,
             reason=reason,
         )
@@ -870,7 +922,14 @@ class ForumChannel(abc.GuildChannel, Hashable):
     position: :class:`int`
         The position in the channel list, where the first channel is ``0``.
     nsfw: :class:`bool`
+        Alias for :attr:`.age_restricted`.
+
+        .. versionadded:: 2.5
+            This is now an alias for :attr:`.age_restricted`.
+    age_restricted: :class:`bool`
         If this channel is age restricted.
+
+        .. versionadded:: 2.5
     slowmode_delay: :class:`int`
         The delay in seconds which members must wait between sending messages.
     flags: :class:`ChannelFlags`
@@ -903,6 +962,7 @@ class ForumChannel(abc.GuildChannel, Hashable):
         "position",
         "topic",
         "nsfw",
+        "age_restricted",
         "flags",
         "slowmode_delay",
         "default_auto_archive_duration",
@@ -928,7 +988,8 @@ class ForumChannel(abc.GuildChannel, Hashable):
         self.category_id: Optional[int] = utils.get_as_snowflake(data, "parent_id")
         self.topic: Optional[str] = data.get("topic")
         self.position: int = data["position"]
-        self.nsfw: bool = data.get("nsfw", False)
+        self.age_restricted: bool = data.get("nsfw", False)
+        self.nsfw: bool = self.age_restricted
         # Does this need coercion into `int`? No idea yet.
         self.slowmode_delay: int = data.get("rate_limit_per_user", 0)
         self.flags: ChannelFlags = ChannelFlags._from_value(data.get("flags", 0))
@@ -990,9 +1051,20 @@ class ForumChannel(abc.GuildChannel, Hashable):
         """List[:class:`Thread`]: Returns all the threads of this channel."""
         return [thread for thread in self.guild._threads.values() if thread.parent_id == self.id]
 
+    def is_age_restricted(self) -> bool:
+        """:class:`bool`: Checks if the channel is age restricted.
+
+        .. versionadded:: 2.5
+        """
+        return self.age_restricted
+
     def is_nsfw(self) -> bool:
-        """:class:`bool`: Checks if the channel is age restricted."""
-        return self.nsfw
+        """:class:`bool`: Alias for :meth:`.is_age_restricted`.
+
+        .. versionchanged:: 2.5
+            This is now an alias for :meth:`.is_age_restricted`.
+        """
+        return self.is_age_restricted()
 
     @property
     def last_message(self) -> Optional[Message]:
@@ -1049,7 +1121,29 @@ class ForumChannel(abc.GuildChannel, Hashable):
         name: str = ...,
         topic: str = ...,
         position: int = ...,
-        nsfw: bool = ...,
+        age_resricted: bool = ...,
+        sync_permissions: bool = ...,
+        category: Optional[CategoryChannel] = ...,
+        slowmode_delay: int = ...,
+        default_auto_archive_duration: ThreadArchiveDuration = ...,
+        overwrites: Mapping[Union[Role, Member, Snowflake], PermissionOverwrite] = ...,
+        flags: ChannelFlags = ...,
+        reason: Optional[str] = ...,
+        default_sort_order: Optional[SortOrderType] = ...,
+        default_thread_slowmode_delay: int = ...,
+        available_tags: List[ForumTag] = ...,
+        default_reaction: Optional[Union[Emoji, PartialEmoji, str]] = ...,
+    ) -> ForumChannel:
+        ...
+
+    @overload
+    async def edit(
+        self,
+        *,
+        name: str = ...,
+        topic: str = ...,
+        position: int = ...,
+        nsfw: bool = ...,  # alias for age_restricted
         sync_permissions: bool = ...,
         category: Optional[CategoryChannel] = ...,
         slowmode_delay: int = ...,
@@ -1085,7 +1179,14 @@ class ForumChannel(abc.GuildChannel, Hashable):
         position: :class:`int`
             The new channel's position.
         nsfw: :class:`bool`
+            Alias for ``age_restricted``.
+
+            .. versionchanged:: 2.5
+                This is now an alias for ``age_restricted``.
+        age_resricted: :class:`bool`
             To mark the channel as age restricted or not.
+
+            .. versionadded:: 2.5
         sync_permissions: :class:`bool`
             Whether to sync permissions with the channel's new or pre-existing
             category. Defaults to ``False``.
@@ -1544,13 +1645,20 @@ class VoiceChannel(VocalGuildChannel, abc.Messageable):
 
         .. versionadded:: 2.1
     nsfw: :class:`bool`
-        If the channel is marked as "not safe for work".
+        Alias for :attr:`.age_resricted`.
+
+        .. versionadded:: 2.1
+
+        .. versionchanged:: 2.5
+            This is now an alias for :attr:`.age_resricted`.
+    age_resricted: :class:`bool`
+        If the channel is age restricted.
 
         .. note::
 
-            To check if the channel or the guild of that channel are age restricted, consider :meth:`is_nsfw` instead.
+            To check if the channel or the guild of that channel are age restricted, consider :meth:`.is_age_resricted` instead.
 
-        .. versionadded:: 2.1
+        .. versionadded:: 2.5
     flags: :class:`ChannelFlags`
         Extra features of the channel.
 
@@ -1560,6 +1668,7 @@ class VoiceChannel(VocalGuildChannel, abc.Messageable):
     __slots__ = (
         "last_message_id",
         "nsfw",
+        "age_restricted",
     )
 
     def __repr__(self) -> str:
@@ -1579,7 +1688,7 @@ class VoiceChannel(VocalGuildChannel, abc.Messageable):
     def _update(self, guild: Guild, data: VoiceChannelPayload) -> None:
         VocalGuildChannel._update(self, guild, data)
         self.last_message_id: Optional[int] = utils.get_as_snowflake(data, "last_message_id")
-        self.nsfw: bool = data.get("nsfw", False)
+        self.age_restricted: bool = data.get("nsfw", False)
 
     async def _get_channel(self):
         return self
@@ -1589,9 +1698,20 @@ class VoiceChannel(VocalGuildChannel, abc.Messageable):
         """:class:`ChannelType`: The channel's Discord type."""
         return ChannelType.voice
 
+    def is_age_restricted(self) -> bool:
+        """:class:`bool`: Check if the channel is age restricted.
+
+        .. versionadded:: 2.5
+        """
+        return self.age_restricted
+
     def is_nsfw(self) -> bool:
-        """:class:`bool`: Checks if the channel is age restricted."""
-        return self.nsfw
+        """:class:`bool`: Alias for :meth:`.is_age_restricted`.
+
+        .. versionchanged:: 2.5
+            This is now an alias for :meth:`.is_age_restricted`.
+        """
+        return self.is_age_restricted()
 
     @property
     def last_message(self) -> Optional[Message]:
@@ -2209,11 +2329,18 @@ class CategoryChannel(abc.GuildChannel, Hashable):
         The position in the category list. This is a number that starts at 0. e.g. the
         top category is position 0.
     nsfw: :class:`bool`
-        If the channel is marked as age restricted.
+        Alias for :attr:`.age_restricted`.
+
+        .. versionchanged:: 2.5
+            This is now an alias for :attr:`.age_restricted`.
+    age_restricted: :class:`bool`
+        If the channel is age restricted.
 
         .. note::
 
-            To check if the channel or the guild of that channel are age restricted, consider :meth:`is_nsfw` instead.
+            To check if the channel or the guild of that channel are age restricted, consider :meth:`is_age_restricted` instead.
+
+        .. versionadded:: 2.5
     flags: :class:`ChannelFlags`
         Extra features of the channel.
 
@@ -2225,6 +2352,7 @@ class CategoryChannel(abc.GuildChannel, Hashable):
         "id",
         "guild",
         "nsfw",
+        "age_restricted",
         "_state",
         "position",
         "_overwrites",
@@ -2238,13 +2366,14 @@ class CategoryChannel(abc.GuildChannel, Hashable):
         self._update(guild, data)
 
     def __repr__(self) -> str:
-        return f"<CategoryChannel id={self.id} name={self.name!r} position={self.position} nsfw={self.nsfw}>"
+        return f"<CategoryChannel id={self.id} name={self.name!r} position={self.position} age_resricted={self.nsfw}>"
 
     def _update(self, guild: Guild, data: CategoryChannelPayload) -> None:
         self.guild: Guild = guild
         self.name: str = data["name"]
         self.category_id: Optional[int] = utils.get_as_snowflake(data, "parent_id")
-        self.nsfw: bool = data.get("nsfw", False)
+        self.age_restricted: bool = data.get("nsfw", False)
+        self.nsfw: bool = self.age_restricted
         self.position: int = data["position"]
         self.flags: ChannelFlags = ChannelFlags._from_value(data.get("flags", 0))
         self._fill_overwrites(data)
@@ -2258,9 +2387,20 @@ class CategoryChannel(abc.GuildChannel, Hashable):
         """:class:`ChannelType`: The channel's Discord type."""
         return ChannelType.category
 
+    def is_age_restricted(self) -> bool:
+        """:class:`bool`: Checks if the category is age restricted.
+
+        .. versionadded:: 2.5
+        """
+        return self.age_restricted
+
     def is_nsfw(self) -> bool:
-        """:class:`bool`: Checks if the category is age restricted."""
-        return self.nsfw
+        """:class:`bool`: Alias for :meth:`.is_age_restricted`.
+
+        .. versionchanged:: 2.5
+            This is now an alias for :meth:`.is_age_restricted`.
+        """
+        return self.is_age_restricted()
 
     @utils.copy_doc(abc.GuildChannel.clone)
     async def clone(
@@ -2274,7 +2414,20 @@ class CategoryChannel(abc.GuildChannel, Hashable):
         *,
         name: str = ...,
         position: int = ...,
-        nsfw: bool = ...,
+        age_restricted: bool = ...,
+        overwrites: Mapping[Union[Role, Member], PermissionOverwrite] = ...,
+        flags: ChannelFlags = ...,
+        reason: Optional[str] = ...,
+    ) -> Optional[CategoryChannel]:
+        ...
+
+    @overload
+    async def edit(
+        self,
+        *,
+        name: str = ...,
+        position: int = ...,
+        nsfw: bool = ...,  # alias for age_restricted
         overwrites: Mapping[Union[Role, Member], PermissionOverwrite] = ...,
         flags: ChannelFlags = ...,
         reason: Optional[str] = ...,
@@ -2306,7 +2459,14 @@ class CategoryChannel(abc.GuildChannel, Hashable):
         position: :class:`int`
             The new category's position.
         nsfw: :class:`bool`
+            Alias for ``age_restricted``.
+
+            .. versionchanged:: 2.5
+                This is now an alias for ``age_restricted``.
+        age_restricted: :class:`bool`
             To mark the category as age restricted or not.
+
+            .. versionadded:: 2.5
         reason: Optional[:class:`str`]
             The reason for editing this category. Shows up on the audit log.
         overwrites: :class:`Mapping`

--- a/nextcord/channel.py
+++ b/nextcord/channel.py
@@ -142,7 +142,7 @@ class TextChannel(abc.Messageable, abc.GuildChannel, Hashable, PinsMixin):
 
         .. note::
 
-            To check if the channel or the guild of that channel are marked as NSFW, consider :meth:`is_nsfw` instead.
+            To check if the channel or the guild of that channel are marked as age restricted, consider :meth:`is_nsfw` instead.
     default_auto_archive_duration: :class:`int`
         The default auto archive duration in minutes for threads created in this channel.
 
@@ -244,7 +244,7 @@ class TextChannel(abc.Messageable, abc.GuildChannel, Hashable, PinsMixin):
         return [thread for thread in self.guild._threads.values() if thread.parent_id == self.id]
 
     def is_nsfw(self) -> bool:
-        """:class:`bool`: Checks if the channel is NSFW."""
+        """:class:`bool`: Checks if the channel is age restricted."""
         return self.nsfw
 
     def is_news(self) -> bool:
@@ -322,7 +322,7 @@ class TextChannel(abc.Messageable, abc.GuildChannel, Hashable, PinsMixin):
         position: :class:`int`
             The new channel's position.
         nsfw: :class:`bool`
-            To mark the channel as NSFW or not.
+            To mark the channel as age restricted or not.
         sync_permissions: :class:`bool`
             Whether to sync permissions with the channel's new or pre-existing
             category. Defaults to ``False``.
@@ -870,7 +870,7 @@ class ForumChannel(abc.GuildChannel, Hashable):
     position: :class:`int`
         The position in the channel list, where the first channel is ``0``.
     nsfw: :class:`bool`
-        If this channel is marked as NSFW.
+        If this channel is age restricted.
     slowmode_delay: :class:`int`
         The delay in seconds which members must wait between sending messages.
     flags: :class:`ChannelFlags`
@@ -991,7 +991,7 @@ class ForumChannel(abc.GuildChannel, Hashable):
         return [thread for thread in self.guild._threads.values() if thread.parent_id == self.id]
 
     def is_nsfw(self) -> bool:
-        """:class:`bool`: Checks if the channel is NSFW."""
+        """:class:`bool`: Checks if the channel is age restricted."""
         return self.nsfw
 
     @property
@@ -1085,7 +1085,7 @@ class ForumChannel(abc.GuildChannel, Hashable):
         position: :class:`int`
             The new channel's position.
         nsfw: :class:`bool`
-            To mark the channel as NSFW or not.
+            To mark the channel as age restricted or not.
         sync_permissions: :class:`bool`
             Whether to sync permissions with the channel's new or pre-existing
             category. Defaults to ``False``.
@@ -1548,7 +1548,7 @@ class VoiceChannel(VocalGuildChannel, abc.Messageable):
 
         .. note::
 
-            To check if the channel or the guild of that channel are marked as NSFW, consider :meth:`is_nsfw` instead.
+            To check if the channel or the guild of that channel are marked as age restricted, consider :meth:`is_nsfw` instead.
 
         .. versionadded:: 2.1
     flags: :class:`ChannelFlags`
@@ -1590,7 +1590,7 @@ class VoiceChannel(VocalGuildChannel, abc.Messageable):
         return ChannelType.voice
 
     def is_nsfw(self) -> bool:
-        """:class:`bool`: Checks if the channel is NSFW."""
+        """:class:`bool`: Checks if the channel is age restricted."""
         return self.nsfw
 
     @property
@@ -2209,11 +2209,11 @@ class CategoryChannel(abc.GuildChannel, Hashable):
         The position in the category list. This is a number that starts at 0. e.g. the
         top category is position 0.
     nsfw: :class:`bool`
-        If the channel is marked as "not safe for work".
+        If the channel is marked as age restricted.
 
         .. note::
 
-            To check if the channel or the guild of that channel are marked as NSFW, consider :meth:`is_nsfw` instead.
+            To check if the channel or the guild of that channel are marked as age restricted, consider :meth:`is_nsfw` instead.
     flags: :class:`ChannelFlags`
         Extra features of the channel.
 
@@ -2259,7 +2259,7 @@ class CategoryChannel(abc.GuildChannel, Hashable):
         return ChannelType.category
 
     def is_nsfw(self) -> bool:
-        """:class:`bool`: Checks if the category is NSFW."""
+        """:class:`bool`: Checks if the category is age restricted."""
         return self.nsfw
 
     @utils.copy_doc(abc.GuildChannel.clone)
@@ -2306,7 +2306,7 @@ class CategoryChannel(abc.GuildChannel, Hashable):
         position: :class:`int`
             The new category's position.
         nsfw: :class:`bool`
-            To mark the category as NSFW or not.
+            To mark the category as age restricted or not.
         reason: Optional[:class:`str`]
             The reason for editing this category. Shows up on the audit log.
         overwrites: :class:`Mapping`

--- a/nextcord/channel.py
+++ b/nextcord/channel.py
@@ -145,11 +145,11 @@ class TextChannel(abc.Messageable, abc.GuildChannel, Hashable, PinsMixin):
         .. vesionchanged:: 2.5
             This is now an alias for :attr:`.age_restricted`.
     age_restricted: :class:`bool`
-        If the channel is age restricted.
+        Whether the channel is age restricted.
 
         .. note::
 
-            To check if the channel or the guild of that channel are age restricted, consider :meth:`.is_age_restricted` instead.
+            To check whether the channel or the guild of that channel are age restricted, consider :meth:`.is_age_restricted` instead.
 
         .. versionadded:: 2.5
 
@@ -340,7 +340,7 @@ class TextChannel(abc.Messageable, abc.GuildChannel, Hashable, PinsMixin):
     async def edit(self) -> Optional[TextChannel]:
         ...
 
-    async def edit(self, *, reason=None, **options):
+    async def edit(self, *, reason: Optional[str] = None, **options):
         """|coro|
 
         Edits the channel.
@@ -933,7 +933,7 @@ class ForumChannel(abc.GuildChannel, Hashable):
     nsfw: :class:`bool`
         Alias for :attr:`.age_restricted`.
 
-        .. versionadded:: 2.5
+        .. versionchanged:: 2.5
             This is now an alias for :attr:`.age_restricted`.
     age_restricted: :class:`bool`
         If this channel is age restricted.
@@ -1181,7 +1181,7 @@ class ForumChannel(abc.GuildChannel, Hashable):
     async def edit(self) -> ForumChannel:
         ...
 
-    async def edit(self, *, reason=None, **options) -> ForumChannel:
+    async def edit(self, *, reason: Optional[str] = None, **options) -> ForumChannel:
         """|coro|
 
         Edits the channel.
@@ -1855,7 +1855,7 @@ class VoiceChannel(VocalGuildChannel, abc.Messageable):
     async def edit(self) -> Optional[VoiceChannel]:
         ...
 
-    async def edit(self, *, reason=None, **options):
+    async def edit(self, *, reason: Optional[str] = None, **options):
         """|coro|
 
         Edits the channel.
@@ -2370,7 +2370,7 @@ class StageChannel(VocalGuildChannel):
     async def edit(self) -> Optional[StageChannel]:
         ...
 
-    async def edit(self, *, reason=None, **options):
+    async def edit(self, *, reason: Optional[str] = None, **options):
         """|coro|
 
         Edits the channel.
@@ -2577,7 +2577,7 @@ class CategoryChannel(abc.GuildChannel, Hashable):
     async def edit(self) -> Optional[CategoryChannel]:
         ...
 
-    async def edit(self, *, reason=None, **options):
+    async def edit(self, *, reason: Optional[str] = None, **options):
         """|coro|
 
         Edits the channel.

--- a/nextcord/enums.py
+++ b/nextcord/enums.py
@@ -39,6 +39,7 @@ __all__ = (
     "ApplicationCommandType",
     "ApplicationCommandOptionType",
     "NSFWLevel",
+    "AgeRestrictionLevel",
     "ScheduledEventEntityType",
     "ScheduledEventPrivacyLevel",
     "ScheduledEventStatus",
@@ -658,11 +659,15 @@ class StagePrivacyLevel(IntEnum):
     guild_only = 2
 
 
-class NSFWLevel(IntEnum):
+class AgeRestrictionLevel(IntEnum):
     default = 0
     explicit = 1
     safe = 2
     age_restricted = 3
+
+
+# Alias
+NSFWLevel = AgeRestrictionLevel
 
 
 class ScheduledEventEntityType(IntEnum):

--- a/nextcord/ext/application_checks/core.py
+++ b/nextcord/ext/application_checks/core.py
@@ -15,6 +15,7 @@ from nextcord.application_command import (
 from nextcord.interactions import Interaction
 
 from .errors import (
+    ApplicationAgeRestrictedChannelRequired,
     ApplicationBotMissingAnyRole,
     ApplicationBotMissingPermissions,
     ApplicationBotMissingRole,
@@ -26,7 +27,6 @@ from .errors import (
     ApplicationMissingRole,
     ApplicationNoPrivateMessage,
     ApplicationNotOwner,
-    ApplicationNSFWChannelRequired,
     ApplicationPrivateMessageOnly,
 )
 
@@ -49,6 +49,7 @@ __all__ = (
     "guild_only",
     "is_owner",
     "is_nsfw",
+    "is_age_restricted",
     "application_command_before_invoke",
     "application_command_after_invoke",
 )
@@ -659,10 +660,21 @@ def is_owner() -> AC:
 
 
 def is_nsfw() -> AC:
+    """This is an alias for :func:`.is_age_restricted`.
+
+    .. versionchanged:: 2.5
+        This is now an alias for :func:`.is_age_restricted`.
+    """
+    return is_age_restricted()
+
+
+def is_age_restricted() -> AC:
     """A :func:`.check` that checks if the channel is age restricted.
 
-    This check raises a special exception, :exc:`.ApplicationNSFWChannelRequired`
+    This check raises a special exception, :exc:`.ApplicationAgeRestrictedChannelRequired`
     that is derived from :exc:`.ApplicationCheckFailure`.
+
+    .. versionadded:: 2.5
 
     Example
     -------
@@ -670,7 +682,7 @@ def is_nsfw() -> AC:
     .. code-block:: python3
 
         @bot.slash_command()
-        @application_checks.is_nsfw()
+        @application_checks.is_age_restricted()
         async def ownercmd(interaction: Interaction):
             await interaction.response.send_message('Only age restricted channels!')
     """
@@ -678,10 +690,10 @@ def is_nsfw() -> AC:
     def pred(interaction: Interaction) -> bool:
         ch = interaction.channel
         if interaction.guild is None or (
-            isinstance(ch, (nextcord.TextChannel, nextcord.Thread)) and ch.is_nsfw()
+            isinstance(ch, (nextcord.TextChannel, nextcord.Thread)) and ch.is_age_restricted()
         ):
             return True
-        raise ApplicationNSFWChannelRequired(ch)
+        raise ApplicationAgeRestrictedChannelRequired(ch)
 
     return check(pred)
 

--- a/nextcord/ext/application_checks/core.py
+++ b/nextcord/ext/application_checks/core.py
@@ -659,7 +659,7 @@ def is_owner() -> AC:
 
 
 def is_nsfw() -> AC:
-    """A :func:`.check` that checks if the channel is a age restricted channel.
+    """A :func:`.check` that checks if the channel is age restricted.
 
     This check raises a special exception, :exc:`.ApplicationNSFWChannelRequired`
     that is derived from :exc:`.ApplicationCheckFailure`.

--- a/nextcord/ext/application_checks/core.py
+++ b/nextcord/ext/application_checks/core.py
@@ -659,7 +659,7 @@ def is_owner() -> AC:
 
 
 def is_nsfw() -> AC:
-    """A :func:`.check` that checks if the channel is a NSFW channel.
+    """A :func:`.check` that checks if the channel is a age restricted channel.
 
     This check raises a special exception, :exc:`.ApplicationNSFWChannelRequired`
     that is derived from :exc:`.ApplicationCheckFailure`.
@@ -672,7 +672,7 @@ def is_nsfw() -> AC:
         @bot.slash_command()
         @application_checks.is_nsfw()
         async def ownercmd(interaction: Interaction):
-            await interaction.response.send_message('Only NSFW channels!')
+            await interaction.response.send_message('Only age restricted channels!')
     """
 
     def pred(interaction: Interaction) -> bool:

--- a/nextcord/ext/application_checks/errors.py
+++ b/nextcord/ext/application_checks/errors.py
@@ -232,19 +232,19 @@ class ApplicationNotOwner(ApplicationCheckFailure):
 
 
 class ApplicationNSFWChannelRequired(ApplicationCheckFailure):
-    """Exception raised when a channel does not have the required NSFW setting.
+    """Exception raised when a channel is not age restricted.
 
     This inherits from :exc:`~.ApplicationCheckFailure`.
 
     Parameters
     ----------
     channel: Optional[Union[:class:`.abc.GuildChannel`, :class:`.Thread`, :class:`PartialMessageable`]]
-        The channel that does not have NSFW enabled.
+        The channel is not age restricted.
     """
 
     def __init__(self, channel: Optional[Union[GuildChannel, Thread, PartialMessageable]]) -> None:
         self.channel: Optional[Union[GuildChannel, Thread, PartialMessageable]] = channel
-        super().__init__(f"Channel '{channel}' needs to be NSFW for this command to work.")
+        super().__init__(f"Channel '{channel}' must be age restricted to use this command to work.")
 
 
 class ApplicationCheckForBotOnly(ApplicationCheckFailure):

--- a/nextcord/ext/application_checks/errors.py
+++ b/nextcord/ext/application_checks/errors.py
@@ -20,6 +20,7 @@ __all__ = (
     "ApplicationPrivateMessageOnly",
     "ApplicationNotOwner",
     "ApplicationNSFWChannelRequired",
+    "ApplicationAgeRestrictedChannelRequired",
     "ApplicationCheckForBotOnly",
 )
 
@@ -231,20 +232,28 @@ class ApplicationNotOwner(ApplicationCheckFailure):
     pass
 
 
-class ApplicationNSFWChannelRequired(ApplicationCheckFailure):
+class ApplicationAgeRestrictedChannelRequired(ApplicationCheckFailure):
     """Exception raised when a channel is not age restricted.
 
     This inherits from :exc:`~.ApplicationCheckFailure`.
 
+    There is an alias for this called ``ApplicationNSFWChannelRequired``
+
+    .. versionchanged:: 2.5
+        Changed the name from ``ApplicationNSFWChannelRequired`` to :exc:`ApplicationAgeRestrictedChannelRequired`. ``ApplicationNSFWChannelRequired`` is now an alias.
+
     Parameters
     ----------
     channel: Optional[Union[:class:`.abc.GuildChannel`, :class:`.Thread`, :class:`PartialMessageable`]]
-        The channel is not age restricted.
+        The channel that is not age restricted.
     """
 
     def __init__(self, channel: Optional[Union[GuildChannel, Thread, PartialMessageable]]) -> None:
         self.channel: Optional[Union[GuildChannel, Thread, PartialMessageable]] = channel
         super().__init__(f"Channel '{channel}' must be age restricted to use this command to work.")
+
+
+ApplicationNSFWChannelRequired = ApplicationAgeRestrictedChannelRequired
 
 
 class ApplicationCheckForBotOnly(ApplicationCheckFailure):

--- a/nextcord/ext/commands/core.py
+++ b/nextcord/ext/commands/core.py
@@ -2230,7 +2230,7 @@ def is_owner() -> Callable[[T], T]:
 
 
 def is_nsfw() -> Callable[[T], T]:
-    """A :func:`.check` that checks if the channel is "Age restriced".
+    """A :func:`.check` that checks if the channel is age restriced.
 
     This check raises a special exception, :exc:`.NSFWChannelRequired`
     that is derived from :exc:`.CheckFailure`.

--- a/nextcord/ext/commands/core.py
+++ b/nextcord/ext/commands/core.py
@@ -63,6 +63,7 @@ __all__ = (
     "guild_only",
     "is_owner",
     "is_nsfw",
+    "is_age_restricted",
     "has_guild_permissions",
     "bot_has_guild_permissions",
 )
@@ -2229,27 +2230,33 @@ def is_owner() -> Callable[[T], T]:
     return check(predicate)
 
 
-def is_nsfw() -> Callable[[T], T]:
+def is_age_restricted() -> Callable[[T], T]:
     """A :func:`.check` that checks if the channel is age restriced.
 
-    This check raises a special exception, :exc:`.NSFWChannelRequired`
+    This check raises a special exception, :exc:`.AgeRestrictedChannelRequired`
     that is derived from :exc:`.CheckFailure`.
 
-    .. versionchanged:: 1.1
-
-        Raise :exc:`.NSFWChannelRequired` instead of generic :exc:`.CheckFailure`.
-        DM channels will also now pass this check.
+    .. versionadded:: 2.5
     """
 
     def pred(ctx: Context) -> bool:
         ch = ctx.channel
         if ctx.guild is None or (
-            isinstance(ch, (nextcord.TextChannel, nextcord.Thread)) and ch.is_nsfw()
+            isinstance(ch, (nextcord.TextChannel, nextcord.Thread)) and ch.is_age_restricted()
         ):
             return True
-        raise NSFWChannelRequired(ch)  # type: ignore
+        raise AgeRestrictedChannelRequired(ch)  # type: ignore
 
     return check(pred)
+
+
+def is_nsfw() -> Callable[[T], T]:
+    """Alias for :func:`.is_age_restricted`.
+
+    .. versionchanged:: 2.5
+        This is now an alias for :func:`.is_age_restricted`.
+    """
+    return is_age_restricted()
 
 
 def cooldown(

--- a/nextcord/ext/commands/core.py
+++ b/nextcord/ext/commands/core.py
@@ -2230,7 +2230,7 @@ def is_owner() -> Callable[[T], T]:
 
 
 def is_nsfw() -> Callable[[T], T]:
-    """A :func:`.check` that checks if the channel is a NSFW channel.
+    """A :func:`.check` that checks if the channel is "Age restriced".
 
     This check raises a special exception, :exc:`.NSFWChannelRequired`
     that is derived from :exc:`.CheckFailure`.

--- a/nextcord/ext/commands/errors.py
+++ b/nextcord/ext/commands/errors.py
@@ -723,13 +723,13 @@ class AgeRestrictedChannelRequired(CheckFailure):
     There is an alias for this called ``NSFWChannelRequired``.
 
     .. versionadded:: 2.5
-    .. versionchanged:: 2.5
         Renamed from ``NSFWChannelRequired`` to :exc:`AgeRestrictedChannelRequired`. ``NSFWChannelRequired`` is now an alias.
 
     Parameters
     ----------
     channel: Union[:class:`.abc.GuildChannel`, :class:`.Thread`]
         The channel is not age restricted
+        The channel is not age restricted.
     """
 
     def __init__(self, channel: Union[GuildChannel, Thread]) -> None:

--- a/nextcord/ext/commands/errors.py
+++ b/nextcord/ext/commands/errors.py
@@ -57,6 +57,7 @@ __all__ = (
     "MissingPermissions",
     "BotMissingPermissions",
     "NSFWChannelRequired",
+    "AgeRestrictedChannelRequired",
     "ConversionError",
     "BadUnionArgument",
     "BadLiteralArgument",
@@ -714,12 +715,16 @@ class BotMissingAnyRole(CheckFailure):
         super().__init__(message)
 
 
-class NSFWChannelRequired(CheckFailure):
+class AgeRestrictedChannelRequired(CheckFailure):
     """Exception raised when a channel is not age restricted.
 
     This inherits from :exc:`CheckFailure`.
 
-    .. versionadded:: 1.1
+    There is an alias for this called ``NSFWChannelRequired``.
+
+    .. versionadded:: 2.5
+    .. versionchanged:: 2.5
+        Renamed from ``NSFWChannelRequired`` to :exc:`AgeRestrictedChannelRequired`. ``NSFWChannelRequired`` is now an alias.
 
     Parameters
     ----------
@@ -730,6 +735,10 @@ class NSFWChannelRequired(CheckFailure):
     def __init__(self, channel: Union[GuildChannel, Thread]) -> None:
         self.channel: Union[GuildChannel, Thread] = channel
         super().__init__(f"Channel '{channel}' must be age restricted for this command to work.")
+
+
+# alias
+NSFWChannelRequired = AgeRestrictedChannelRequired
 
 
 class MissingPermissions(CheckFailure):

--- a/nextcord/ext/commands/errors.py
+++ b/nextcord/ext/commands/errors.py
@@ -715,7 +715,7 @@ class BotMissingAnyRole(CheckFailure):
 
 
 class NSFWChannelRequired(CheckFailure):
-    """Exception raised when a channel does not have the required NSFW setting.
+    """Exception raised when a channel is not age restricted.
 
     This inherits from :exc:`CheckFailure`.
 
@@ -724,12 +724,12 @@ class NSFWChannelRequired(CheckFailure):
     Parameters
     ----------
     channel: Union[:class:`.abc.GuildChannel`, :class:`.Thread`]
-        The channel that does not have NSFW enabled.
+        The channel is not age restricted
     """
 
     def __init__(self, channel: Union[GuildChannel, Thread]) -> None:
         self.channel: Union[GuildChannel, Thread] = channel
-        super().__init__(f"Channel '{channel}' needs to be NSFW for this command to work.")
+        super().__init__(f"Channel '{channel}' must be age restricted for this command to work.")
 
 
 class MissingPermissions(CheckFailure):

--- a/nextcord/guild.py
+++ b/nextcord/guild.py
@@ -1165,7 +1165,7 @@ class Guild(Hashable):
             Specifies the slowmode rate limit for user in this channel, in seconds.
             The maximum value possible is ``21600``.
         nsfw: :class:`bool`
-            To mark the channel as NSFW or not.
+            To mark the channel as age restricted or not.
         reason: Optional[:class:`str`]
             The reason for creating this channel. Shows up on the audit log.
 

--- a/nextcord/guild.py
+++ b/nextcord/guild.py
@@ -240,7 +240,7 @@ class Guild(Hashable):
         .. versionchanged:: 2.5
             This is now an alias to :attr:`.age_restriction_level` and returns :class:`AgeRestrictionLevel` instead of :class:`NSFWLevel`.
 
-    age_restrication_level: :class:`AgeRestrictionLevel`
+    age_restriction_level: :class:`AgeRestrictionLevel`
         The guild's age restriction level.
 
         .. versionadded:: 2.5
@@ -283,7 +283,7 @@ class Guild(Hashable):
         "premium_subscription_count",
         "preferred_locale",
         "nsfw_level",
-        "age_restrication_level",
+        "age_restriction_level",
         "_application_commands",
         "_members",
         "_channels",
@@ -496,10 +496,10 @@ class Guild(Hashable):
         self._public_updates_channel_id: Optional[int] = utils.get_as_snowflake(
             guild, "public_updates_channel_id"
         )
-        self.age_restrication_level: AgeRestrictionLevel = try_enum(
+        self.age_restriction_level: AgeRestrictionLevel = try_enum(
             AgeRestrictionLevel, guild.get("nsfw_level", 0)
         )
-        self.nsfw_level: AgeRestrictionLevel = self.age_restrication_level
+        self.nsfw_level: AgeRestrictionLevel = self.age_restriction_level
         self.approximate_presence_count = guild.get("approximate_presence_count")
         self.approximate_member_count = guild.get("approximate_member_count")
 

--- a/nextcord/threads.py
+++ b/nextcord/threads.py
@@ -355,9 +355,9 @@ class Thread(Messageable, Hashable, PinsMixin):
         return self._type is ChannelType.news_thread
 
     def is_nsfw(self) -> bool:
-        """:class:`bool`: Whether the thread is NSFW or not.
+        """:class:`bool`: Whether the thread is age restricted or not.
 
-        An NSFW thread is a thread that has a parent that is an NSFW channel,
+        An age restricted thread is a thread that has a parent that is an age restricted channel,
         i.e. :meth:`.TextChannel.is_nsfw` is ``True``.
         """
         parent = self.parent

--- a/nextcord/threads.py
+++ b/nextcord/threads.py
@@ -354,14 +354,20 @@ class Thread(Messageable, Hashable, PinsMixin):
         """
         return self._type is ChannelType.news_thread
 
-    def is_nsfw(self) -> bool:
+    def is_age_restricted(self) -> bool:
         """:class:`bool`: Whether the thread is age restricted or not.
 
         An age restricted thread is a thread that has a parent that is an age restricted channel,
-        i.e. :meth:`.TextChannel.is_nsfw` is ``True``.
+        i.e. :meth:`.TextChannel.is_age_restricted` is ``True``.
+
+        .. versionadded:: 2.5
         """
         parent = self.parent
-        return parent is not None and parent.is_nsfw()
+        return parent is not None and parent.is_age_restricted()
+
+    def is_nsfw(self) -> bool:
+        """:class:`bool`: Alias for :meth:`.is_age_restricted`."""
+        return self.is_age_restricted()
 
     def permissions_for(self, obj: Union[Member, Role], /) -> Permissions:
         """Handles permission resolution for the :class:`~nextcord.Member`


### PR DESCRIPTION
## Summary

This PR changes almost all mentions of "NSFW" in the docstrings to "age restricted" since discord has done the same for their TOS/Guidelines and in the UI.
 
I'm unsure if we should also change the classes with "NSFW" in the name or at least add them ad aliases if we do.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
  - [ ] I have updated the documentation to reflect the changes.
  - [ ] I have run `task pyright` and fixed the relevant issues.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
