### PR TITLE
fix: menu assigning failing due to read only attributes

### DIFF
--- a/nextcord/application_command.py
+++ b/nextcord/application_command.py
@@ -1706,11 +1706,10 @@ class SlashCommandMixin(CallbackMixin):
         command_ids: Dict[Optional[int], int]
         qualified_name: str
         _children: Dict[str, SlashApplicationSubcommand]
-        _options: Dict[str, SlashCommandOption]
 
     def __init__(self, callback: Optional[Callable], parent_cog: Optional[ClientCog]) -> None:
         CallbackMixin.__init__(self, callback=callback, parent_cog=parent_cog)
-        self._options = {}
+        self.options = {}
         self._parsed_docstring: Optional[Dict[str, Any]] = None
         self._children: Dict[str, SlashApplicationSubcommand] = {}
 
@@ -1722,15 +1721,6 @@ class SlashCommandMixin(CallbackMixin):
             ``.children`` is now a read-only property.
         """
         return self._children
-
-    @property
-    def options(self) -> Dict[str, SlashCommandOption]:
-        """Dict[:class:`str`, :class:`SlashCommandOption`]: Returns the options of the command.
-
-        .. versionchanged:: 2.5
-            This is now a read-only property.
-        """
-        return self._options
 
     @property
     def description(self) -> str:
@@ -1769,11 +1759,11 @@ class SlashCommandMixin(CallbackMixin):
                 raise ValueError("Discord did not provide us any options data")
 
         kwargs = {}
-        uncalled_args = self._options.copy()
+        uncalled_args = self.options.copy()
         for arg_data in option_data:
             if arg_data["name"] in uncalled_args:
                 uncalled_args.pop(arg_data["name"])
-                kwargs[self.options[arg_data["name"]].functional_name] = await self._options[
+                kwargs[self.options[arg_data["name"]].functional_name] = await self.options[
                     arg_data["name"]
                 ].handle_value(state, arg_data.get("value"), interaction)
             else:
@@ -1942,7 +1932,7 @@ class BaseApplicationCommand(CallbackMixin, CallbackWrapperMixin):
         Dict[Optional[:class:`int`], :class:`int`]:
             Command IDs that this application command currently has. Schema: {Guild ID (None for global): command ID}
         """
-        self._options: Dict[str, ApplicationCommandOption] = {}
+        self.options: Dict[str, ApplicationCommandOption] = {}
 
     # Simple-ish getter + setter methods.
 

--- a/nextcord/components.py
+++ b/nextcord/components.py
@@ -106,7 +106,7 @@ class ActionRow(Component):
         The children components that this holds, if any.
     """
 
-    __slots__: Tuple[str, ...] = ("children",)
+    __slots__: Tuple[str, ...] = ("type", "children")
 
     __repr_info__: ClassVar[Tuple[str, ...]] = __slots__
 
@@ -151,6 +151,7 @@ class Button(Component):
     """
 
     __slots__: Tuple[str, ...] = (
+        "type",
         "style",
         "custom_id",
         "url",
@@ -589,6 +590,7 @@ class SelectOption:
 
 class TextInput(Component):
     __slots__: Tuple[str, ...] = (
+        "type",
         "style",
         "custom_id",
         "label",

--- a/nextcord/components.py
+++ b/nextcord/components.py
@@ -64,7 +64,7 @@ class Component:
         The type of component.
     """
 
-    __slots__: Tuple[str, ...] = ("type",)
+    __slots__: Tuple[str, ...] = ()
 
     __repr_info__: ClassVar[Tuple[str, ...]]
     type: ComponentType
@@ -77,10 +77,6 @@ class Component:
     def _raw_construct(cls, **kwargs) -> Self:
         self = cls.__new__(cls)
         for slot in get_slots(cls):
-            if slot == "type" and getattr(self, slot, None) is not None:
-                # nextcord/issues/1103
-                continue
-
             try:
                 value = kwargs[slot]
             except KeyError:

--- a/nextcord/components.py
+++ b/nextcord/components.py
@@ -77,7 +77,7 @@ class Component:
     def _raw_construct(cls, **kwargs) -> Self:
         self = cls.__new__(cls)
         for slot in get_slots(cls):
-            if slot == "type" and getattr(self, slot) is not None:
+            if slot == "type" and getattr(self, slot, None) is not None:
                 # nextcord/issues/1103
                 continue
 

--- a/nextcord/components.py
+++ b/nextcord/components.py
@@ -77,7 +77,7 @@ class Component:
     def _raw_construct(cls, **kwargs) -> Self:
         self = cls.__new__(cls)
         for slot in get_slots(cls):
-            if slot == "type":
+            if slot == "type" and getattr(self, slot) is not None:
                 # nextcord/issues/1103
                 continue
 

--- a/nextcord/components.py
+++ b/nextcord/components.py
@@ -77,6 +77,10 @@ class Component:
     def _raw_construct(cls, **kwargs) -> Self:
         self = cls.__new__(cls)
         for slot in get_slots(cls):
+            if slot == "type":
+                # nextcord/issues/1103
+                continue
+
             try:
                 value = kwargs[slot]
             except KeyError:


### PR DESCRIPTION
## Summary

<!-- What is this pull request for? Does it fix any issues? -->
Types are now hard coded onto menus and are also read only, this resolves an issue where the underlying constructor would try to override that attribute resulting in an error

<!-- Link any issues if applicable.
Use keywords from https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests
-->
Closes #1103 

<!-- Uncomment based on the type of your changes below -->

<!--
## This is a **Code Change**

- [X] I have tested my changes.
- [ ] I have updated the documentation to reflect the changes.
- [X] I have run `task pyright` and fixed the relevant issues.
