### PR TITLE
feat: default checks in check_any decorator

### DIFF
--- a/nextcord/types/checks.py
+++ b/nextcord/types/checks.py
@@ -15,6 +15,19 @@ if TYPE_CHECKING:
     ApplicationCheck = Union[
         Callable[[ClientCog, Interaction], MaybeCoro[bool]],
         Callable[[Interaction], MaybeCoro[bool]],
+    
+        Callable[
+            [
+                Union[
+                    CoroFunc,
+                    Callable[[Interaction], bool],
+                    BaseApplicationCommand,
+                    SlashApplicationSubcommand,
+                ]
+            ],
+            CheckWrapper,
+        ]
+    
     ]
     ApplicationHook = Union[
         Callable[[ClientCog, Interaction], Coro[Any]], Callable[[Interaction], Coro[Any]]

--- a/nextcord/types/checks.py
+++ b/nextcord/types/checks.py
@@ -5,12 +5,11 @@ from typing import TYPE_CHECKING, Any, Callable, Coroutine, TypeVar, Union
 if TYPE_CHECKING:
     from nextcord.application_command import (
         BaseApplicationCommand,
-        CallbackWrapper,
+        ClientCog,
         SlashApplicationSubcommand,
-        ClientCog
     )
-    from ..ext.application_checks.core import CheckWrapper
 
+    from ..ext.application_checks.core import CheckWrapper
     from ..interactions import Interaction
 
     T = TypeVar("T")

--- a/nextcord/types/checks.py
+++ b/nextcord/types/checks.py
@@ -15,7 +15,6 @@ if TYPE_CHECKING:
     ApplicationCheck = Union[
         Callable[[ClientCog, Interaction], MaybeCoro[bool]],
         Callable[[Interaction], MaybeCoro[bool]],
-    
         Callable[
             [
                 Union[
@@ -26,8 +25,7 @@ if TYPE_CHECKING:
                 ]
             ],
             CheckWrapper,
-        ]
-    
+        ],
     ]
     ApplicationHook = Union[
         Callable[[ClientCog, Interaction], Coro[Any]], Callable[[Interaction], Coro[Any]]

--- a/nextcord/types/checks.py
+++ b/nextcord/types/checks.py
@@ -3,7 +3,13 @@
 from typing import TYPE_CHECKING, Any, Callable, Coroutine, TypeVar, Union
 
 if TYPE_CHECKING:
-    from nextcord.application_command import ClientCog
+    from nextcord.application_command import (
+        BaseApplicationCommand,
+        CallbackWrapper,
+        SlashApplicationSubcommand,
+        ClientCog
+    )
+    from ..ext.application_checks.core import CheckWrapper
 
     from ..interactions import Interaction
 
@@ -12,6 +18,7 @@ if TYPE_CHECKING:
     Coro = Coroutine[Any, Any, T]
     MaybeCoro = Union[T, Coro[T]]
     CoroFunc = Callable[..., Coro[Any]]
+
     ApplicationCheck = Union[
         Callable[[ClientCog, Interaction], MaybeCoro[bool]],
         Callable[[Interaction], MaybeCoro[bool]],


### PR DESCRIPTION
## Summary

Pull request adds ability to provide [default checks](https://github.com/nextcord/nextcord/blob/master/nextcord/ext/application_checks/core.py#L79-L89) to `check_any`  and `check` decorators. For example:
```py
from nextcord.ext.application_checks import check_any, has_permissions

@slash_command(name="command")
@check_any(has_permissions(manage_messages=True), some_user_check())
async def command_callback(self, interaction: Inter):
    ...
```

## This is a **Code Change**

- [x] I have tested my changes.
- [ ] I have updated the documentation to reflect the changes.
- [ ] I have run `task pyright` and fixed the relevant issues.
