### PR TITLE
fix: Support Interaction annotation with client type specified

### DIFF
--- a/nextcord/application_command.py
+++ b/nextcord/application_command.py
@@ -757,7 +757,7 @@ class CallbackMixin:
                         and issubclass(param.annotation, Interaction)
                     )
                     # will always be an interaction parameter (generic with the outermost type being Interaction)
-                    or getattr(param.annotation, "__origin__", None) is Interaction
+                    or typing_extensions.get_origin(param.annotation) is Interaction
                     # will always be a self parameter
                     # TODO: use typing.Self when 3.11 is standard
                     or param.annotation is typing_extensions.Self

--- a/nextcord/application_command.py
+++ b/nextcord/application_command.py
@@ -757,7 +757,7 @@ class CallbackMixin:
                         and issubclass(param.annotation, Interaction)
                     )
                     # will always be an interaction parameter (generic with the outermost type being Interaction)
-                    or (getattr(param.annotation, "__origin__", None) is Interaction)
+                    or getattr(param.annotation, "__origin__", None) is Interaction
                     # will always be a self parameter
                     # TODO: use typing.Self when 3.11 is standard
                     or param.annotation is typing_extensions.Self

--- a/nextcord/application_command.py
+++ b/nextcord/application_command.py
@@ -25,6 +25,7 @@ from typing import (
     Union,
     cast,
     overload,
+    _GenericAlias,
 )
 
 import typing_extensions
@@ -755,6 +756,11 @@ class CallbackMixin:
                     or (
                         isinstance(param.annotation, type)
                         and issubclass(param.annotation, Interaction)
+                    )
+                    # will always be an interaction parameter (generic with the outermost type being Interaction)
+                    or (
+                        isinstance(param.annotation, _GenericAlias)
+                        and param.annotation.__origin__ is Interaction
                     )
                     # will always be a self parameter
                     # TODO: use typing.Self when 3.11 is standard

--- a/nextcord/application_command.py
+++ b/nextcord/application_command.py
@@ -757,7 +757,10 @@ class CallbackMixin:
                         and issubclass(param.annotation, Interaction)
                     )
                     # will always be an interaction parameter (generic with the outermost type being Interaction)
-                    or typing_extensions.get_origin(param.annotation) is Interaction
+                    or (
+                        (origin := typing_extensions.get_origin(param.annotation))
+                        and issubclass(origin, Interaction)
+                    )
                     # will always be a self parameter
                     # TODO: use typing.Self when 3.11 is standard
                     or param.annotation is typing_extensions.Self

--- a/nextcord/application_command.py
+++ b/nextcord/application_command.py
@@ -25,7 +25,6 @@ from typing import (
     Union,
     cast,
     overload,
-    _GenericAlias,
 )
 
 import typing_extensions
@@ -758,10 +757,7 @@ class CallbackMixin:
                         and issubclass(param.annotation, Interaction)
                     )
                     # will always be an interaction parameter (generic with the outermost type being Interaction)
-                    or (
-                        isinstance(param.annotation, _GenericAlias)
-                        and param.annotation.__origin__ is Interaction
-                    )
+                    or (getattr(param.annotation, "__origin__", None) is Interaction)
                     # will always be a self parameter
                     # TODO: use typing.Self when 3.11 is standard
                     or param.annotation is typing_extensions.Self


### PR DESCRIPTION
## Summary

Fixes an issue where the bot would crash if `nextcord.Interaction[commands.Bot]` or similar is used as the interaction annotation. This is the fully qualified annotation which specifies the client type and is recommended so should be supported.

Example where it is broken:

```py
class PingCog(commands.Cog):
    @nextcord.slash_command()
    async def ping(self, interaction: nextcord.Interaction[commands.Bot]):
        await interaction.send("Pong")
```

Error traceback:

```py
Traceback (most recent call last):
  File "python/lib/python3.10/site-packages/nextcord/ext/commands/bot.py", line 775, in _load_from_module_spec
    setup(self, **extras)
  File "/app/modules/ping/cog.py", line 30, in setup
    bot.add_cog(PingCog(bot))
  File "python/lib/python3.10/site-packages/nextcord/ext/commands/cog.py", line 182, in __new__
    self = super().__new__(cls)
  File "python/lib/python3.10/site-packages/nextcord/application_command.py", line 484, in __new__
    new_cls._read_application_commands()
  File "python/lib/python3.10/site-packages/nextcord/application_command.py", line 500, in _read_application_commands
    value.from_callback(value.callback, call_children=False)
  File "python/lib/python3.10/site-packages/nextcord/application_command.py", line 2795, in from_callback
    BaseApplicationCommand.from_callback(self, callback=callback, option_class=option_class)
  File "python/lib/python3.10/site-packages/nextcord/application_command.py", line 2385, in from_callback
    super().from_callback(callback=callback, option_class=option_class)
  File "python/lib/python3.10/site-packages/nextcord/application_command.py", line 790, in from_callback
    raise e
  File "python/lib/python3.10/site-packages/nextcord/application_command.py", line 768, in from_callback
    raise ValueError(
ValueError: Callback SlashApplicationCommand ping <function PingCog.ping at 0x7f98b7d86b00> is missing the self and/or interaction parameters. Please double check your function definition.

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/app/bot.py", line 47, in <module>
    asyncio.run(main())
  File "python/lib/python3.10/asyncio/runners.py", line 44, in run
    return loop.run_until_complete(main)
  File "python/lib/python3.10/asyncio/base_events.py", line 649, in run_until_complete
    return future.result()
  File "/app/bot.py", line 28, in main
    bot.load_extension(f"modules.{folder}.cog")
  File "python/lib/python3.10/site-packages/nextcord/ext/commands/bot.py", line 863, in load_extension
    self._load_from_module_spec(spec, name, extras=extras)
  File "python/lib/python3.10/site-packages/nextcord/ext/commands/bot.py", line 780, in _load_from_module_spec
    raise errors.ExtensionFailed(key, e) from e
nextcord.ext.commands.errors.ExtensionFailed: Extension 'modules.ping.cog' raised an error: ValueError: Callback SlashApplicationCommand ping <function PingCog.ping at 0x7f98b7d86b00> is missing the self and/or interaction parameters. Please double check your function definition.
```

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
  - [ ] I have updated the documentation to reflect the changes.
  - [ ] I have run `task pyright` and fixed the relevant issues.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
