### PR TITLE
refactor: remove _modify_api_version

### DIFF
--- a/nextcord/http.py
+++ b/nextcord/http.py
@@ -98,38 +98,6 @@ _DEFAULT_API_VERSION = 10
 _API_VERSION: Literal[9, 10] = _DEFAULT_API_VERSION
 
 
-class UnsupportedAPIVersion(UserWarning):
-    """Warning category raised when changing the API version to an unsupported version."""
-
-
-def _modify_api_version(version: Literal[9, 10]):
-    """Modify the API version used by the HTTP client.
-
-    Additional versions may be added around the time of a Discord API
-    version bump to allow temporarily downgrading to an older API version
-    or upgrading to a newer version that is not yet supported by the library.
-
-    Changing the API version from the default is not supported and may result in
-    unexpected behaviour.
-    """
-    available_versions = (9, 10)
-
-    if version not in available_versions:
-        raise ValueError(f"Only API versions {available_versions} are available.")
-
-    if version != _DEFAULT_API_VERSION:
-        warnings.warn(
-            "Changing the API version is not supported and may result in unexpected behaviour.",
-            category=UnsupportedAPIVersion,
-            stacklevel=2,
-        )
-
-    global _API_VERSION
-    _API_VERSION = version
-
-    Route.BASE = f"https://discord.com/api/v{version}"
-
-
 class Route:
     BASE: ClassVar[str] = f"https://discord.com/api/v{_DEFAULT_API_VERSION}"
 

--- a/nextcord/http.py
+++ b/nextcord/http.py
@@ -94,11 +94,11 @@ async def json_or_text(response: aiohttp.ClientResponse) -> Union[Dict[str, Any]
 
 _DEFAULT_API_VERSION = 10
 
-_API_VERSION: Literal[9, 10] = _DEFAULT_API_VERSION
+_API_VERSION: Literal[10] = _DEFAULT_API_VERSION
 
 
 class Route:
-    BASE: ClassVar[str] = f"https://discord.com/api/v{_DEFAULT_API_VERSION}"
+    BASE: ClassVar[str] = f"https://discord.com/api/v{_API_VERSION}"
 
     def __init__(self, method: str, path: str, **parameters: Any) -> None:
         self.path: str = path

--- a/nextcord/http.py
+++ b/nextcord/http.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import asyncio
 import logging
 import sys
-import warnings
 import weakref
 from typing import (
     TYPE_CHECKING,


### PR DESCRIPTION
## Summary

This PR removes `http._modify_api_version`. It was a temporary workaround in the past around the message content intent changes that were made in API v10. Nowadays, it has no use and it's not recommended to use it, according to its own documentation.

<!-- Link any issues if applicable.
Use keywords from https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests
-->

<!-- Uncomment based on the type of your changes below -->

<!--
## This is a **Code Change**

- [ ] I have tested my changes.
- [ ] I have updated the documentation to reflect the changes.
- [ ] I have run `task pyright` and fixed the relevant issues.
