### PR TITLE
revert: "docs(app-cmds): document SlashCommandMixin.options"

### DIFF
--- a/nextcord/application_command.py
+++ b/nextcord/application_command.py
@@ -1706,11 +1706,10 @@ class SlashCommandMixin(CallbackMixin):
         command_ids: Dict[Optional[int], int]
         qualified_name: str
         _children: Dict[str, SlashApplicationSubcommand]
-        _options: Dict[str, SlashCommandOption]
 
     def __init__(self, callback: Optional[Callable], parent_cog: Optional[ClientCog]) -> None:
         CallbackMixin.__init__(self, callback=callback, parent_cog=parent_cog)
-        self._options = {}
+        self.options: Dict[str, SlashCommandOption] = {}
         self._parsed_docstring: Optional[Dict[str, Any]] = None
         self._children: Dict[str, SlashApplicationSubcommand] = {}
 
@@ -1722,15 +1721,6 @@ class SlashCommandMixin(CallbackMixin):
             ``.children`` is now a read-only property.
         """
         return self._children
-
-    @property
-    def options(self) -> Dict[str, SlashCommandOption]:
-        """Dict[:class:`str`, :class:`SlashCommandOption`]: Returns the options of the command.
-
-        .. versionchanged:: 2.5
-            This is now a read-only property.
-        """
-        return self._options
 
     @property
     def description(self) -> str:
@@ -1769,11 +1759,11 @@ class SlashCommandMixin(CallbackMixin):
                 raise ValueError("Discord did not provide us any options data")
 
         kwargs = {}
-        uncalled_args = self._options.copy()
+        uncalled_args = self.options.copy()
         for arg_data in option_data:
             if arg_data["name"] in uncalled_args:
                 uncalled_args.pop(arg_data["name"])
-                kwargs[self.options[arg_data["name"]].functional_name] = await self._options[
+                kwargs[self.options[arg_data["name"]].functional_name] = await self.options[
                     arg_data["name"]
                 ].handle_value(state, arg_data.get("value"), interaction)
             else:
@@ -1942,7 +1932,7 @@ class BaseApplicationCommand(CallbackMixin, CallbackWrapperMixin):
         Dict[Optional[:class:`int`], :class:`int`]:
             Command IDs that this application command currently has. Schema: {Guild ID (None for global): command ID}
         """
-        self._options: Dict[str, ApplicationCommandOption] = {}
+        self.options: Dict[str, ApplicationCommandOption] = {}
 
     # Simple-ish getter + setter methods.
 


### PR DESCRIPTION
Reverts nextcord/nextcord#986

The PR introduced unwanted changes which break end user bots