### PR TITLE
feat(User & Member): update display_name method to include global_name

### DIFF
--- a/nextcord/member.py
+++ b/nextcord/member.py
@@ -505,11 +505,14 @@ class Member(abc.Messageable, _UserTag):
     def display_name(self) -> str:
         """:class:`str`: Returns the user's display name.
 
-        For regular users this is just their username, but
-        if they have a guild specific nickname then that
-        is returned instead.
+        Returns the users displayed name.
+        So whatever is the first thing to exist from the following priority list:
+
+        1. Guild specific nickname
+        2. Global Name (also known as 'Display Name' in the Discord UI)
+        3. Unique username
         """
-        return self.nick or self.name
+        return self.nick or self.global_name or self.name
 
     @property
     def display_avatar(self) -> Asset:

--- a/nextcord/member.py
+++ b/nextcord/member.py
@@ -506,7 +506,7 @@ class Member(abc.Messageable, _UserTag):
         """:class:`str`: Returns the user's display name.
 
         Returns the users displayed name.
-        So whatever is the first thing to exist from the following priority list:
+        This will return the name using the following hierachy:
 
         1. Guild specific nickname
         2. Global Name (also known as 'Display Name' in the Discord UI)

--- a/nextcord/member.py
+++ b/nextcord/member.py
@@ -505,7 +505,6 @@ class Member(abc.Messageable, _UserTag):
     def display_name(self) -> str:
         """:class:`str`: Returns the user's display name.
 
-        Returns the users displayed name.
         This will return the name using the following hierachy:
 
         1. Guild specific nickname

--- a/nextcord/user.py
+++ b/nextcord/user.py
@@ -247,12 +247,10 @@ class BaseUser(_UserTag):
     def display_name(self) -> str:
         """:class:`str`: Returns the user's display name.
 
-        Returns the users displayed name.
         This will return the name using the following hierachy:
 
-        1. Guild specific nickname
-        2. Global Name (also known as 'Display Name' in the Discord UI)
-        3. Unique username
+        1. Global Name (also known as 'Display Name' in the Discord UI)
+        2. Unique username
         """
         return self.global_name or self.name
 

--- a/nextcord/user.py
+++ b/nextcord/user.py
@@ -248,7 +248,7 @@ class BaseUser(_UserTag):
         """:class:`str`: Returns the user's display name.
 
         Returns the users displayed name.
-        So whatever is the first thing to exist from the following priority list:
+        This will return the name using the following hierachy:
 
         1. Guild specific nickname
         2. Global Name (also known as 'Display Name' in the Discord UI)

--- a/nextcord/user.py
+++ b/nextcord/user.py
@@ -247,11 +247,14 @@ class BaseUser(_UserTag):
     def display_name(self) -> str:
         """:class:`str`: Returns the user's display name.
 
-        For regular users this is just their username, but
-        if they have a guild specific nickname then that
-        is returned instead.
+        Returns the users displayed name.
+        So whatever is the first thing to exist from the following priority list:
+
+        1. Guild specific nickname
+        2. Global Name (also known as 'Display Name' in the Discord UI)
+        3. Unique username
         """
-        return self.name
+        return self.global_name or self.name
 
     def mentioned_in(self, message: Message) -> bool:
         """Checks if the user is mentioned in the specified message.


### PR DESCRIPTION
## Summary

Without this change the display_name property returns a nickname if present, if not just the username (which is the hidden away username). It doesn't consider the "Display Name" also known as global_name at all.

In my opinion, that is bad behavior, because the global_name takes priority in the Discord UI over the username if it exists, so it should here as well. After all, when people use this property, they want the name the person is displayed as, not the hidden away unique username.

## This is a **Code Change**

- [x] I have tested my changes.
- [x] I have updated the documentation to reflect the changes.
- [x] I have run `task pyright` and fixed the relevant issues.
