### PR TITLE
fix: ForumChannel and Thread returning wrong ForumTags

### DIFF
--- a/nextcord/channel.py
+++ b/nextcord/channel.py
@@ -961,7 +961,7 @@ class ForumChannel(abc.GuildChannel, Hashable):
             "default_thread_slowmode_delay"
         )
         self._available_tags: Dict[int, ForumTag] = {
-            int(data["id"]): ForumTag.from_data(tag) for tag in data.get("available_tags", [])
+            int(tag["id"]): ForumTag.from_data(tag) for tag in data.get("available_tags", [])
         }
 
         self.default_reaction: Optional[PartialEmoji]

--- a/nextcord/channel.py
+++ b/nextcord/channel.py
@@ -3042,7 +3042,7 @@ class ForumTag:
     @property
     def payload(self) -> ForumTagPayload:
         data: ForumTagPayload = {
-            "id": str(self.id) if self.id is not None else None,
+            "id": str(self.id),
             "name": self.name,
             "moderated": self.moderated,
         }

--- a/nextcord/threads.py
+++ b/nextcord/threads.py
@@ -177,9 +177,7 @@ class Thread(Messageable, Hashable, PinsMixin):
         else:
             self.me = ThreadMember(self, member)
 
-        self.applied_tag_ids: List[int] = [
-            int(tag_id) for tag_id in data.get("applied_tags", [])
-        ]
+        self.applied_tag_ids: List[int] = [int(tag_id) for tag_id in data.get("applied_tags", [])]
 
     def _unroll_metadata(self, data: ThreadMetadata) -> None:
         self.archived = data["archived"]

--- a/nextcord/threads.py
+++ b/nextcord/threads.py
@@ -178,7 +178,7 @@ class Thread(Messageable, Hashable, PinsMixin):
             self.me = ThreadMember(self, member)
 
         self.applied_tag_ids: List[int] = [
-            int(tag_id) for tag_id in data.get("applied_thread_tags", [])
+            int(tag_id) for tag_id in data.get("applied_tags", [])
         ]
 
     def _unroll_metadata(self, data: ThreadMetadata) -> None:

--- a/nextcord/types/channel.py
+++ b/nextcord/types/channel.py
@@ -151,7 +151,7 @@ class StageInstance(TypedDict):
 
 
 class ForumTag(TypedDict):
-    id: Optional[Snowflake]
+    id: Snowflake
     name: str
     moderated: bool
     emoji_id: NotRequired[Optional[Snowflake]]


### PR DESCRIPTION
## Summary

<!-- What is this pull request for? Does it fix any issues? -->
Fixed ForumChannel.available_tags only returned last tag by wrong id: used wrong dict to get id
Fixed Thread.applied_tags and Thread.applied_tag_ids returned empty list: used non-existent key in getting tags data from payload
ForumTag id is no longer optional when getting from payload

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
  - [ ] I have updated the documentation to reflect the changes.
  - [ ] I have run `task pyright` and fixed the relevant issues.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
