### PR TITLE
docs: update `StickerType.standard`

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -2832,7 +2832,7 @@ of :class:`enum.Enum`.
 
     .. attribute:: standard
 
-        Represents a standard sticker that all Nitro users can use.
+        Represents a standard sticker.
 
     .. attribute:: guild
 


### PR DESCRIPTION
## Summary

- discord/discord-api-docs#6265

Standard stickers are free now, so the documentation must no longer specify that they are for Nitro users.

<!-- Link any issues if applicable.
Use keywords from https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests
-->

<!-- Uncomment based on the type of your changes below -->

<!--
## This is a **Code Change**

- [ ] I have tested my changes.
- [ ] I have updated the documentation to reflect the changes.
- [ ] I have run `task pyright` and fixed the relevant issues.
--->
