### PR TITLE
fix(voice): include ssrc parameter when sending a `SPEAKING` payload

### DIFF
--- a/nextcord/gateway.py
+++ b/nextcord/gateway.py
@@ -959,7 +959,10 @@ class DiscordVoiceWebSocket:
     async def load_secret_key(self, data: Dict[str, Any]) -> None:
         _log.info("received secret key for voice connection")
         self.secret_key = self._connection.secret_key = data["secret_key"]
-        await self.speak()
+        # Send a speak command with the "not speaking" state.
+        # This also tells Discord our SSRC value, which Discord requires
+        # before sending any voice data (and is the real reason why we
+        # call this here).
         await self.speak(SpeakingState.none)
 
     async def poll_event(self) -> None:

--- a/nextcord/gateway.py
+++ b/nextcord/gateway.py
@@ -873,7 +873,14 @@ class DiscordVoiceWebSocket:
         await self.send_as_json(payload)
 
     async def speak(self, state: SpeakingState = SpeakingState.voice) -> None:
-        payload = {"op": self.SPEAKING, "d": {"speaking": int(state), "delay": 0}}
+        payload = {
+            "op": self.SPEAKING,
+            "d": {
+                "speaking": int(state),
+                "delay": 0,
+                "ssrc": self._connection.ssrc,
+            }
+        }
 
         await self.send_as_json(payload)
 

--- a/nextcord/gateway.py
+++ b/nextcord/gateway.py
@@ -879,7 +879,7 @@ class DiscordVoiceWebSocket:
                 "speaking": int(state),
                 "delay": 0,
                 "ssrc": self._connection.ssrc,
-            }
+            },
         }
 
         await self.send_as_json(payload)


### PR DESCRIPTION
## Summary

As it is a required parameter, see https://discord.com/developers/docs/topics/voice-connections#speaking.

Additionally included in this PR is the elimination of an unnecessary call to `DiscordVoiceWebSocket.speak` - see the commit message of https://github.com/nextcord/nextcord/commit/5d7b63d10ca6408194e1f1b7a8688c0934127bbf for why.

We found that without the ssrc change, [our Discord bot](https://github.com/anoadragon453/busty/) would fail to play audio after joining a stage. Regular voice channels were fine, however. Moving the bot between the audience and the stage seemed to be a workaround, but didn't in all cases.

The issue also seemed to only affect certain Discord guilds, for whatever reason, and only cropped up in the past month, suggesting that Discord has changed something on their side that made sending this parameter more important.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
  - [ ] I have updated the documentation to reflect the changes.
  - [ ] I have run `task pyright` and fixed the relevant issues.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
