### PR TITLE
docs: fix build warnings

### DIFF
--- a/nextcord/ui/select/mentionable.py
+++ b/nextcord/ui/select/mentionable.py
@@ -39,7 +39,7 @@ class MentionableSelectValues(SelectValuesBase):
 
     @property
     def users(self) -> List[User]:
-        """List[:class:`.User`]: A list of users that were selected."""
+        """List[:class:`nextcord.User`]: A list of users that were selected."""
         return [v for v in self.data if isinstance(v, User)]
 
     @property
@@ -119,7 +119,7 @@ class MentionableSelect(SelectBase, Generic[V]):
 
     @property
     def values(self) -> MentionableSelectValues:
-        """:class:`.ui.MentionableSelectValues`: A list of Union[:class:`.Member`, :class:`.User`, :class:`.Role`] that have been selected by the user."""
+        """:class:`.ui.MentionableSelectValues`: A list of Union[:class:`.Member`, :class:`nextcord.User`, :class:`.Role`] that have been selected by the user."""
         return self._selected_values
 
     def to_component_dict(self) -> MentionableSelectMenuPayload:

--- a/nextcord/ui/select/user.py
+++ b/nextcord/ui/select/user.py
@@ -38,7 +38,7 @@ class UserSelectValues(SelectValuesBase):
 
     @property
     def users(self) -> List[User]:
-        """List[:class:`.User`]: A list of users that were selected."""
+        """List[:class:`nextcord.User`]: A list of users that were selected."""
         return [v for v in self.data if isinstance(v, User)]
 
 
@@ -111,7 +111,7 @@ class UserSelect(SelectBase, Generic[V]):
 
     @property
     def values(self) -> UserSelectValues:
-        """:class:`.ui.UserSelectValues`: A list of Union[:class:`.Member`, :class:`.User`] that have been selected by the user."""
+        """:class:`.ui.UserSelectValues`: A list of Union[:class:`.Member`, :class:`nextcord.User`] that have been selected by the user."""
         return self._selected_values
 
     def to_component_dict(self) -> UserSelectMenuPayload:


### PR DESCRIPTION
## Summary

For some time now, whenever building the documentation, you would get these warnings:
```
<path>/nextcord/nextcord/ui/select/user.py:docstring of nextcord.ui.UserSelect.values:1: WARNING: 
more than one target found for cross-reference 'User': nextcord.abc.User, nextcord.User, nextcord.user.User
<path>/nextcord/nextcord/ui/select/user.py:docstring of nextcord.ui.UserSelectValues.users:3: WARNING: 
more than one target found for cross-reference 'User': nextcord.abc.User, nextcord.User, nextcord.user.User
<path>/nextcord/nextcord/ui/select/mentionable.py:docstring of nextcord.ui.MentionableSelect.values:1: WARNING: 
more than one target found for cross-reference 'User': nextcord.abc.User, nextcord.User, nextcord.user.User
<path>/nextcord/nextcord/ui/select/mentionable.py:docstring of nextcord.ui.MentionableSelectValues.users:3: WARNING: 
more than one target found for cross-reference 'User': nextcord.abc.User, nextcord.User, nextcord.user.User
```

This PR resolves these warnings by specifying what `User` class is being referred.

<!-- Link any issues if applicable.
Use keywords from https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests
-->

<!-- Uncomment based on the type of your changes below -->

<!--
## This is a **Code Change**

- [ ] I have tested my changes.
- [ ] I have updated the documentation to reflect the changes.
- [ ] I have run `task pyright` and fixed the relevant issues.
