### PR TITLE
refactor(webhook): use WeakValueDictionary for _locks

### DIFF
--- a/nextcord/webhook/async_.py
+++ b/nextcord/webhook/async_.py
@@ -22,6 +22,7 @@ from typing import (
     overload,
 )
 from urllib.parse import quote as urlquote
+from weakref import WeakValueDictionary
 
 import aiohttp
 
@@ -56,6 +57,7 @@ if TYPE_CHECKING:
     from ..mentions import AllowedMentions
     from ..state import ConnectionState
     from ..types.message import Message as MessagePayload
+    from ..types.snowflake import Snowflake as SnowflakeAlias
     from ..types.webhook import Webhook as WebhookPayload
     from ..ui.view import View
 
@@ -86,8 +88,11 @@ class AsyncDeferredLock:
 
 
 class AsyncWebhookAdapter:
-    def __init__(self) -> None:
-        self._locks: Dict[Any, asyncio.Lock] = {}
+    def __init__(self):
+        self._locks: WeakValueDictionary[
+            Tuple[Optional[SnowflakeAlias], Optional[str]],
+            asyncio.Lock,
+        ] = WeakValueDictionary()
 
     async def request(
         self,

--- a/nextcord/webhook/async_.py
+++ b/nextcord/webhook/async_.py
@@ -88,7 +88,7 @@ class AsyncDeferredLock:
 
 
 class AsyncWebhookAdapter:
-    def __init__(self):
+    def __init__(self) -> None:
         self._locks: WeakValueDictionary[
             Tuple[Optional[SnowflakeAlias], Optional[str]],
             asyncio.Lock,

--- a/nextcord/webhook/sync.py
+++ b/nextcord/webhook/sync.py
@@ -16,6 +16,7 @@ import time
 from types import TracebackType
 from typing import TYPE_CHECKING, Any, Dict, List, Literal, Optional, Tuple, Type, Union, overload
 from urllib.parse import quote as urlquote
+from weakref import WeakValueDictionary
 
 from .. import utils
 from ..channel import PartialMessageable
@@ -36,6 +37,7 @@ if TYPE_CHECKING:
     from ..embeds import Embed
     from ..file import File
     from ..mentions import AllowedMentions
+    from ..types.snowflake import Snowflake as SnowflakeAlias
     from ..types.webhook import Webhook as WebhookPayload
 
     try:
@@ -70,8 +72,11 @@ class DeferredLock:
 
 
 class WebhookAdapter:
-    def __init__(self) -> None:
-        self._locks: Dict[Any, threading.Lock] = {}
+    def __init__(self):
+        self._locks: WeakValueDictionary[
+            Tuple[Optional[SnowflakeAlias], Optional[str]],
+            threading.Lock,
+        ] = WeakValueDictionary()
 
     def request(
         self,

--- a/nextcord/webhook/sync.py
+++ b/nextcord/webhook/sync.py
@@ -72,7 +72,7 @@ class DeferredLock:
 
 
 class WebhookAdapter:
-    def __init__(self):
+    def __init__(self) -> None:
         self._locks: WeakValueDictionary[
             Tuple[Optional[SnowflakeAlias], Optional[str]],
             threading.Lock,


### PR DESCRIPTION
## Summary

Values in `_locks` are no longer required when a webhook has been used fully. Since interactions use webhooks, I have a couple hundred thousand `Lock` objects in memory that are not needed.
<!-- What is this pull request for? Does it fix any issues? -->

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
  - [ ] I have updated the documentation to reflect the changes.
  - [x] I have run `task pyright` and fixed the relevant issues.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
