### PR TITLE
refactor: Change missing self/interaction errors to warnings

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -5096,6 +5096,12 @@ Cogs
 .. autoclass:: ClientCog
     :members:
 
+Warnings
+--------
+
+.. autoclass:: MissingApplicationCommandParametersWarning
+
+
 Exceptions
 ----------
 

--- a/nextcord/application_command.py
+++ b/nextcord/application_command.py
@@ -94,6 +94,7 @@ __all__ = (
     "Mentionable",
     "Range",
     "String",
+    "MissingApplicationCommandParametersWarning",
 )
 
 _log = logging.getLogger(__name__)
@@ -567,6 +568,23 @@ class ClientCog:
         pass
 
 
+class MissingApplicationCommandParametersWarning(UserWarning):
+    """Warning category raised when creating a slash command from a callback when it appears
+    the self and/or interaction parameter is missing based on the given type annotations.
+
+    This warning can be silenced using :func:`warnings.simplefilter`.
+
+    .. code-block:: python3
+
+        import warnings
+        from nextcord import MissingApplicationCommandParametersWarning
+
+        warnings.simplefilter("ignore", MissingApplicationCommandParametersWarning)
+    """
+
+    pass
+
+
 class CallbackMixin:
     name: Optional[str]
     options: Dict[str, BaseCommandOption]
@@ -767,14 +785,14 @@ class CallbackMixin:
                 if self.parent_cog is not None and non_option_params < 2:
                     warnings.warn(
                         f"Callback {self.error_name} is missing the self and/or interaction parameters. Please double check your function definition.",
-                        stacklevel=2,
-                        category=UserWarning,
+                        stacklevel=0,
+                        category=MissingApplicationCommandParametersWarning,
                     )
                 elif non_option_params < 1:
                     warnings.warn(
                         f"Callback {self.error_name} is missing the interaction parameter. Please double check your function definition.",
-                        stacklevel=2,
-                        category=UserWarning,
+                        stacklevel=0,
+                        category=MissingApplicationCommandParametersWarning,
                     )
 
                 for name, param in callback_params.items():

--- a/nextcord/application_command.py
+++ b/nextcord/application_command.py
@@ -765,12 +765,16 @@ class CallbackMixin:
                 )
 
                 if self.parent_cog is not None and non_option_params < 2:
-                    raise ValueError(
-                        f"Callback {self.error_name} is missing the self and/or interaction parameters. Please double check your function definition."
+                    warnings.warn(
+                        f"Callback {self.error_name} is missing the self and/or interaction parameters. Please double check your function definition.",
+                        stacklevel=2,
+                        category=UserWarning,
                     )
                 elif non_option_params < 1:
-                    raise ValueError(
-                        f"Callback {self.error_name} is missing the interaction parameter. Please double check your function definition."
+                    warnings.warn(
+                        f"Callback {self.error_name} is missing the interaction parameter. Please double check your function definition.",
+                        stacklevel=2,
+                        category=UserWarning,
                     )
 
                 for name, param in callback_params.items():


### PR DESCRIPTION
## Summary

"Callback ... is missing the self and/or interaction parameters. Please double check your function definition"

"Callback ... is missing the interaction parameter. Please double check your function definition"

These errors are caused by the type annotations specified for the parameters not being one of the expected types, since the bot can continue to function in some cases where the annotations are unexpected, these can be warnings instead of errors.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
  - [ ] I have updated the documentation to reflect the changes.
  - [ ] I have run `task pyright` and fixed the relevant issues.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
