### PR TITLE
fix(app-cmds): incomplete payloads giving tracebacks within autocomplete

### DIFF
--- a/nextcord/application_command.py
+++ b/nextcord/application_command.py
@@ -1680,9 +1680,9 @@ class SlashCommandOption(BaseCommandOption, SlashOption, AutocompleteOptionMixin
                     # the member object is not cached
                     value = state._users.get(user_id)
 
-                if value is None:
-                    # Fall back to a Object at-least
-                    value = Object(id=user_id)
+                    if value is None:
+                        # Fall back to a Object at-least
+                        value = Object(id=user_id)
         elif self.type is ApplicationCommandOptionType.role:
             if interaction.guild is None:
                 raise TypeError("Unable to handle a Role type when guild is None")

--- a/nextcord/application_command.py
+++ b/nextcord/application_command.py
@@ -1677,7 +1677,10 @@ class SlashCommandOption(BaseCommandOption, SlashOption, AutocompleteOptionMixin
                     guild = state._guilds.get(int(guild_id))
                     if guild:
                         value = guild.get_member(user_id)
-                else:
+
+                if value is None:
+                    # Either we aren't in a guild or
+                    # the member object is not cached
                     value = state._users.get(user_id)
 
                 if value is None:

--- a/nextcord/application_command.py
+++ b/nextcord/application_command.py
@@ -30,7 +30,7 @@ from typing import (
 import typing_extensions
 from typing_extensions import Annotated
 
-import nextcord
+from .object import Object
 from .abc import GuildChannel
 from .channel import (
     CategoryChannel,
@@ -1676,7 +1676,7 @@ class SlashCommandOption(BaseCommandOption, SlashOption, AutocompleteOptionMixin
 
                 if value is None:
                     # Fall back to a Object at-least
-                    value = nextcord.Object(id=user_id)
+                    value = Object(id=user_id)
         elif self.type is ApplicationCommandOptionType.role:
             if interaction.guild is None:
                 raise TypeError("Unable to handle a Role type when guild is None")

--- a/nextcord/application_command.py
+++ b/nextcord/application_command.py
@@ -1190,9 +1190,9 @@ class AutocompleteCommandMixin:
             To use inputs from other options inputted in the command, you can add them as arguments to the autocomplete
             callback. The order of the arguments does not matter, but the names do.
 
-            If you are using :py:class:`nextcord.Member` or :py:class:`nextcord.User` typehints in
+            If you are using :class:`nextcord.Member` or :class:`nextcord.User` typehints in
             your autocompletes then just note that the objects provided can be both `None` and
-            :py:class:`nextcord.Object` depending on the data Discord sends.
+            :class:`nextcord.Object` depending on the data Discord sends.
 
         Parameters
         ----------

--- a/nextcord/application_command.py
+++ b/nextcord/application_command.py
@@ -1190,9 +1190,9 @@ class AutocompleteCommandMixin:
             To use inputs from other options inputted in the command, you can add them as arguments to the autocomplete
             callback. The order of the arguments does not matter, but the names do.
 
-            If you are using :py:class:`nextcord.Member` or :py:class:`nextcord.user` typehints in
+            If you are using :py:class:`nextcord.Member` or :py:class:`nextcord.User` typehints in
             your autocompletes then just note that the objects provided can be both `None` and
-            :py:class:`nextcord.Object` depending on the data discord sends.
+            :py:class:`nextcord.Object` depending on the data Discord sends.
 
         Parameters
         ----------
@@ -1670,12 +1670,9 @@ class SlashCommandOption(BaseCommandOption, SlashOption, AutocompleteOptionMixin
                 # By here the interaction data doesn't contain
                 # a full member/user object yet so fall back to bot cache
                 value = None
-                data = interaction.data
-                data = cast(ApplicationCommandInteractionData, data)
-                guild_id = data.get("guild_id")
-                if guild_id:
-                    guild = state._guilds.get(int(guild_id))
-                    if guild:
+                data = cast(ApplicationCommandInteractionData, interaction.data)
+                if guild_id := data.get("guild_id"):
+                    if guild := state._guilds.get(int(guild_id)):
                         value = guild.get_member(user_id)
 
                 if value is None:

--- a/nextcord/application_command.py
+++ b/nextcord/application_command.py
@@ -1190,6 +1190,10 @@ class AutocompleteCommandMixin:
             To use inputs from other options inputted in the command, you can add them as arguments to the autocomplete
             callback. The order of the arguments does not matter, but the names do.
 
+            If you are using :py:class:`nextcord.Member` or :py:class:`nextcord.user` typehints in
+            your autocompletes then just note that the objects provided can be both `None` and
+            :py:class:`nextcord.Object` depending on the data discord sends.
+
         Parameters
         ----------
         on_kwarg: :class:`str`

--- a/nextcord/application_command.py
+++ b/nextcord/application_command.py
@@ -1670,13 +1670,15 @@ class SlashCommandOption(BaseCommandOption, SlashOption, AutocompleteOptionMixin
                 # By here the interaction data doesn't contain
                 # a full member/user object yet so fall back to bot cache
                 value = None
-                guild_id = interaction.data.get("guild_id")
+                data = interaction.data
+                data = cast(ApplicationCommandInteractionData, data)
+                guild_id = data.get("guild_id")
                 if guild_id:
                     guild = state._guilds.get(int(guild_id))
                     if guild:
                         value = guild.get_member(user_id)
                 else:
-                    value = state._user.get(user_id)
+                    value = state._users.get(user_id)
 
                 if value is None:
                     # Fall back to a Object at-least


### PR DESCRIPTION
## Summary

When using either a `nextcord.User` or `nextcord.Member` item within autocomplete there is a chance that the required data is missing due to discord not sending the data. This PR fixes the raw tracebacks and instead takes a best effort approach to attempting to get a valid object from cache before returning atleast a `nextcord.Object` object.

#### Reproduction code

```py

@client.slash_command()
async def test(
    interaction: nextcord.Interaction,
    member: nextcord.Member = nextcord.SlashOption(
        name="member", description="Select member", required=True
    ),
    warn: int = nextcord.SlashOption(name="warn", description="Warn", required=True),
):
    print(type(member))


@test.on_autocomplete("warn")
async def warn_autocomplete(interaction: nextcord.Interaction, warn: int, member: nextcord.Member):
    print(type(member))

    return await interaction.response.send_autocomplete([str(i) for i in range(10)])
```

#### Reproduction steps

Run the command, when populating the `member` choices click a user and do nothing else. Then click and fill in the `warn` entry, this should produce a traceback

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
  - [x] I have updated the documentation to reflect the changes.
  - [x] I have run `task pyright` and fixed the relevant issues.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
