### PR TITLE
refactor(gateway): switch to 74 byte UDP packet format for IP discovery

### DIFF
--- a/nextcord/gateway.py
+++ b/nextcord/gateway.py
@@ -906,16 +906,20 @@ class DiscordVoiceWebSocket:
         state.voice_port = data["port"]
         state.endpoint_ip = data["ip"]
 
-        packet = bytearray(70)
-        struct.pack_into(">H", packet, 0, 1)  # 1 = Send
-        struct.pack_into(">H", packet, 2, 70)  # 70 = Length
+        # Discover our external IP and port by asking our voice port.
+        # https://discord.com/developers/docs/topics/voice-connections#ip-discovery
+        packet = bytearray(74)
+
+        # > = big-endian, H = unsigned short, I = unsigned int
+        struct.pack_into(">H", packet, 0, 1)  # 1 = Request
+        struct.pack_into(">H", packet, 2, 70)  # 70 = Message length. A constant of 70.
         struct.pack_into(">I", packet, 4, state.ssrc)
         state.socket.sendto(packet, (state.endpoint_ip, state.voice_port))
-        recv = await self.loop.sock_recv(state.socket, 70)
+        recv = await self.loop.sock_recv(state.socket, 74)
         _log.debug("received packet in initial_connection: %s", recv)
 
-        # the ip is ascii starting at the 4th byte and ending at the first null
-        ip_start = 4
+        # the ip is ascii starting at the 8th byte and ending at the first null
+        ip_start = 8
         ip_end = recv.index(0, ip_start)
         state.ip = recv[ip_start:ip_end].decode("ascii")
 

--- a/nextcord/gateway.py
+++ b/nextcord/gateway.py
@@ -907,7 +907,7 @@ class DiscordVoiceWebSocket:
         state.endpoint_ip = data["ip"]
 
         # Discover our external IP and port by asking our voice port.
-        # https://discord.com/developers/docs/topics/voice-connections#ip-discovery
+        # https://discord.dev/topics/voice-connections#ip-discovery
         packet = bytearray(74)
 
         # > = big-endian, H = unsigned short, I = unsigned int


### PR DESCRIPTION
## Summary

This PR updates Nextcord to use the new UDP packet format for [discovering your external IP address and port](https://discord.com/developers/docs/topics/voice-connections#ip-discovery) against Discord's VoIP servers.

Discord announced in their guild that on **March 15th, 2023**, all VoIP servers would be updated to **only** accept the 74-byte packet length, and would no longer accept the 70-byte packet length format which nextcord currently uses.

![image](https://user-images.githubusercontent.com/1342360/223873328-eb56a489-de62-4a1a-a6e6-4cca050e2273.png)

disnake made [a similar change](https://github.com/DisnakeDev/disnake/pull/967) to their library in their most recent release.


## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
  - [ ] I have updated the documentation to reflect the changes.
  - [ ] I have run `task pyright` and fixed the relevant issues.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [?] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
