### PR TITLE
fix(ui.select): type checking imports used at runtime

### DIFF
--- a/nextcord/ui/select/mentionable.py
+++ b/nextcord/ui/select/mentionable.py
@@ -8,10 +8,10 @@ from typing import TYPE_CHECKING, Callable, Generic, List, Optional, Tuple, Type
 from ...components import MentionableSelectMenu
 from ...enums import ComponentType
 from ...interactions import ClientT
-from ...utils import MISSING
 from ...member import Member
 from ...role import Role
 from ...user import User
+from ...utils import MISSING
 from ..item import ItemCallbackType
 from ..view import View
 from .base import SelectBase, SelectValuesBase

--- a/nextcord/ui/select/mentionable.py
+++ b/nextcord/ui/select/mentionable.py
@@ -9,6 +9,9 @@ from ...components import MentionableSelectMenu
 from ...enums import ComponentType
 from ...interactions import ClientT
 from ...utils import MISSING
+from ...member import Member
+from ...role import Role
+from ...user import User
 from ..item import ItemCallbackType
 from ..view import View
 from .base import SelectBase, SelectValuesBase
@@ -17,12 +20,9 @@ if TYPE_CHECKING:
     from typing_extensions import Self
 
     from ...guild import Guild
-    from ...member import Member
-    from ...role import Role
     from ...state import ConnectionState
     from ...types.components import MentionableSelectMenu as MentionableSelectMenuPayload
     from ...types.interactions import ComponentInteractionData
-    from ...user import User
 
 __all__ = ("MentionableSelect", "mentionable_select", "MentionableSelectValues")
 

--- a/nextcord/ui/select/role.py
+++ b/nextcord/ui/select/role.py
@@ -8,9 +8,9 @@ from typing import TYPE_CHECKING, Callable, Generic, List, Optional, Tuple, Type
 from ...components import RoleSelectMenu
 from ...enums import ComponentType
 from ...interactions import ClientT
+from ...role import Role
 from ...state import ConnectionState
 from ...utils import MISSING
-from ...role import Role
 from ..item import ItemCallbackType
 from ..view import View
 from .base import SelectBase, SelectValuesBase

--- a/nextcord/ui/select/role.py
+++ b/nextcord/ui/select/role.py
@@ -10,6 +10,7 @@ from ...enums import ComponentType
 from ...interactions import ClientT
 from ...state import ConnectionState
 from ...utils import MISSING
+from ...role import Role
 from ..item import ItemCallbackType
 from ..view import View
 from .base import SelectBase, SelectValuesBase
@@ -18,7 +19,6 @@ if TYPE_CHECKING:
     from typing_extensions import Self
 
     from ...guild import Guild
-    from ...role import Role
     from ...types.components import RoleSelectMenu as RoleSelectMenuPayload
     from ...types.interactions import ComponentInteractionData
 


### PR DESCRIPTION
## Summary

This PR fixes an issue with #848 where type checking imports were used at runtime.

In order to merge this PR, two different people will have to test it to ensure that I have not missed any imports.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
  - [ ] I have updated the documentation to reflect the changes.
  - [ ] I have run `task pyright` and fixed the relevant issues.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
