### PR TITLE
docs(README): add missing nextcord import

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -93,6 +93,7 @@ Quick Example
 
 .. code:: py
 
+    import nextcord
     from nextcord.ext import commands
 
 


### PR DESCRIPTION
## Summary

This adds the missing `nextcord` import that was used for `nextcord.Interaction` in the readme file.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
  - [ ] I have updated the documentation to reflect the changes.
  - [ ] I have run `task pyright` and fixed the relevant issues.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
