### PR TITLE
chore: remove redundant pr template checkboxes

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -9,7 +9,3 @@
 - [ ] If code changes were made then they have been tested.
   - [ ] I have updated the documentation to reflect the changes.
   - [ ] I have run `task pyright` and fixed the relevant issues.
-- [ ] This PR fixes an issue.
-- [ ] This PR adds something new (e.g. new method or parameters).
-- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
-- [ ] This PR is **not** a code change (e.g. documentation, README, ...)

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,10 +2,15 @@
 
 <!-- What is this pull request for? Does it fix any issues? -->
 
-## Checklist
+<!-- Link any issues if applicable.
+Use keywords from https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests
+-->
 
-<!-- Put an x inside [ ] to check it, like so: [x] -->
+<!-- Uncomment based on the type of your changes below -->
 
-- [ ] If code changes were made then they have been tested.
-  - [ ] I have updated the documentation to reflect the changes.
-  - [ ] I have run `task pyright` and fixed the relevant issues.
+<!--
+## This is a **Code Change**
+
+- [ ] I have tested my changes.
+- [ ] I have updated the documentation to reflect the changes.
+- [ ] I have run `task pyright` and fixed the relevant issues.


### PR DESCRIPTION
## Summary

Using conventional commits means these are no longer needed.

- Fixes are represented as `fix:`
- New features are represented as `feat:`
- Breaking changes are represented as `BREAKING CHANGE:` and/or `<type>!:`
- Other types are represented as `docs:`, `chore:`, `refactor:`, ...

The checklist has been commented out, to be uncommented when required.

Inspired by <https://raw.githubusercontent.com/eludris/eludris/main/.github/PULL_REQUEST_TEMPLATE.md> from @spifory 

<!-- What is this pull request for? Does it fix any issues? -->
