### PR TITLE
feat(flags): add missing MessageFlags values

### DIFF
--- a/nextcord/flags.py
+++ b/nextcord/flags.py
@@ -354,7 +354,7 @@ class MessageFlags(BaseFlags):
 
         This is represented in the UI as "bot is thinking...".
 
-        .. versionadded:: 2.4
+        .. versionadded:: 2.5
         """
         return 1 << 7
 
@@ -364,7 +364,7 @@ class MessageFlags(BaseFlags):
 
         This means that those members were not added.
 
-        .. versionadded:: 2.4
+        .. versionadded:: 2.5
         """
         return 1 << 8
 
@@ -374,7 +374,7 @@ class MessageFlags(BaseFlags):
 
         These are sent via `@silent` message prefixes in the UI.
 
-        .. versionadded:: 2.4
+        .. versionadded:: 2.5
         """
         return 1 << 12
 

--- a/nextcord/flags.py
+++ b/nextcord/flags.py
@@ -307,22 +307,22 @@ class MessageFlags(BaseFlags):
     @flag_value
     def crossposted(self) -> int:
         """:class:`bool`: Returns ``True`` if the message is the original crossposted message."""
-        return 1
+        return 1 << 0
 
     @flag_value
     def is_crossposted(self) -> int:
         """:class:`bool`: Returns ``True`` if the message was crossposted from another channel."""
-        return 2
+        return 1 << 1
 
     @flag_value
     def suppress_embeds(self) -> int:
         """:class:`bool`: Returns ``True`` if the message's embeds have been suppressed."""
-        return 4
+        return 1 << 2
 
     @flag_value
     def source_message_deleted(self) -> int:
         """:class:`bool`: Returns ``True`` if the source message for this crosspost has been deleted."""
-        return 8
+        return 1 << 3
 
     @flag_value
     def urgent(self) -> int:
@@ -330,7 +330,7 @@ class MessageFlags(BaseFlags):
 
         An urgent message is one sent by Discord Trust and Safety.
         """
-        return 16
+        return 1 << 4
 
     @flag_value
     def has_thread(self) -> int:
@@ -338,7 +338,7 @@ class MessageFlags(BaseFlags):
 
         .. versionadded:: 2.0
         """
-        return 32
+        return 1 << 5
 
     @flag_value
     def ephemeral(self) -> int:
@@ -346,7 +346,7 @@ class MessageFlags(BaseFlags):
 
         .. versionadded:: 2.0
         """
-        return 64
+        return 1 << 6
 
 
 @fill_with_flags()

--- a/nextcord/flags.py
+++ b/nextcord/flags.py
@@ -348,6 +348,36 @@ class MessageFlags(BaseFlags):
         """
         return 1 << 6
 
+    @flag_value
+    def loading(self) -> int:
+        """:class:`bool`: Returns ``True`` if the source message is loading.
+
+        This is represented in the UI as "bot is thinking...".
+
+        .. versionadded:: 2.4
+        """
+        return 1 << 7
+
+    @flag_value
+    def failed_to_mention_roles(self) -> int:
+        """:class:`bool`: Returns ``True`` if the message failed to mention some roles in a thread.
+
+        This means that those members were not added.
+
+        .. versionadded:: 2.4
+        """
+        return 1 << 8
+
+    @flag_value
+    def suppress_notifications(self) -> int:
+        """:class:`bool`: Returns ``True`` if the message does not trigger notifications.
+
+        These are sent via `@silent` message prefixes in the UI.
+
+        .. versionadded:: 2.4
+        """
+        return 1 << 9
+
 
 @fill_with_flags()
 class PublicUserFlags(BaseFlags):

--- a/nextcord/flags.py
+++ b/nextcord/flags.py
@@ -376,7 +376,7 @@ class MessageFlags(BaseFlags):
 
         .. versionadded:: 2.4
         """
-        return 1 << 9
+        return 1 << 12
 
 
 @fill_with_flags()

--- a/nextcord/flags.py
+++ b/nextcord/flags.py
@@ -354,7 +354,7 @@ class MessageFlags(BaseFlags):
 
         This is represented in the UI as "bot is thinking...".
 
-        .. versionadded:: 2.5
+        .. versionadded:: 2.6
         """
         return 1 << 7
 
@@ -364,7 +364,7 @@ class MessageFlags(BaseFlags):
 
         This means that those members were not added.
 
-        .. versionadded:: 2.5
+        .. versionadded:: 2.6
         """
         return 1 << 8
 
@@ -374,7 +374,7 @@ class MessageFlags(BaseFlags):
 
         These are sent via `@silent` message prefixes in the UI.
 
-        .. versionadded:: 2.5
+        .. versionadded:: 2.6
         """
         return 1 << 12
 


### PR DESCRIPTION
## Summary

The suppress notifications option is from discord/discord-api-docs#5910.
Bitshifted values seemed to have been missed in #911 as this is a flag

<!-- What is this pull request for? Does it fix any issues? -->

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
  - [x] I have updated the documentation to reflect the changes.
  - [x] I have run `task pyright` and fixed the relevant issues.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
