### PR TITLE
refactor: use audit log `after` query param

### DIFF
--- a/nextcord/http.py
+++ b/nextcord/http.py
@@ -1709,12 +1709,15 @@ class HTTPClient:
         guild_id: Snowflake,
         limit: int = 100,
         before: Optional[Snowflake] = None,
+        after: Optional[Snowflake] = None,
         user_id: Optional[Snowflake] = None,
         action_type: Optional[AuditLogAction] = None,
     ) -> Response[audit_log.AuditLog]:
         params: Dict[str, Any] = {"limit": limit}
         if before:
             params["before"] = before
+        if after:
+            params["after"] = after
         if user_id:
             params["user_id"] = user_id
         if action_type:

--- a/nextcord/iterators.py
+++ b/nextcord/iterators.py
@@ -282,11 +282,8 @@ class HistoryIterator(_AsyncIterator["Message"]):
         if isinstance(around, datetime.datetime):
             around = Object(id=time_snowflake(around))
 
-        self.reverse: bool
-        if oldest_first is None:
-            self.reverse = after is not None
-        else:
-            self.reverse = oldest_first
+        # Maintain compatibility with `None` being passed in for `oldest_first`
+        self.reverse: bool = bool(oldest_first)
 
         self.messageable: Messageable = messageable
         self.limit: Optional[int] = limit

--- a/nextcord/iterators.py
+++ b/nextcord/iterators.py
@@ -282,8 +282,11 @@ class HistoryIterator(_AsyncIterator["Message"]):
         if isinstance(around, datetime.datetime):
             around = Object(id=time_snowflake(around))
 
-        # Maintain compatibility with `None` being passed in for `oldest_first`
-        self.reverse: bool = bool(oldest_first)
+        self.reverse: bool
+        if oldest_first is None:
+            self.reverse = after is not None
+        else:
+            self.reverse = oldest_first
 
         self.messageable: Messageable = messageable
         self.limit: Optional[int] = limit
@@ -516,11 +519,8 @@ class AuditLogIterator(_AsyncIterator["AuditLogEntry"]):
         if isinstance(after, datetime.datetime):
             after = Object(id=time_snowflake(after, high=True))
 
-        self.reverse: bool
-        if oldest_first is None:
-            self.reverse = False
-        else:
-            self.reverse = oldest_first
+        # Maintain compatibility with `None` being passed in for `oldest_first`
+        self.reverse: bool = bool(oldest_first)
 
         self.guild: Guild = guild
         self.loop: asyncio.AbstractEventLoop = guild._state.loop

--- a/nextcord/iterators.py
+++ b/nextcord/iterators.py
@@ -49,7 +49,7 @@ if TYPE_CHECKING:
     from .scheduled_events import ScheduledEvent, ScheduledEventUser  # noqa: F401
     from .state import ConnectionState
     from .threads import Thread
-    from .types.audit_log import AuditLog as AuditLogPayload, AuditLogEntry as AuditLogEntryPayload
+    from .types.audit_log import AuditLog as AuditLogPayload
     from .types.guild import Ban as BanPayload, Guild as GuildPayload
     from .types.member import MemberWithUser
     from .types.message import Message as MessagePayload
@@ -521,7 +521,7 @@ class AuditLogIterator(_AsyncIterator["AuditLogEntry"]):
 
         self.reverse: bool
         if oldest_first is None:
-            self.reverse = after is not None
+            self.reverse = False
         else:
             self.reverse = oldest_first
 
@@ -531,25 +531,21 @@ class AuditLogIterator(_AsyncIterator["AuditLogEntry"]):
         self.before: Optional[Snowflake] = before
         self.user_id: Optional[int] = user_id
         self.action_type: Optional[AuditLogAction] = action_type
-        self.after: Optional[Snowflake] = after or OLDEST_OBJECT
+        self.after: Optional[Snowflake] = after
         self._state: ConnectionState = guild._state
-
-        self._filter: Optional[Callable[[AuditLogEntryPayload], bool]] = None  # entry dict -> bool
 
         self.entries: asyncio.Queue[AuditLogEntry] = asyncio.Queue()
 
-        self._strategy = self._before_strategy
-        if self.after and self.after != OLDEST_OBJECT:
-            self._filter = lambda m: int(m["id"]) > self.after.id  # type: ignore
-
-    async def _before_strategy(self, retrieve: int):
+    async def _get_logs(self, retrieve: int):
         before = self.before.id if self.before else None
+        after = self.after.id if self.after else None
         data: AuditLogPayload = await self._state.http.get_audit_logs(
             self.guild.id,
             limit=retrieve,
             user_id=self.user_id,
             action_type=self.action_type,
             before=before,
+            after=after,
         )
 
         entries = data.get("audit_log_entries", [])
@@ -579,15 +575,13 @@ class AuditLogIterator(_AsyncIterator["AuditLogEntry"]):
 
     async def _fill(self):
         if self._get_retrieve():
-            data = await self._strategy(self.retrieve)
+            data = await self._get_logs(self.retrieve)
             if len(data) < 100:
                 self.limit = 0  # terminate the infinite loop
 
             entries = data.get("audit_log_entries")
             if self.reverse:
                 entries = reversed(entries)
-            if self._filter:
-                entries = filter(self._filter, entries)
 
             state = self._state
 


### PR DESCRIPTION
## Summary

Since the after parameter in audit log retrieval is documented, this can be used over filtering, reversing and fetching tons of logs.
<https://github.com/discord/discord-api-docs/commit/38f01b07531b672880e434692d215233e45eb0db>
[Test Code](https://paste.nextcord.dev/?id=1673044721454197)
<!-- What is this pull request for? Does it fix any issues? -->

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
  - [ ] I have updated the documentation to reflect the changes.
  - [x] I have run `task pyright` and fixed the relevant issues.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
