### PR TITLE
feat: add ability to format strings like text channel names

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -1227,6 +1227,8 @@ Utility Functions
 
 .. autofunction:: nextcord.utils.parse_raw_channel_mentions
 
+.. autofunction:: nextcord.utils.format_as_channel_name
+
 .. autofunction:: nextcord.utils.resolve_invite
 
 .. autofunction:: nextcord.utils.resolve_template

--- a/nextcord/utils.py
+++ b/nextcord/utils.py
@@ -1131,6 +1131,30 @@ def format_dt(dt: datetime.datetime, /, style: Optional[TimestampStyle] = None) 
     return f"<t:{int(dt.timestamp())}:{style}>"
 
 
+def format_as_channel_name(s: str, include_hashtag: bool = False) -> str:
+    """Strip a string of whitespace & special characters, like Discord does when creating a text channel.
+
+    Parameters
+    ----------
+    s: :class:`str`
+        The string to format.
+    include_hashtag: :class:`bool`
+        Whether or not to include the leading hashtag.
+
+    Returns
+    -------
+    :class:`str`
+        The formatted string.
+    """
+
+    if include_hashtag:
+        return "#" + re.sub(_TEXT_CHANNEL_REGEX, '-', s).strip().lower()
+    else:
+        return re.sub(_TEXT_CHANNEL_REGEX, '-', s).strip().lower()
+
+
+_TEXT_CHANNEL_REGEX = r"[^\w\s]+"
+
 _FUNCTION_DESCRIPTION_REGEX = re.compile(r"\A(?:.|\n)+?(?=\Z|\r?\n\r?\n)", re.MULTILINE)
 
 _ARG_NAME_SUBREGEX = r"(?:\\?\*)*(?P<name>[^\s:\-]+)"

--- a/nextcord/utils.py
+++ b/nextcord/utils.py
@@ -1148,9 +1148,9 @@ def format_as_channel_name(s: str, include_hashtag: bool = False) -> str:
     """
 
     if include_hashtag:
-        return "#" + re.sub(_TEXT_CHANNEL_REGEX, '-', s).strip().lower()
+        return "#" + re.sub(_TEXT_CHANNEL_REGEX, "-", s).strip().lower()
     else:
-        return re.sub(_TEXT_CHANNEL_REGEX, '-', s).strip().lower()
+        return re.sub(_TEXT_CHANNEL_REGEX, "-", s).strip().lower()
 
 
 _TEXT_CHANNEL_REGEX = r"[^\w\s]+"


### PR DESCRIPTION
## Summary

<!-- What is this pull request for? Does it fix any issues? -->
Adds `format_as_channel_name`, a function to convert text to a text-channel compatible name, same as Discord does in the background when creating channels via the API. 

Example: "Joey's Cool Channel" -> "joeys-cool-channel"

This is my first PR, I've looked at the contributing guidelines but I'm unsure about what to do regarding docs. Please could someone take a look? Thanks! 😅 

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
  - [ ] I have updated the documentation to reflect the changes.
  - [x] I have run `task pyright` and fixed the relevant issues.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
