### PR TITLE
fix(audit_logs)!: channel_id can be None due AutoMod blocking nickname changes

### DIFF
--- a/nextcord/audit_logs.py
+++ b/nextcord/audit_logs.py
@@ -475,10 +475,10 @@ class AuditLogEntry(Hashable):
                 self.action is enums.AuditLogAction.member_move
                 or self.action is enums.AuditLogAction.message_delete
             ):
-                channel_id = int(self.extra["channel_id"]) if self.extra["channel_id"] else None
+                channel_id = int(self.extra["channel_id"])
                 elems = {
                     "count": int(self.extra["count"]),
-                    "channel": self.guild.get_channel(channel_id) or Object(id=channel_id) if channel_id else None,
+                    "channel": self.guild.get_channel(channel_id) or Object(id=channel_id),
                 }
                 self.extra = type("_AuditLogProxy", (), elems)()  # type: ignore
             elif self.action is enums.AuditLogAction.member_disconnect:
@@ -489,9 +489,9 @@ class AuditLogEntry(Hashable):
                 self.extra = type("_AuditLogProxy", (), elems)()  # type: ignore
             elif self.action.name.endswith("pin"):
                 # the pin actions have a dict with some information
-                channel_id = int(self.extra["channel_id"]) if self.extra["channel_id"] else None
+                channel_id = int(self.extra["channel_id"])
                 elems = {
-                    "channel": self.guild.get_channel(channel_id) or Object(id=channel_id) if channel_id else None,
+                    "channel": self.guild.get_channel(channel_id) or Object(id=channel_id),
                     "message_id": int(self.extra["message_id"]),
                 }
                 self.extra = type("_AuditLogProxy", (), elems)()  # type: ignore
@@ -508,8 +508,8 @@ class AuditLogEntry(Hashable):
                         role.name = self.extra.get("role_name")  # type: ignore
                     self.extra = role  # type: ignore
             elif self.action.name.startswith("stage_instance"):
-                channel_id = int(self.extra["channel_id"]) if self.extra["channel_id"] else None
-                elems = {"channel": self.guild.get_channel(channel_id) or Object(id=channel_id) if channel_id else None}
+                channel_id = int(self.extra["channel_id"])
+                elems = {"channel": self.guild.get_channel(channel_id) or Object(id=channel_id)}
                 self.extra = type("_AuditLogProxy", (), elems)()  # type: ignore
             elif (
                 self.action is enums.AuditLogAction.auto_moderation_block_message

--- a/nextcord/audit_logs.py
+++ b/nextcord/audit_logs.py
@@ -523,7 +523,7 @@ class AuditLogEntry(Hashable):
         if channel_id and self.action:
             elems["channel"] = self.guild.get_channel(channel_id) or Object(id=channel_id)
             
-        if not self.extra:
+        if type(self.extra) is dict:
             self.extra = type("_AuditLogProxy", (), elems)() # type: ignore
 
         # this key is not present when the above is present, typically.

--- a/nextcord/audit_logs.py
+++ b/nextcord/audit_logs.py
@@ -521,7 +521,7 @@ class AuditLogEntry(Hashable):
 
         # this just gets automatically filled in if present, this way prevents crashes if channel_id is None
         if channel_id and self.action:
-            elems["channel"] = self.guild.get_channel(channel_id) or Object(id=channel_id)
+            elems["channel"] = self.guild.get_channel_or_thread(channel_id) or Object(id=channel_id)
             
         if type(self.extra) is dict:
             self.extra = type("_AuditLogProxy", (), elems)() # type: ignore

--- a/nextcord/audit_logs.py
+++ b/nextcord/audit_logs.py
@@ -475,10 +475,10 @@ class AuditLogEntry(Hashable):
                 self.action is enums.AuditLogAction.member_move
                 or self.action is enums.AuditLogAction.message_delete
             ):
-                channel_id = int(self.extra["channel_id"])
+                channel_id = int(self.extra["channel_id"]) if self.extra["channel_id"] else None
                 elems = {
                     "count": int(self.extra["count"]),
-                    "channel": self.guild.get_channel(channel_id) or Object(id=channel_id),
+                    "channel": self.guild.get_channel(channel_id) or Object(id=channel_id) if channel_id else None,
                 }
                 self.extra = type("_AuditLogProxy", (), elems)()  # type: ignore
             elif self.action is enums.AuditLogAction.member_disconnect:
@@ -489,9 +489,9 @@ class AuditLogEntry(Hashable):
                 self.extra = type("_AuditLogProxy", (), elems)()  # type: ignore
             elif self.action.name.endswith("pin"):
                 # the pin actions have a dict with some information
-                channel_id = int(self.extra["channel_id"])
+                channel_id = int(self.extra["channel_id"]) if self.extra["channel_id"] else None
                 elems = {
-                    "channel": self.guild.get_channel(channel_id) or Object(id=channel_id),
+                    "channel": self.guild.get_channel(channel_id) or Object(id=channel_id) if channel_id else None,
                     "message_id": int(self.extra["message_id"]),
                 }
                 self.extra = type("_AuditLogProxy", (), elems)()  # type: ignore
@@ -508,18 +508,19 @@ class AuditLogEntry(Hashable):
                         role.name = self.extra.get("role_name")  # type: ignore
                     self.extra = role  # type: ignore
             elif self.action.name.startswith("stage_instance"):
-                channel_id = int(self.extra["channel_id"])
-                elems = {"channel": self.guild.get_channel(channel_id) or Object(id=channel_id)}
+                channel_id = int(self.extra["channel_id"]) if self.extra["channel_id"] else None
+                elems = {"channel": self.guild.get_channel(channel_id) or Object(id=channel_id) if channel_id else None}
                 self.extra = type("_AuditLogProxy", (), elems)()  # type: ignore
             elif (
                 self.action is enums.AuditLogAction.auto_moderation_block_message
                 or self.action is enums.AuditLogAction.auto_moderation_flag_to_channel
                 or self.action is enums.AuditLogAction.auto_moderation_user_communication_disabled
             ):
-                channel_id = int(self.extra["channel_id"])
+                channel_id = int(self.extra["channel_id"]) if self.extra["channel_id"] else None
                 elems = {
                     "channel": (
-                        self.guild.get_channel_or_thread(channel_id) or Object(id=channel_id)
+                        self.guild.get_channel_or_thread(channel_id) or Object(id=channel_id) \
+                            if channel_id else None
                     ),
                     "rule_name": self.extra["auto_moderation_rule_name"],
                     "rule_trigger_type": enums.try_enum(

--- a/nextcord/audit_logs.py
+++ b/nextcord/audit_logs.py
@@ -522,7 +522,7 @@ class AuditLogEntry(Hashable):
         # this just gets automatically filled in if present, this way prevents crashes if channel_id is None
         if channel_id and self.action:
             elems["channel"] = self.guild.get_channel_or_thread(channel_id) or Object(id=channel_id)
-            
+
         if type(self.extra) is dict:
             self.extra = type("_AuditLogProxy", (), elems)()  # type: ignore
 

--- a/nextcord/types/audit_log.py
+++ b/nextcord/types/audit_log.py
@@ -283,7 +283,7 @@ AuditLogChange = Union[
 class AuditEntryInfo(TypedDict):
     delete_member_days: str
     members_removed: str
-    channel_id: Snowflake
+    channel_id: Optional[Snowflake]
     message_id: Snowflake
     count: str
     id: Snowflake

--- a/nextcord/types/audit_log.py
+++ b/nextcord/types/audit_log.py
@@ -283,7 +283,7 @@ AuditLogChange = Union[
 class AuditEntryInfo(TypedDict):
     delete_member_days: str
     members_removed: str
-    channel_id: Optional[Snowflake]
+    channel_id: Snowflake
     message_id: Snowflake
     count: str
     id: Snowflake


### PR DESCRIPTION
## Summary

<!-- What is this pull request for? Does it fix any issues? -->
Fixes #1038. There's a possibility that `channel_id` for being None when a nickname change was blocked by AutoMod and this has been logged in the AutoMod log channel.
Also removes some repetition in audit_logs.py

Testing code: https://paste.nextcord.dev/?id=1682809496392755

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
  - [ ] I have updated the documentation to reflect the changes.
  - [x] I have run `task pyright` and fixed the relevant issues.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
