### PR TITLE
refactor(channel): add invitable argument in create_thread method

### DIFF
--- a/nextcord/channel.py
+++ b/nextcord/channel.py
@@ -716,6 +716,7 @@ class TextChannel(abc.Messageable, abc.GuildChannel, Hashable, PinsMixin):
         message: Optional[Snowflake] = None,
         auto_archive_duration: ThreadArchiveDuration = MISSING,
         type: Optional[ChannelType] = None,
+        invitable: bool = True,
         reason: Optional[str] = None,
     ) -> Thread:
         """|coro|
@@ -742,6 +743,9 @@ class TextChannel(abc.Messageable, abc.GuildChannel, Hashable, PinsMixin):
             The type of thread to create. If a ``message`` is passed then this parameter
             is ignored, as a thread created with a message is always a public thread.
             By default this creates a private thread if this is ``None``.
+        invitable: :class:`bool`
+            Whether non-moderators can add other non-moderators to this thread.
+            Only available for private threads and without message.
         reason: :class:`str`
             The reason for creating a new thread. Shows up on the audit log.
 
@@ -767,6 +771,7 @@ class TextChannel(abc.Messageable, abc.GuildChannel, Hashable, PinsMixin):
                 name=name,
                 auto_archive_duration=auto_archive_duration or self.default_auto_archive_duration,
                 type=type.value,
+                invitable=invitable,
                 reason=reason,
             )
         else:

--- a/nextcord/channel.py
+++ b/nextcord/channel.py
@@ -745,7 +745,7 @@ class TextChannel(abc.Messageable, abc.GuildChannel, Hashable, PinsMixin):
             By default this creates a private thread if this is ``None``.
         invitable: :class:`bool`
             Whether non-moderators can add other non-moderators to this thread.
-            Only available for private threads and without message.
+            Only available for private threads and created without ``message``.
         reason: :class:`str`
             The reason for creating a new thread. Shows up on the audit log.
 

--- a/nextcord/channel.py
+++ b/nextcord/channel.py
@@ -745,7 +745,7 @@ class TextChannel(abc.Messageable, abc.GuildChannel, Hashable, PinsMixin):
             By default this creates a private thread if this is ``None``.
         invitable: :class:`bool`
             Whether non-moderators can add other non-moderators to this thread.
-            Only available for private threads and created without ``message``.
+            Only available for private threads and threads created without a ``message``.
         reason: :class:`str`
             The reason for creating a new thread. Shows up on the audit log.
 


### PR DESCRIPTION
## Summary

The `invitable` parameter was not present in the `TextChannel.create_thread` method for some reason even if the underlying state supported it, so I added it.

## Checklist

- [x] If code changes were made then they have been tested.
  - [ ] I have updated the documentation to reflect the changes.
  - [ ] I have run `task pyright` and fixed the relevant issues.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
