### PR TITLE
feat(state): add on_thread_create

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -708,6 +708,15 @@ to handle it, which defaults to print a traceback and ignoring the exception.
     :param last_pin: The latest message that was pinned as an aware datetime in UTC. Could be ``None``.
     :type last_pin: Optional[:class:`datetime.datetime`]
 
+.. function:: on_thread_create(thread)
+
+    Called when a thread is created.
+
+    .. versionadded:: 2.4
+
+    :param thread: The thread that got created.
+    :type thread: :class:`Thread`
+
 .. function:: on_thread_join(thread)
 
     Called whenever a thread is joined or created. Note that from the API's perspective there is no way to

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -719,12 +719,17 @@ to handle it, which defaults to print a traceback and ignoring the exception.
 
 .. function:: on_thread_join(thread)
 
-    Called whenever a thread is joined or created. Note that from the API's perspective there is no way to
-    differentiate between a thread being created or the bot joining a thread.
+    Called whenever a thread is joined or created.
 
     Note that you can get the guild from :attr:`Thread.guild`.
 
     This requires :attr:`Intents.guilds` to be enabled.
+
+    .. note::
+
+        This event is also called when a thread is created. To differentiate,
+        use :func:`on_thread_create` instead. This is done to avoid a breaking change
+        in v2.
 
     .. versionadded:: 2.0
 

--- a/nextcord/state.py
+++ b/nextcord/state.py
@@ -1515,6 +1515,16 @@ class ConnectionState:
         has_thread = guild.get_thread(thread.id)
         guild._add_thread(thread)
         if not has_thread:
+            # `newly_created` is documented outside of a thread's fields:
+            # https://discord.dev/topics/gateway-events#thread-create
+            if data.get("newly_created", False):
+                if isinstance(thread.parent, ForumChannel):
+                    thread.parent.last_message_id = thread.id
+
+                self.dispatch("thread_create", thread)
+
+            # Avoid an unnecessary breaking change right now by dispatching `thread_join` for
+            # threads that were already created.
             self.dispatch("thread_join", thread)
 
     def parse_thread_update(self, data) -> None:


### PR DESCRIPTION
## Summary

Closes #962.
Since dispatching `on_thread_join` will cause a breaking change, it is dispatched in both conditions for now.
**Test Code:** <https://paste.nextcord.dev/?id=1673220045815470>
<!-- What is this pull request for? Does it fix any issues? -->

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
  - [x] I have updated the documentation to reflect the changes.
  - [x] I have run `task pyright` and fixed the relevant issues.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
