### PR TITLE
feat(raw-models): add guild and user attr to RawMemberRemoveEvent

### DIFF
--- a/nextcord/raw_models.py
+++ b/nextcord/raw_models.py
@@ -310,6 +310,10 @@ class RawMemberRemoveEvent(_RawReprMixin):
     ----------
     guild_id: :class:`int`
         The guild ID where the member left from.
+    guild: Optional[:class:`Guild`]
+        The guild where the member left from.
+    user: :class:`User`
+        The user that left the guild.
     """
 
     __slots__ = ("guild_id", "user", "guild")

--- a/nextcord/raw_models.py
+++ b/nextcord/raw_models.py
@@ -312,8 +312,12 @@ class RawMemberRemoveEvent(_RawReprMixin):
         The guild ID where the member left from.
     guild: Optional[:class:`Guild`]
         The guild where the member left from.
+
+        .. versionadded:: 2.5
     user: :class:`User`
         The user that left the guild.
+
+        .. versionadded:: 2.5
     """
 
     __slots__ = ("guild_id", "user", "guild")

--- a/nextcord/raw_models.py
+++ b/nextcord/raw_models.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING, List, Optional, Set
 from .user import User
 
 if TYPE_CHECKING:
+    from .guild import Guild
     from .member import Member
     from .message import Message
     from .partial_emoji import PartialEmoji
@@ -311,8 +312,9 @@ class RawMemberRemoveEvent(_RawReprMixin):
         The guild ID where the member left from.
     """
 
-    __slots__ = ("guild_id", "user")
+    __slots__ = ("guild_id", "user", "guild")
 
     def __init__(self, *, data: MemberRemoveEvent, state: ConnectionState) -> None:
         self.guild_id: int = int(data["guild_id"])
+        self.guild: Optional[Guild] = state._get_guild(int(data["guild_id"]))
         self.user: User = User(state=state, data=data["user"])

--- a/nextcord/raw_models.py
+++ b/nextcord/raw_models.py
@@ -5,10 +5,13 @@ from __future__ import annotations
 import datetime
 from typing import TYPE_CHECKING, List, Optional, Set
 
+from .user import User
+
 if TYPE_CHECKING:
     from .member import Member
     from .message import Message
     from .partial_emoji import PartialEmoji
+    from .state import ConnectionState
     from .types.raw_models import (
         BulkMessageDeleteEvent,
         IntegrationDeleteEvent,
@@ -310,6 +313,6 @@ class RawMemberRemoveEvent(_RawReprMixin):
 
     __slots__ = ("guild_id", "user")
 
-    def __init__(self, data: MemberRemoveEvent) -> None:
+    def __init__(self, *, data: MemberRemoveEvent, state: ConnectionState) -> None:
         self.guild_id: int = int(data["guild_id"])
-        # FIXME: practically no data
+        self.user: User = User(state=state, data=data["user"])

--- a/nextcord/raw_models.py
+++ b/nextcord/raw_models.py
@@ -313,11 +313,11 @@ class RawMemberRemoveEvent(_RawReprMixin):
     guild: Optional[:class:`Guild`]
         The guild where the member left from.
 
-        .. versionadded:: 2.5
+        .. versionadded:: 2.6
     user: :class:`User`
         The user that left the guild.
 
-        .. versionadded:: 2.5
+        .. versionadded:: 2.6
     """
 
     __slots__ = ("guild_id", "user", "guild")

--- a/nextcord/state.py
+++ b/nextcord/state.py
@@ -1691,8 +1691,6 @@ class ConnectionState:
             )
 
         raw = RawMemberRemoveEvent(data=data, state=self)
-        user = User(state=self, data=data["user"])
-        raw.user = user
         self.dispatch("raw_member_remove", raw)
 
     def parse_guild_member_update(self, data) -> None:

--- a/nextcord/state.py
+++ b/nextcord/state.py
@@ -1679,11 +1679,6 @@ class ConnectionState:
             except AttributeError:
                 pass
 
-            raw = RawMemberRemoveEvent(data)
-            user = User(state=self, data=data["user"])
-            raw.user = user
-            self.dispatch("raw_member_remove", raw)
-
             user_id = int(data["user"]["id"])
             member = guild.get_member(user_id)
             if member is not None:
@@ -1694,6 +1689,11 @@ class ConnectionState:
                 "GUILD_MEMBER_REMOVE referencing an unknown guild ID: %s. Discarding.",
                 data["guild_id"],
             )
+
+        raw = RawMemberRemoveEvent(data=data, state=self)
+        user = User(state=self, data=data["user"])
+        raw.user = user
+        self.dispatch("raw_member_remove", raw)
 
     def parse_guild_member_update(self, data) -> None:
         guild = self._get_guild(int(data["guild_id"]))

--- a/nextcord/state.py
+++ b/nextcord/state.py
@@ -1686,7 +1686,10 @@ class ConnectionState:
                 self.dispatch("member_remove", member)
         else:
             _log.debug(
-                "GUILD_MEMBER_REMOVE referencing an unknown guild ID: %s. Discarding.",
+                (
+                    "GUILD_MEMBER_REMOVE referencing an unknown guild ID: %s."
+                    "Falling back to raw data."
+                ),
                 data["guild_id"],
             )
 


### PR DESCRIPTION
## Summary

Previously, it was not possible to see what user left. This adds the attribute to `RawMemberRemoveEvent`, using a full user object ( :D finally a non-partial ) to get a full `User`.

<!-- What is this pull request for? Does it fix any issues? -->

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
  - [x] I have updated the documentation to reflect the changes.
  - [x] I have run `task pyright` and fixed the relevant issues.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
