### PR TITLE
Fix: ForumChannel and Thread not returning proper ForumTags

### DIFF
--- a/nextcord/channel.py
+++ b/nextcord/channel.py
@@ -961,7 +961,7 @@ class ForumChannel(abc.GuildChannel, Hashable):
             "default_thread_slowmode_delay"
         )
         self._available_tags: Dict[int, ForumTag] = {
-            int(data["id"]): ForumTag.from_data(tag) for tag in data.get("available_tags", [])
+            int(tag["id"]): ForumTag.from_data(tag) for tag in data.get("available_tags", [])
         }
 
         self.default_reaction: Optional[PartialEmoji]

--- a/nextcord/threads.py
+++ b/nextcord/threads.py
@@ -178,7 +178,7 @@ class Thread(Messageable, Hashable, PinsMixin):
             self.me = ThreadMember(self, member)
 
         self.applied_tag_ids: List[int] = [
-            int(tag_id) for tag_id in data.get("applied_thread_tags", [])
+            int(tag_id) for tag_id in data.get("applied_tags", [])
         ]
 
     def _unroll_metadata(self, data: ThreadMetadata) -> None:


### PR DESCRIPTION
## Summary

<!-- What is this pull request for? Does it fix any issues? -->
**Issues:**
- ForumChannel.available_tags only returned last ForumTag
- Thread.applied_tags and Thread.applied_tag_ids returned empty list
- This applies to any way of getting ForumChannel and Thread

**Reasons:**
- Wrong dict used in ForumChannel._update while generating keys for ForumChannel._available_tags
- Wrong dict key used in Thread.from_data while generating Thread.applied_tag_ids

**Fixed:** changed wrong values to proper ones.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
  - [ ] I have updated the documentation to reflect the changes.
  - [ ] I have run `task pyright` and fixed the relevant issues.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
