### PR TITLE
chore: prefer os.environ

### DIFF
--- a/examples/secure_token_storage.py
+++ b/examples/secure_token_storage.py
@@ -13,4 +13,4 @@ load_dotenv()
 bot = commands.Bot()
 
 # run the bot using the token in .env
-bot.run(os.getenv("BOT_TOKEN"))
+bot.run(os.environ["BOT_TOKEN"])


### PR DESCRIPTION
## Summary

Prefer os.environ over os.getenv for the token example. I had the reasoning laid out here but `gh` fucked up the request and deleted my message, tl;dr it gives a better error.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
  - [ ] I have updated the documentation to reflect the changes.
  - [ ] I have run `task pyright` and fixed the relevant issues.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
