### PR TITLE
feat(flags): add MemberFlags and relevant fields

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -912,6 +912,7 @@ to handle it, which defaults to print a traceback and ignoring the exception.
     - nickname
     - roles
     - pending
+    - flags
 
     This requires :attr:`Intents.members` to be enabled.
 
@@ -4726,6 +4727,14 @@ PublicUserFlags
 .. attributetable:: PublicUserFlags
 
 .. autoclass:: PublicUserFlags()
+    :members:
+
+MemberFlags
+~~~~~~~~~~~
+
+.. attributetable:: MemberFlags
+
+.. autoclass:: MemberFlags()
     :members:
 
 ChannelFlags

--- a/nextcord/flags.py
+++ b/nextcord/flags.py
@@ -504,7 +504,7 @@ class MemberFlags(BaseFlags):
             Checks if two MemberFlags are not equal.
         .. describe:: hash(x)
 
-            Return the flag's hash.
+            Returns the flag's hash.
         .. describe:: iter(x)
 
             Returns an iterator of ``(name, value)`` pairs. This allows it

--- a/nextcord/flags.py
+++ b/nextcord/flags.py
@@ -520,7 +520,7 @@ class MemberFlags(BaseFlags):
 
     @flag_value
     def did_rejoin(self):
-        """:class:`bool`: Returns ``True`` if the member left and rejoined the :attr:`~nextcord.Member.guild`."""
+        """:class:`bool`: Returns ``True`` if the member left and rejoined the :attr:`~nextcord.Guild`."""
         return 1 << 0
 
     @flag_value

--- a/nextcord/flags.py
+++ b/nextcord/flags.py
@@ -27,6 +27,7 @@ __all__ = (
     "SystemChannelFlags",
     "MessageFlags",
     "PublicUserFlags",
+    "MemberFlags",
     "Intents",
     "MemberCacheFlags",
     "ApplicationFlags",

--- a/nextcord/flags.py
+++ b/nextcord/flags.py
@@ -487,6 +487,79 @@ class PublicUserFlags(BaseFlags):
 
 
 @fill_with_flags()
+class MemberFlags(BaseFlags):
+    r"""Wraps up the Discord Guild Member flags
+
+    .. versionadded:: 2.5
+
+    .. container:: operations
+
+        .. describe:: x == y
+
+            Checks if two MemberFlags are equal.
+
+        .. describe:: x != y
+
+            Checks if two MemberFlags are not equal.
+
+        .. describe:: x | y, x |= y
+
+            Returns a MemberFlags instance with all enabled flags from
+            both x and y.
+
+        .. describe:: x & y, x &= y
+
+            Returns a MemberFlags instance with only flags enabled on
+            both x and y.
+
+        .. describe:: x ^ y, x ^= y
+
+            Returns a MemberFlags instance with only flags enabled on
+            only one of x or y, not on both.
+
+        .. describe:: ~x
+
+            Returns a MemberFlags instance with all flags inverted from x.
+
+        .. describe:: hash(x)
+
+            Return the flag's hash.
+
+        .. describe:: iter(x)
+
+            Returns an iterator of ``(name, value)`` pairs. This allows it
+            to be, for example, constructed as a dict or a list of pairs.
+            Note that aliases are not shown.
+
+    Attributes
+    -----------
+    value: :class:`int`
+        The raw value. You should query flags via the properties
+        rather than using this raw value.
+    """
+
+    @flag_value
+    def did_rejoin(self):
+        """:class:`bool`: Returns ``True`` if the member left and rejoined the :attr:`~nextcord.Member.guild`."""
+        return 1 << 0
+
+    @flag_value
+    def completed_onboarding(self):
+        """:class:`bool`: Returns ``True`` if the member has completed onboarding."""
+        return 1 << 1
+
+    @flag_value
+    def bypasses_verification(self):
+        """:class:`bool`: Returns ``True`` if the member can bypass the guild verification requirements."""
+        return 1 << 2
+
+    @flag_value
+    def started_onboarding(self):
+        """:class:`bool`: Returns ``True`` if the member has started onboarding."""
+        return 1 << 3
+
+
+@fill_with_flags()
 class Intents(BaseFlags):
     r"""Wraps up a Discord gateway intent flag.
 

--- a/nextcord/flags.py
+++ b/nextcord/flags.py
@@ -491,7 +491,7 @@ class PublicUserFlags(BaseFlags):
 class MemberFlags(BaseFlags):
     r"""Wraps up the Discord Guild Member flags
 
-    .. versionadded:: 2.6 
+    .. versionadded:: 2.6
 
     .. container:: operations
 

--- a/nextcord/flags.py
+++ b/nextcord/flags.py
@@ -491,7 +491,7 @@ class PublicUserFlags(BaseFlags):
 class MemberFlags(BaseFlags):
     r"""Wraps up the Discord Guild Member flags
 
-    .. versionadded:: 2.5
+    .. versionadded:: 2.6 
 
     .. container:: operations
 

--- a/nextcord/flags.py
+++ b/nextcord/flags.py
@@ -502,30 +502,9 @@ class MemberFlags(BaseFlags):
         .. describe:: x != y
 
             Checks if two MemberFlags are not equal.
-
-        .. describe:: x | y, x |= y
-
-            Returns a MemberFlags instance with all enabled flags from
-            both x and y.
-
-        .. describe:: x & y, x &= y
-
-            Returns a MemberFlags instance with only flags enabled on
-            both x and y.
-
-        .. describe:: x ^ y, x ^= y
-
-            Returns a MemberFlags instance with only flags enabled on
-            only one of x or y, not on both.
-
-        .. describe:: ~x
-
-            Returns a MemberFlags instance with all flags inverted from x.
-
         .. describe:: hash(x)
 
             Return the flag's hash.
-
         .. describe:: iter(x)
 
             Returns an iterator of ``(name, value)`` pairs. This allows it

--- a/nextcord/member.py
+++ b/nextcord/member.py
@@ -284,7 +284,7 @@ class Member(abc.Messageable, _UserTag):
         self._timeout: Optional[datetime.datetime] = utils.parse_time(
             data.get("communication_disabled_until")
         )
-        self._flags = data.get("flags", 0)
+        self._flags: int = data.get("flags", 0)
 
     def __str__(self) -> str:
         return str(self._user)
@@ -554,7 +554,7 @@ class Member(abc.Messageable, _UserTag):
     def flags(self) -> MemberFlags:
         """:class:`MemberFlags`: Returns the member's flags.
 
-        .. versionadded:: 2.5
+        .. versionadded:: 2.6
         """
         return MemberFlags._from_value(self._flags)
 
@@ -771,11 +771,11 @@ class Member(abc.Messageable, _UserTag):
             The flags to set for this member.
             Currently only :class:`~nextcord.MemberFlags.bypasses_verification` is able to be set.
 
-            .. versionadded:: 2.5
+            .. versionadded:: 2.6
         bypass_verification: :class:`bool`
             Indicates if the member should be allowed to bypass the guild verification requirements.
 
-            .. versionadded:: 2.5
+            .. versionadded:: 2.6
 
         Raises
         ------

--- a/nextcord/member.py
+++ b/nextcord/member.py
@@ -14,6 +14,7 @@ from .activity import ActivityTypes, create_activity
 from .asset import Asset
 from .colour import Colour
 from .enums import Status, try_enum
+from .flags import MemberFlags
 from .object import Object
 from .permissions import Permissions
 from .user import BaseUser, User, _UserTag
@@ -244,6 +245,7 @@ class Member(abc.Messageable, _UserTag):
         "_state",
         "_avatar",
         "_timeout",
+        "_flags",
     )
 
     if TYPE_CHECKING:
@@ -282,6 +284,7 @@ class Member(abc.Messageable, _UserTag):
         self._timeout: Optional[datetime.datetime] = utils.parse_time(
             data.get("communication_disabled_until")
         )
+        self._flags = data.get("flags", 0)
 
     def __str__(self) -> str:
         return str(self._user)
@@ -314,6 +317,7 @@ class Member(abc.Messageable, _UserTag):
         self.nick = data.get("nick", None)
         self.pending = data.get("pending", False)
         self._timeout = utils.parse_time(data.get("communication_disabled_until"))
+        self._flags = data.get("flags", 0)
 
     @classmethod
     def _try_upgrade(
@@ -343,6 +347,7 @@ class Member(abc.Messageable, _UserTag):
         self._state = member._state
         self._avatar = member._avatar
         self._timeout = member._timeout
+        self._flags = member._flags
 
         # Reference will not be copied unless necessary by PRESENCE_UPDATE
         # See below
@@ -370,6 +375,7 @@ class Member(abc.Messageable, _UserTag):
         self._roles = utils.SnowflakeList(map(int, data["roles"]))
         self._avatar = data.get("avatar")
         self._timeout = utils.parse_time(data.get("communication_disabled_until"))
+        self._flags = data.get("flags", 0)
 
     def _presence_update(
         self, data: PartialPresenceUpdate, user: UserPayload
@@ -544,6 +550,14 @@ class Member(abc.Messageable, _UserTag):
         if self.activities:
             return self.activities[0]
 
+    @property
+    def flags(self) -> MemberFlags:
+        """:class:`MemberFlags`: Returns the member's flags.
+
+        .. versionadded:: 2.5
+        """
+        return MemberFlags._from_value(self._flags)
+
     def mentioned_in(self, message: Message) -> bool:
         """Checks if the member is mentioned in the specified message.
 
@@ -693,6 +707,8 @@ class Member(abc.Messageable, _UserTag):
         voice_channel: Optional[VocalGuildChannel] = MISSING,
         reason: Optional[str] = None,
         timeout: Optional[Union[datetime.datetime, datetime.timedelta]] = MISSING,
+        flags: Optional[MemberFlags] = MISSING,
+        bypass_verification: bool = MISSING,
     ) -> Optional[Member]:
         """|coro|
 
@@ -700,21 +716,23 @@ class Member(abc.Messageable, _UserTag):
 
         Depending on the parameter passed, this requires different permissions listed below:
 
-        +---------------+--------------------------------------+
-        |   Parameter   |              Permission              |
-        +---------------+--------------------------------------+
-        | nick          | :attr:`Permissions.manage_nicknames` |
-        +---------------+--------------------------------------+
-        | mute          | :attr:`Permissions.mute_members`     |
-        +---------------+--------------------------------------+
-        | deafen        | :attr:`Permissions.deafen_members`   |
-        +---------------+--------------------------------------+
-        | roles         | :attr:`Permissions.manage_roles`     |
-        +---------------+--------------------------------------+
-        | voice_channel | :attr:`Permissions.move_members`     |
-        +---------------+--------------------------------------+
-        | timeout       | :attr:`Permissions.moderate_members` |
-        +---------------+--------------------------------------+
+        +---------------------+--------------------------------------+
+        |      Parameter      |              Permission              |
+        +---------------------+--------------------------------------+
+        | nick                | :attr:`Permissions.manage_nicknames` |
+        +---------------------+--------------------------------------+
+        | mute                | :attr:`Permissions.mute_members`     |
+        +---------------------+--------------------------------------+
+        | deafen              | :attr:`Permissions.deafen_members`   |
+        +---------------------+--------------------------------------+
+        | roles               | :attr:`Permissions.manage_roles`     |
+        +---------------------+--------------------------------------+
+        | voice_channel       | :attr:`Permissions.move_members`     |
+        +---------------------+--------------------------------------+
+        | timeout             | :attr:`Permissions.moderate_members` |
+        +---------------------+--------------------------------------+
+        | bypass_verification | :attr:`Permissions.moderate_members` |
+        +---------------------+--------------------------------------+
 
         All parameters are optional.
 
@@ -749,6 +767,15 @@ class Member(abc.Messageable, _UserTag):
             Set this to None to disable their timeout.
 
             .. versionadded:: 2.0
+        flags: Optional[:class:`~nextcord.MemberFlags`]
+            The flags to set for this member.
+            Currently only :class:`~nextcord.MemberFlags.bypasses_verification` is able to be set.
+
+            .. versionadded:: 2.5
+        bypass_verification: :class:`bool`
+            Indicates if the member should be allowed to bypass the guild verification requirements.
+
+            .. versionadded:: 2.5
 
         Raises
         ------
@@ -823,6 +850,16 @@ class Member(abc.Messageable, _UserTag):
                 "Timeout must be a `datetime.datetime` or `datetime.timedelta`"
                 f"not {timeout.__class__.__name__}"
             )
+
+        if flags is None:
+            flags = MemberFlags()
+        if bypass_verification is not MISSING:
+            flags.bypasses_verification = bypass_verification
+
+        flag_value: Optional[int] = flags.value if flags.value != 0 else None
+
+        if flag_value is not None:
+            payload["flags"] = flag_value
 
         if payload:
             data = await http.edit_member(guild_id, self.id, reason=reason, **payload)

--- a/nextcord/member.py
+++ b/nextcord/member.py
@@ -707,7 +707,7 @@ class Member(abc.Messageable, _UserTag):
         voice_channel: Optional[VocalGuildChannel] = MISSING,
         reason: Optional[str] = None,
         timeout: Optional[Union[datetime.datetime, datetime.timedelta]] = MISSING,
-        flags: Optional[MemberFlags] = MISSING,
+        flags: MemberFlags = MISSING,
         bypass_verification: bool = MISSING,
     ) -> Optional[Member]:
         """|coro|
@@ -767,7 +767,7 @@ class Member(abc.Messageable, _UserTag):
             Set this to None to disable their timeout.
 
             .. versionadded:: 2.0
-        flags: Optional[:class:`~nextcord.MemberFlags`]
+        flags: :class:`~nextcord.MemberFlags`
             The flags to set for this member.
             Currently only :class:`~nextcord.MemberFlags.bypasses_verification` is able to be set.
 
@@ -851,15 +851,13 @@ class Member(abc.Messageable, _UserTag):
                 f"not {timeout.__class__.__name__}"
             )
 
-        if flags is None:
+        if flags is MISSING:
             flags = MemberFlags()
         if bypass_verification is not MISSING:
             flags.bypasses_verification = bypass_verification
 
-        flag_value: Optional[int] = flags.value if flags.value != 0 else None
-
-        if flag_value is not None:
-            payload["flags"] = flag_value
+        if flags.value != 0:
+            payload["flags"] = flags.value
 
         if payload:
             data = await http.edit_member(guild_id, self.id, reason=reason, **payload)

--- a/nextcord/types/member.py
+++ b/nextcord/types/member.py
@@ -15,6 +15,7 @@ class PartialMember(TypedDict):
     joined_at: str
     deaf: str
     mute: str
+    flags: int
 
 
 class Member(PartialMember, total=False):


### PR DESCRIPTION
## Summary

Relevant link to API Docs:
- https://discord.com/developers/docs/resources/guild#guild-member-object-guild-member-structure
- https://discord.com/developers/docs/resources/guild#guild-member-object-guild-member-flags

This PR adds support for getting a member's flags via the matching attributes.

I have not tested this but.. most of the code is from **my** PR to discord.py - https://github.com/Rapptz/discord.py/pull/9204 which was fully tested.

Adds the following:

- Classes:
  - `MemberFlags`

- Attributes to nextcord.Member:
  - `_flags`
  - `flags` (property)

- Kwargs to nextcord.Member.edit:
  - `flags`
  - `bypass_verification`

- Fields to `PartialMember` (type):
  - `flags`

- Possible attrs for `on_member_update` (docs):
  - `flags`

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
  - [x] I have updated the documentation to reflect the changes.
  - [x] I have run `task pyright` and fixed the relevant issues.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
