### PR TITLE
docs(ui): specify what items modals support

### DIFF
--- a/nextcord/ui/modal.py
+++ b/nextcord/ui/modal.py
@@ -173,7 +173,7 @@ class Modal:
 
             .. note::
 
-                At the current time, Discord supports only Text Input items in Modals. 
+                At the current time, Discord supports only Text Input items in Modals.
                 The current Discord Docs page for supported items is [here](https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-response-object-modal).
 
         Raises

--- a/nextcord/ui/modal.py
+++ b/nextcord/ui/modal.py
@@ -173,8 +173,7 @@ class Modal:
 
             .. note::
 
-                At the current time, Discord supports only Text Input items in Modals.
-                The current Discord Docs page for supported items is [here](https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-response-object-modal).
+                The only items that are currently supported are :class:`TextInput`\s.
 
         Raises
         ------

--- a/nextcord/ui/modal.py
+++ b/nextcord/ui/modal.py
@@ -171,6 +171,11 @@ class Modal:
         item: :class:`Item`
             The item to add to the modal.
 
+            .. note::
+
+                At the current time, Discord supports only Text Input items in Modals. 
+                The current Discord Docs page for supported items is [here](https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-response-object-modal).
+
         Raises
         ------
         TypeError


### PR DESCRIPTION
## Summary

This PR specifies what items modals support in `Modal.add_item`.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
  - [ ] I have updated the documentation to reflect the changes.
  - [ ] I have run `task pyright` and fixed the relevant issues.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
