### PR TITLE
fix(scheduled-events): sort out optionals and nullables

### DIFF
--- a/nextcord/scheduled_events.py
+++ b/nextcord/scheduled_events.py
@@ -218,13 +218,13 @@ class ScheduledEvent(Hashable):
         else:
             self.creator: Optional[User] = None
         self.name: str = data["name"]
-        self.description: str = data.get("description", "")
+        self.description: str = data.get("description") or ""
         self.start_time: datetime = parse_time(data["scheduled_start_time"])
         self.end_time: Optional[datetime] = parse_time(data.get("scheduled_end_time"))
         self.privacy_level: ScheduledEventPrivacyLevel = ScheduledEventPrivacyLevel(
             data["privacy_level"]
         )
-        self.metadata: EntityMetadata = EntityMetadata(**data.get("entity_metadata", {}))
+        self.metadata: EntityMetadata = EntityMetadata(**(data["entity_metadata"] or {}))
         self.user_count: int = data.get("user_count", 0)
         self.channel: Optional[GuildChannel] = self._state.get_channel(  # type: ignore # who knows
             int(data.get("channel_id") or 0)

--- a/nextcord/types/scheduled_events.py
+++ b/nextcord/types/scheduled_events.py
@@ -1,6 +1,8 @@
 # SPDX-License-Identifier: MIT
 
-from typing import Literal, TypedDict
+from typing import Literal, Optional, TypedDict
+
+from typing_extensions import NotRequired
 
 from .member import Member
 from .snowflake import Snowflake
@@ -18,19 +20,20 @@ class EntityMetadata(TypedDict, total=False):
 class ScheduledEvent(TypedDict):
     id: Snowflake
     guild_id: Snowflake
-    channel_id: Snowflake
+    channel_id: Optional[Snowflake]
+    creator_id: NotRequired[int]
     name: str
-    description: str
+    description: NotRequired[Optional[str]]
     scheduled_start_time: str
-    scheduled_end_time: str
+    scheduled_end_time: Optional[str]
     privacy_level: ScheduledEventPrivacyLevel
     status: ScheduledEventStatus
     entity_type: ScheduledEventEntityType
-    entity_id: Snowflake
-    entity_metadata: EntityMetadata
-    creator: User
-    user_count: int
-    image: str
+    entity_id: Optional[Snowflake]
+    entity_metadata: Optional[EntityMetadata]
+    creator: NotRequired[User]
+    user_count: NotRequired[int]
+    image: NotRequired[Optional[str]]
 
 
 class ScheduledEventUser(TypedDict):


### PR DESCRIPTION
## Summary

[Docs](https://discord.com/developers/docs/resources/guild-scheduled-event#guild-scheduled-event-object)
it seems like the `TypedDict` and docs were mismatched, causing `TypeError: nextcord.scheduled_events.EntityMetadata() argument after ** must be a mapping, not NoneType`

<!-- What is this pull request for? Does it fix any issues? -->

<!-- Link any issues if applicable.
Use keywords from https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests
-->

<!-- Uncomment based on the type of your changes below -->

## This is a **Code Change**

- [x] I have tested my changes.
- [x] I have updated the documentation to reflect the changes.
- [x] I have run `task pyright` and fixed the relevant issues.
