### PR TITLE
docs: Fix docstring in add_cog

### DIFF
--- a/nextcord/ext/commands/bot.py
+++ b/nextcord/ext/commands/bot.py
@@ -599,7 +599,7 @@ class BotBase(GroupMixin):
             The cog does not inherit from :class:`.Cog`.
         CommandError
             An error happened during loading.
-        .ClientException
+        ClientException
             A cog with the same name is already loaded.
         """
 


### PR DESCRIPTION
## Summary
Looks like there is an extra dot(.) inside `BotBase.add_cog` docstring 

## This is a **Code Change**

- [x] I have updated the documentation to reflect the changes.
