### PR TITLE
fix(guild): premium_progress_bar_enabled can be null

### DIFF
--- a/nextcord/guild.py
+++ b/nextcord/guild.py
@@ -516,7 +516,7 @@ class Guild(Hashable):
         for event in guild.get("guild_scheduled_events") or []:
             self._store_scheduled_event(event)
 
-        self._premium_progress_bar_enabled: bool = guild["premium_progress_bar_enabled"]
+        self._premium_progress_bar_enabled: Optional[bool] = guild.get("premium_progress_bar_enabled")
 
     # TODO: refactor/remove?
     def _sync(self, data: GuildPayload) -> None:
@@ -654,7 +654,7 @@ class Guild(Hashable):
         return list(self._scheduled_events.values())
 
     @property
-    def premium_progress_bar_enabled(self) -> bool:
+    def premium_progress_bar_enabled(self) -> Optional[bool]:
         """:class:`bool`: Whether the premium boost progress bar is enabled.
 
         .. versionadded:: 2.6

--- a/nextcord/guild.py
+++ b/nextcord/guild.py
@@ -657,7 +657,7 @@ class Guild(Hashable):
 
     @property
     def premium_progress_bar_enabled(self) -> Optional[bool]:
-        """:class:`bool`: Whether the premium boost progress bar is enabled.
+        """Optional[:class:`bool`:] Whether the premium boost progress bar is enabled.
 
         .. versionadded:: 2.6
         """

--- a/nextcord/guild.py
+++ b/nextcord/guild.py
@@ -516,7 +516,9 @@ class Guild(Hashable):
         for event in guild.get("guild_scheduled_events") or []:
             self._store_scheduled_event(event)
 
-        self._premium_progress_bar_enabled: Optional[bool] = guild.get("premium_progress_bar_enabled")
+        self._premium_progress_bar_enabled: Optional[bool] = guild.get(
+            "premium_progress_bar_enabled"
+        )
 
     # TODO: refactor/remove?
     def _sync(self, data: GuildPayload) -> None:

--- a/nextcord/types/guild.py
+++ b/nextcord/types/guild.py
@@ -119,7 +119,7 @@ class Guild(_BaseGuildPreview):
     premium_subscription_count: NotRequired[int]
     max_video_channel_users: NotRequired[int]
     stickers: NotRequired[List[GuildSticker]]
-    premium_progress_bar_enabled: bool
+    premium_progress_bar_enabled: Optional[bool]
 
 
 class InviteGuild(Guild, total=False):


### PR DESCRIPTION
## Summary

The documentation specifies that this field will always be avaliable, but apparently not.
This PR no longer uses key access to get the field in case it happens to be null when there is an unavaliable guild payload.

Continuation of #1067

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
  - [ ] I have updated the documentation to reflect the changes.
  - [x] I have run `task pyright` and fixed the relevant issues.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
