### PR TITLE
refactor(user): use key access for `BaseUser.discriminator` 

### DIFF
--- a/nextcord/user.py
+++ b/nextcord/user.py
@@ -92,7 +92,7 @@ class BaseUser(_UserTag):
     def _update(self, data: Union[PartialUserPayload, UserPayload]) -> None:
         self.name = data["username"]
         self.id = int(data["id"])
-        self.discriminator = data.get("discriminator")
+        self.discriminator = data["discriminator"]
         self._avatar = data["avatar"]
         self._banner = data.get("banner", None)
         self._accent_colour = data.get("accent_color", None)


### PR DESCRIPTION
## Summary

This makes `BaseUser.discriminator` use key access instead of `.get`.

The issue was initially caused by #1061 where at first I had planned for the discriminator to be None, but forgot it would be a breaking change.

## This is a **Code Change**

- [x] I have tested my changes.
- [ ] I have updated the documentation to reflect the changes.
- [x] I have run `task pyright` and fixed the relevant issues.
