### PR TITLE
fix(iterators): import PartialUserPayload during runtime

### DIFF
--- a/nextcord/iterators.py
+++ b/nextcord/iterators.py
@@ -24,6 +24,7 @@ from .auto_moderation import AutoModerationRule
 from .bans import BanEntry
 from .errors import NoMoreItems
 from .object import Object
+from .types.user import PartialUser as PartialUserPayload
 from .utils import maybe_coroutine, snowflake_time, time_snowflake
 
 __all__ = (
@@ -58,7 +59,6 @@ if TYPE_CHECKING:
         ScheduledEventUser as ScheduledEventUserPayload,
     )
     from .types.threads import Thread as ThreadPayload, ThreadPaginationPayload
-    from .types.user import PartialUser as PartialUserPayload
     from .user import User
 
 T = TypeVar("T")


### PR DESCRIPTION
## Summary

This imports `nextcord.types.user.PartialUserPayload` during runtime in nextcord/iterators.py. As it is actually used in the code and not only for the sake of typehinting.

Introduced in #872

Fixes #984

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
  - [ ] I have updated the documentation to reflect the changes.
  - [ ] I have run `task pyright` and fixed the relevant issues.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
