### PR TITLE
feat(file): add context manager to File

### DIFF
--- a/nextcord/file.py
+++ b/nextcord/file.py
@@ -152,7 +152,7 @@ class File:
             self.force_close = True
         return self
 
-    def __close__(self, *_) -> None:
+    def __exit__(self, *_) -> None:
         self.close()
 
     def reset(self, *, seek: Union[int, bool] = True) -> None:

--- a/nextcord/file.py
+++ b/nextcord/file.py
@@ -13,6 +13,12 @@ class File:
     r"""A parameter object used for :meth:`abc.Messageable.send`
     for sending file objects.
 
+    .. versionadded:: 2.4
+
+        You can now use nextcord.File as a context manager. This will
+        automatically call `close()` when the context manager exits scope.
+        When using the context manager, force_close will default to True.
+
     .. note::
 
         File objects are single use and are not meant to be reused in
@@ -47,6 +53,7 @@ class File:
         This will also make the file bytes unusable by flushing it from
         memory after it is sent once.
         Enable this if you don't wish to reuse the same bytes.
+        Defaults to True when using context manager.
 
         .. versionadded:: 2.2
 
@@ -138,12 +145,14 @@ class File:
             self.filename is not None and self.filename.startswith("SPOILER_")
         )
 
-    def __enter__(self):
+    def __enter__(self) -> File:
+        # Set force_close to true when using context manager
+        # and force_close was not provided to __init__
         if self.force_close is None:
             self.force_close = True
         return self
 
-    def __close__(self):
+    def __close__(self) -> None:
         self.close()
 
     def reset(self, *, seek: Union[int, bool] = True) -> None:

--- a/nextcord/file.py
+++ b/nextcord/file.py
@@ -152,7 +152,7 @@ class File:
             self.force_close = True
         return self
 
-    def __close__(self) -> None:
+    def __close__(self, *_) -> None:
         self.close()
 
     def reset(self, *, seek: Union[int, bool] = True) -> None:

--- a/nextcord/file.py
+++ b/nextcord/file.py
@@ -90,7 +90,7 @@ class File:
         filename: Optional[str]
         description: Optional[str]
         spoiler: bool
-        force_close: bool
+        force_close: Optional[bool]
 
     def __init__(
         self,
@@ -99,7 +99,7 @@ class File:
         *,
         description: Optional[str] = None,
         spoiler: bool = False,
-        force_close: bool = False,
+        force_close: Optional[bool] = None,
     ) -> None:
         if isinstance(fp, io.IOBase):
             if not (fp.seekable() and fp.readable()):
@@ -137,6 +137,14 @@ class File:
         self.spoiler = spoiler or (
             self.filename is not None and self.filename.startswith("SPOILER_")
         )
+
+    def __enter__(self):
+        if self.force_close is None:
+            self.force_close = True
+        return self
+
+    def __close__(self):
+        self.close()
 
     def reset(self, *, seek: Union[int, bool] = True) -> None:
         # The `seek` parameter is needed because

--- a/nextcord/file.py
+++ b/nextcord/file.py
@@ -13,10 +13,10 @@ class File:
     r"""A parameter object used for :meth:`abc.Messageable.send`
     for sending file objects.
 
-    .. versionadded:: 2.4
+    .. versionchanged:: 2.5
 
         You can now use nextcord.File as a context manager. This will
-        automatically call `close()` when the context manager exits scope.
+        automatically call :meth:`close` when the context manager exits scope.
         When using the context manager, force_close will default to True.
 
     .. note::
@@ -53,7 +53,7 @@ class File:
         This will also make the file bytes unusable by flushing it from
         memory after it is sent once.
         Enable this if you don't wish to reuse the same bytes.
-        Defaults to True when using context manager.
+        Defaults to ``True`` when using context manager.
 
         .. versionadded:: 2.2
 


### PR DESCRIPTION
## Summary

Add a context manager to `nextcord.File`. This will automatically call `close()` on the file when the context manager exits scope.

Also change `force_close` to be optional default to None so that we can set `force_close` to True when using context manager if `False` was not provided to init.

### Old Method
```python
file = nextcord.File(filepath)
await channel.send(file=file)
file.close()
```

### New Method (w/ Context Manager)
```python
with nextcord.File(filepath) as file:
    await channel.send(file=file)
```


## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [X] If code changes were made then they have been tested.
  - [X] I have updated the documentation to reflect the changes.
  - [X] I have run `task pyright` and fixed the relevant issues.
- [ ] This PR fixes an issue.
- [X] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed) *Edit: This actually isn't a breaking change as you can still use the old syntax.*
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
