### PR TITLE
fix: make `state` fallback to `name`  for CustomActivity

### DIFF
--- a/nextcord/activity.py
+++ b/nextcord/activity.py
@@ -735,6 +735,11 @@ class CustomActivity(BaseActivity):
         The custom activity's name.
     emoji: Optional[:class:`PartialEmoji`]
         The emoji to pass to the activity, if any.
+    state: Optional[:class:`str`]
+        The custom status text. :attr:`~.CustomActivity.name` must equal to "Custom Status" for this to work.
+
+        .. versionchanged:: 2.6
+            Fallsback to :attr:`~.CustomActivity.name` if not provided.
     """
 
     __slots__ = ("name", "emoji", "state", "_state")
@@ -750,7 +755,7 @@ class CustomActivity(BaseActivity):
         super().__init__(**extra)
         self._state = _connection_state
         self.name: Optional[str] = name
-        self.state: Optional[str] = extra.pop("state", None)
+        self.state: Optional[str] = extra.pop("state", name)
         if self.name == "Custom Status":
             self.name = self.state
 

--- a/nextcord/activity.py
+++ b/nextcord/activity.py
@@ -736,7 +736,7 @@ class CustomActivity(BaseActivity):
     emoji: Optional[:class:`PartialEmoji`]
         The emoji to pass to the activity, if any.
     state: Optional[:class:`str`]
-        The custom status text. :attr:`~.CustomActivity.name` must equal to "Custom Status" for this to work.
+        The custom status text. :attr:`~.CustomActivity.name` must equal "Custom Status" for this to work.
 
         .. versionchanged:: 2.6
             Fallsback to :attr:`~.CustomActivity.name` if not provided.

--- a/nextcord/activity.py
+++ b/nextcord/activity.py
@@ -739,7 +739,7 @@ class CustomActivity(BaseActivity):
         The custom status text. :attr:`~.CustomActivity.name` must equal "Custom Status" for this to work.
 
         .. versionchanged:: 2.6
-            Fallsback to :attr:`~.CustomActivity.name` if not provided.
+            This falls back to :attr:`~.CustomActivity.name` if not provided.
     """
 
     __slots__ = ("name", "emoji", "state", "_state")


### PR DESCRIPTION
## Summary

This PR documents the `state` attribute on `CustomActivity` and makes it fallbacks to `name` instead of `None` if not provided.

This allows users to do the following:
```py
nextcord.CustomActivity(
  name = "Nextcord is the best!"
)  
```
Instead of:
```py
nextcord.CustomActivity(
  name = "Custom Status",
  state = "Nextcord is the best!"
)
# this still works tho.
```

## This is a **Code Change**

- [x] I have tested my changes.
- [x] I have updated the documentation to reflect the changes.
- [x] I have run `task pyright` and fixed the relevant issues.
