### PR TITLE
docs(abc): remove the position specification

### DIFF
--- a/nextcord/abc.py
+++ b/nextcord/abc.py
@@ -224,6 +224,9 @@ class GuildChannel:
         The guild the channel belongs to.
     position: :class:`int`
         The position in the channel list.
+
+        .. note::
+            Due to API inconsistencies, the position may not mirror the correct UI ordering
     """
 
     __slots__ = ()

--- a/nextcord/abc.py
+++ b/nextcord/abc.py
@@ -223,8 +223,7 @@ class GuildChannel:
     guild: :class:`~nextcord.Guild`
         The guild the channel belongs to.
     position: :class:`int`
-        The position in the channel list. This is a number that starts at 0.
-        e.g. the top channel is position 0.
+        The position in the channel list.
     """
 
     __slots__ = ()


### PR DESCRIPTION
## Summary

<!-- What is this pull request for? Does it fix any issues? -->
Fixes #55

This basically removes the part of the doc where it says that the top channel's position is 0. As the issue is that the channel positions are put in random orders (at least, from my understanding from the PR that #55 links).
So that it does not imply anything about what channel comes first and so on.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
  - [ ] I have updated the documentation to reflect the changes.
  - [ ] I have run `task pyright` and fixed the relevant issues.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
