### PR TITLE
refactor(app-cmds): move global checks to Client

### DIFF
--- a/nextcord/application_command.py
+++ b/nextcord/application_command.py
@@ -817,7 +817,7 @@ class CallbackMixin:
             A boolean indicating if the command can be invoked.
         """
         # Global checks
-        for check in interaction.client._connection._application_command_checks:
+        for check in interaction.client._application_command_checks:
             try:
                 check_result = await maybe_coroutine(check, interaction)
             # To catch any subclasses of ApplicationCheckFailure.
@@ -887,8 +887,8 @@ class CallbackMixin:
             if (before_invoke := self.cog_before_invoke) is not None:
                 await before_invoke(interaction)  # type: ignore
 
-            if (before_invoke := state._application_command_before_invoke) is not None:
-                await before_invoke(interaction)  # type: ignore
+            if (before_invoke := interaction.client._application_command_before_invoke) is not None:
+                await before_invoke(interaction)
 
             try:
                 # await self.invoke_callback(interaction, *args, **kwargs)
@@ -909,8 +909,10 @@ class CallbackMixin:
                 if (after_invoke := self.cog_after_invoke) is not None:
                     await after_invoke(interaction)  # type: ignore
 
-                if (after_invoke := state._application_command_after_invoke) is not None:
-                    await after_invoke(interaction)  # type: ignore
+                if (
+                    after_invoke := interaction.client._application_command_after_invoke
+                ) is not None:
+                    await after_invoke(interaction)
 
     async def invoke_callback(self, interaction: Interaction, *args, **kwargs) -> None:
         """|coro|

--- a/nextcord/client.py
+++ b/nextcord/client.py
@@ -2862,7 +2862,8 @@ class Client:
                 return interaction.application_command.qualified_name in allowed_commands
 
         """
-        return self.add_application_command_check(func)  # type: ignore
+        self.add_application_command_check(func)  # type: ignore
+        return func
 
     def application_command_before_invoke(self, coro: ApplicationHook) -> ApplicationHook:
         """A decorator that registers a coroutine as a pre-invoke hook.

--- a/nextcord/client.py
+++ b/nextcord/client.py
@@ -2862,7 +2862,7 @@ class Client:
                 return interaction.application_command.qualified_name in allowed_commands
 
         """
-        self.add_application_command_check(func)  # type: ignore
+        self.add_application_command_check(func)
         return func
 
     def application_command_before_invoke(self, coro: ApplicationHook) -> ApplicationHook:

--- a/nextcord/client.py
+++ b/nextcord/client.py
@@ -2914,7 +2914,7 @@ class Client:
 
         Parameters
         ----------
-        coro: :ref:`coroutine`
+        coro: :ref:`coroutine <coroutine>`
             The coroutine to register as the post-invoke hook.
 
         Raises

--- a/nextcord/ext/commands/bot.py
+++ b/nextcord/ext/commands/bot.py
@@ -49,7 +49,6 @@ if TYPE_CHECKING:
     from nextcord.flags import MemberCacheFlags
     from nextcord.mentions import AllowedMentions
     from nextcord.message import Message
-    from nextcord.types.checks import ApplicationCheck, ApplicationHook
 
     from ._types import Check, CoroFunc
 
@@ -1428,128 +1427,6 @@ class BotBase(GroupMixin):
 
     async def on_message(self, message) -> None:
         await self.process_commands(message)
-
-    def add_application_command_check(self, func: ApplicationCheck) -> None:
-        """Adds a global application check to the bot.
-
-        This is the non-decorator interface to :meth:`.check`
-        and :meth:`.check_once`.
-
-        Parameters
-        ----------
-        func: Callable[[:class:`Interaction`], MaybeCoro[bool]]]
-            The function that was used as a global application check.
-        """
-
-        self._connection._application_command_checks.append(func)  # type: ignore
-
-    def remove_application_command_check(self, func: ApplicationCheck) -> None:
-        """Removes a global check from the bot.
-
-        This function is idempotent and will not raise an exception
-        if the function is not in the global checks.
-
-        Parameters
-        ----------
-        func: Callable[[:class:`Interaction`], MaybeCoro[bool]]]
-            The function to remove from the global application checks.
-        """
-
-        try:
-            self._connection._application_command_checks.remove(func)  # type: ignore
-        except ValueError:
-            pass
-
-    def application_command_check(self, func: Callable) -> ApplicationCheck:
-        r"""A decorator that adds a global application check to the bot.
-
-        A global check is similar to a :func:`.check` that is applied
-        on a per command basis except it is run before any command checks
-        have been verified and applies to every command the bot has.
-
-        .. note::
-
-            This function can either be a regular function or a coroutine.
-
-        Similar to a command :func:`.check`\, this takes a single parameter
-        of type :class:`.Interaction` and can only raise exceptions inherited from
-        :exc:`.ApplicationError`.
-
-        Example
-        -------
-
-        .. code-block:: python3
-
-            @client.check
-            def check_commands(interaction: Interaction) -> bool:
-                return interaction.application_command.qualified_name in allowed_commands
-
-        """
-        return self.add_application_command_check(func)  # type: ignore
-
-    def application_command_before_invoke(self, coro: ApplicationHook) -> ApplicationHook:
-        """A decorator that registers a coroutine as a pre-invoke hook.
-
-        A pre-invoke hook is called directly before the command is
-        called. This makes it a useful function to set up database
-        connections or any type of set up required.
-
-        This pre-invoke hook takes a sole parameter, a :class:`.Interaction`.
-
-        .. note::
-
-            The :meth:`.application_command_before_invoke` and :meth:`.application_command_after_invoke`
-            hooks are only called if all checks pass without error. If any check fails, then the hooks
-            are not called.
-
-        Parameters
-        ----------
-        coro: :ref:`coroutine <coroutine>`
-            The coroutine to register as the pre-invoke hook.
-
-        Raises
-        ------
-        TypeError
-            The coroutine passed is not actually a coroutine.
-        """
-        if not asyncio.iscoroutinefunction(coro):
-            raise TypeError("The pre-invoke hook must be a coroutine.")
-
-        self._connection._application_command_before_invoke = coro  # type: ignore
-        return coro
-
-    def application_command_after_invoke(self, coro: ApplicationHook) -> ApplicationHook:
-        r"""A decorator that registers a coroutine as a post-invoke hook.
-
-        A post-invoke hook is called directly after the command is
-        called. This makes it a useful function to clean-up database
-        connections or any type of clean up required. There may only be
-        one global post-invoke hook.
-
-        This post-invoke hook takes a sole parameter, a :class:`.Interaction`.
-
-        .. note::
-
-            Similar to :meth:`~.Client.application_command_before_invoke`\, this is not called unless
-            checks succeed. This hook is, however, **always** called regardless of the internal command
-            callback raising an error (i.e. :exc:`.ApplicationInvokeError`\).
-            This makes it ideal for clean-up scenarios.
-
-        Parameters
-        ----------
-        coro: :ref:`coroutine`
-            The coroutine to register as the post-invoke hook.
-
-        Raises
-        ------
-        TypeError
-            The coroutine passed is not actually a coroutine.
-        """
-        if not asyncio.iscoroutinefunction(coro):
-            raise TypeError("The post-invoke hook must be a coroutine.")
-
-        self._connection._application_command_after_invoke = coro  # type: ignore
-        return coro
 
 
 class Bot(BotBase, nextcord.Client):

--- a/nextcord/state.py
+++ b/nextcord/state.py
@@ -65,7 +65,6 @@ if TYPE_CHECKING:
     from .http import HTTPClient
     from .types.activity import Activity as ActivityPayload
     from .types.channel import DMChannel as DMChannelPayload
-    from .types.checks import ApplicationCheck, ApplicationHook
     from .types.emoji import Emoji as EmojiPayload
     from .types.guild import Guild as GuildPayload
     from .types.interactions import ApplicationCommand as ApplicationCommandPayload
@@ -253,11 +252,6 @@ class ConnectionState:
         for attr, func in inspect.getmembers(self):
             if attr.startswith("parse_"):
                 parsers[attr[6:].upper()] = func
-
-        # Global application command checks
-        self._application_command_checks: List[ApplicationCheck] = []
-        self._application_command_before_invoke: Optional[ApplicationHook] = None
-        self._application_command_after_invoke: Optional[ApplicationHook] = None
 
         self.clear()
 


### PR DESCRIPTION
## Summary

This PR moves global application command checks to `nextcord.Client` (from `BotBase`), same for storage (from `ConnectionState`(why?))

#956 

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
  - [x] I have updated the documentation to reflect the changes.
  - [x] I have run `task pyright` and fixed the relevant issues.
- [x] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
