### PR TITLE
fix(iterators): allow querying over 100 audit log entries

### DIFF
--- a/nextcord/iterators.py
+++ b/nextcord/iterators.py
@@ -572,10 +572,11 @@ class AuditLogIterator(_AsyncIterator["AuditLogEntry"]):
     async def _fill(self) -> None:
         if self._get_retrieve():
             data = await self._get_logs(self.retrieve)
-            if len(data) < 100:
+
+            entries = data.get("audit_log_entries", [])
+            if len(entries) < 100:
                 self.limit = 0  # terminate the infinite loop
 
-            entries = data.get("audit_log_entries")
             if self.reverse:
                 entries = reversed(entries)
 


### PR DESCRIPTION
## Summary

<!-- What is this pull request for? Does it fix any issues? -->
Fix `AuditLogsIterator` checking for the length of the data returned, instead of the length of the entires returned. (Fixing not allowing more than 100 entries to be queried)

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
  - [x] I have updated the documentation to reflect the changes.
  - [x] I have run `task pyright` and fixed the relevant issues.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
