### PR TITLE
refactor: use ffprobe even if located under /usr/bin

### DIFF
--- a/nextcord/player.py
+++ b/nextcord/player.py
@@ -557,7 +557,7 @@ class FFmpegOpusAudio(FFmpegAudio):
     def _probe_codec_native(
         source, executable: str = "ffmpeg"
     ) -> Tuple[Optional[str], Optional[int]]:
-        exe = executable[:2] + "probe" if executable in ("ffmpeg", "avconv") else executable
+        exe = executable[:-4] + "probe" if executable.endswith(("ffmpeg", "avconv")) else executable
         args = [
             exe,
             "-v",


### PR DESCRIPTION
## Summary
If I call `_probe_codec_native(source, "/bin/ffmpeg")` I want it to use `/bin/ffprobe`.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
  - [ ] I have updated the documentation to reflect the changes.
  - [ ] I have run `task pyright` and fixed the relevant issues.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
