### PR TITLE
fix(app-cmds): unfocused options not getting passed in autocomplete callback

### DIFF
--- a/nextcord/application_command.py
+++ b/nextcord/application_command.py
@@ -1514,10 +1514,7 @@ class SlashCommandOption(BaseCommandOption, SlashOption, AutocompleteOptionMixin
             # If they didn't explicitly enable autocomplete but did add an autocomplete callback...
             self.autocomplete = True
         if self.autocomplete_callback:
-            if not asyncio.iscoroutinefunction(self.autocomplete_callback):
-                raise TypeError(
-                    f"Given autocomplete callback for kwarg {self.functional_name} isn't a coroutine."
-                )
+            self.from_autocomplete_callback(self.autocomplete_callback)
 
         if cmd_arg.required is not None:
             # If the user manually set if it's required...


### PR DESCRIPTION
## Summary

Fixes #1045

### Bug:

`from_autocomplete_callback` is not getting called and `autocomplete_options` is not getting populated when `autocomplete_callback` is supplied to a SlashOption rather than using the decorator. This causes other options from the command to be inaccessible from the autocomplete callback method (see linked issue).

### Fix:

Replaces `iscoroutinefunction` check in `SlashCommandOption` with a call to `self.from_autocomplete_callback(self.autocomplete_callback)` which includes the `iscoroutinefunction` check and also populates the `autocomplete_options` field to have the other options in the command so they can be accessed later when the callback is called (see [`from_autocomplete_callback`](https://github.com/DenverCoderOne/nextcord/blob/c2af2acdee302b0056dfb5f7ede934f20413f971/nextcord/application_command.py#L1005-L1023)).

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
  - [ ] I have updated the documentation to reflect the changes.
  - [x] I have run `task pyright` and fixed the relevant issues.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
