### PR TITLE
refactor(flags)!: remove `ApplicationFlags.active`

### DIFF
--- a/nextcord/flags.py
+++ b/nextcord/flags.py
@@ -1289,11 +1289,3 @@ class ApplicationFlags(BaseFlags):
     def application_command_badge(self):
         """:class:`bool`: Returns ``True`` if the application has registered global application commands."""
         return 1 << 23
-
-    @flag_value
-    def active(self):
-        """:class:`bool`: Returns ``True`` if the application is considered active. This means that it has had any global command executed in the past 30 days.
-
-        .. versionadded:: 2.4
-        """
-        return 1 << 24


### PR DESCRIPTION
## Summary

Fixes nextcord#1037

This removes the `ApplicationFlags.active` flag. While this _is_ a breaking change, there is no reason for it to be in the lib at all because it never existed, as shown by [this comment](https://github.com/discord/discord-api-docs/pull/5620#issuecomment-1355412285).

The PR adding this, nextcord#897 was merged too early, so I assume that's why this existed in nextcord in the first place.

<!-- Link any issues if applicable.
Use keywords from https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests
-->

<!-- Uncomment based on the type of your changes below -->


## This is a **Code Change**

- [x] I have tested my changes.
- [ ] I have updated the documentation to reflect the changes.
- [x] I have run `task pyright` and fixed the relevant issues.
