### PR TITLE
feat(iterators): add `GuildIterator.with_counts`

### DIFF
--- a/nextcord/client.py
+++ b/nextcord/client.py
@@ -1346,6 +1346,7 @@ class Client:
         self,
         *,
         limit: Optional[int] = 200,
+        with_counts: bool = False,
         before: Optional[SnowflakeTime] = None,
         after: Optional[SnowflakeTime] = None,
     ) -> GuildIterator:
@@ -1385,7 +1386,11 @@ class Client:
 
             .. versionchanged:: 2.0
                 Changed default to ``200``.
+        with_counts: :class:`bool`
+            Whether to include approximate member and presence counts for the guilds.
+            Defaults to ``False``.
 
+            .. versionadded:: 2.6
         before: Union[:class:`.abc.Snowflake`, :class:`datetime.datetime`]
             Retrieves guilds before this date or object.
             If a datetime is provided, it is recommended to use a UTC aware datetime.
@@ -1405,7 +1410,7 @@ class Client:
         :class:`.Guild`
             The guild with the guild data parsed.
         """
-        return GuildIterator(self, limit=limit, before=before, after=after)
+        return GuildIterator(self, limit=limit, before=before, after=after, with_counts=with_counts)
 
     async def fetch_template(self, code: Union[Template, str]) -> Template:
         """|coro|

--- a/nextcord/http.py
+++ b/nextcord/http.py
@@ -1343,7 +1343,7 @@ class HTTPClient:
         after: Optional[Snowflake] = None,
         with_counts: bool = False,
     ) -> Response[List[guild.Guild]]:
-        params: Dict[str, Any] = {"limit": limit, "with_counts": with_counts}
+        params: Dict[str, Any] = {"limit": limit, "with_counts": int(with_counts)}
 
         if before:
             params["before"] = before

--- a/nextcord/http.py
+++ b/nextcord/http.py
@@ -1341,10 +1341,9 @@ class HTTPClient:
         limit: int,
         before: Optional[Snowflake] = None,
         after: Optional[Snowflake] = None,
+        with_counts: bool = False,
     ) -> Response[List[guild.Guild]]:
-        params: Dict[str, Any] = {
-            "limit": limit,
-        }
+        params: Dict[str, Any] = {"limit": limit, "with_counts": with_counts}
 
         if before:
             params["before"] = before

--- a/nextcord/iterators.py
+++ b/nextcord/iterators.py
@@ -713,9 +713,7 @@ class GuildIterator(_AsyncIterator["Guild"]):
         """Retrieve guilds and update next parameters."""
         raise NotImplementedError
 
-    async def _retrieve_guilds_before_strategy(
-        self, retrieve: int
-    ) -> List[GuildPayload]:
+    async def _retrieve_guilds_before_strategy(self, retrieve: int) -> List[GuildPayload]:
         """Retrieve guilds using before parameter."""
         before = self.before.id if self.before else None
         data: List[GuildPayload] = await self.bot.http.get_guilds(
@@ -727,9 +725,7 @@ class GuildIterator(_AsyncIterator["Guild"]):
             self.before = Object(id=int(data[0]["id"]))
         return data
 
-    async def _retrieve_guilds_after_strategy(
-        self, retrieve: int
-    ) -> List[GuildPayload]:
+    async def _retrieve_guilds_after_strategy(self, retrieve: int) -> List[GuildPayload]:
         """Retrieve guilds using after parameter."""
         after = self.after.id if self.after else None
         data: List[GuildPayload] = await self.bot.http.get_guilds(

--- a/nextcord/iterators.py
+++ b/nextcord/iterators.py
@@ -714,12 +714,12 @@ class GuildIterator(_AsyncIterator["Guild"]):
         raise NotImplementedError
 
     async def _retrieve_guilds_before_strategy(
-        self, retrieve: int, with_counts: bool = False
+        self, retrieve: int
     ) -> List[GuildPayload]:
         """Retrieve guilds using before parameter."""
         before = self.before.id if self.before else None
         data: List[GuildPayload] = await self.bot.http.get_guilds(
-            retrieve, before=before, with_counts=with_counts
+            retrieve, before=before, with_counts=self.with_counts
         )
         if len(data):
             if self.limit is not None:
@@ -728,12 +728,12 @@ class GuildIterator(_AsyncIterator["Guild"]):
         return data
 
     async def _retrieve_guilds_after_strategy(
-        self, retrieve: int, with_counts: bool = False
+        self, retrieve: int
     ) -> List[GuildPayload]:
         """Retrieve guilds using after parameter."""
         after = self.after.id if self.after else None
         data: List[GuildPayload] = await self.bot.http.get_guilds(
-            retrieve, after=after, with_counts=with_counts
+            retrieve, after=after, with_counts=self.with_counts
         )
         if len(data):
             if self.limit is not None:

--- a/nextcord/iterators.py
+++ b/nextcord/iterators.py
@@ -728,12 +728,12 @@ class GuildIterator(_AsyncIterator["Guild"]):
         return data
 
     async def _retrieve_guilds_after_strategy(
-        self, retrieve: int, with_guilds: bool = False
+        self, retrieve: int, with_counts: bool = False
     ) -> List[GuildPayload]:
         """Retrieve guilds using after parameter."""
         after = self.after.id if self.after else None
         data: List[GuildPayload] = await self.bot.http.get_guilds(
-            retrieve, after=after, with_guilds=with_guilds
+            retrieve, after=after, with_counts=with_counts
         )
         if len(data):
             if self.limit is not None:

--- a/nextcord/iterators.py
+++ b/nextcord/iterators.py
@@ -627,7 +627,7 @@ class GuildIterator(_AsyncIterator["Guild"]):
         Maximum number of guilds to retrieve.
     with_counts: :class:`bool`
         Whether to include approximate member and presence counts for the guilds.
-        Defaults to ``True``.
+        Defaults to ``False``.
 
         .. versionadded:: 2.6
     before: Optional[Union[:class:`abc.Snowflake`, :class:`datetime.datetime`]]


### PR DESCRIPTION
## Summary

Implements discord/discord-api-docs#5628

In case you're wondering, "why is the default for `with_counts` `False`?"
Well that is because the default on the documentation `false`, so just for the sake of consistency, that is why the default is `False`.

## This is a **Code Change**

- [ ] I have tested my changes.
- [x] I have updated the documentation to reflect the changes.
- [x] I have run `task pyright` and fixed the relevant issues.
