### PR TITLE
refactor(health_check): replace pkg_resources with importlib.metadata

### DIFF
--- a/nextcord/health_check.py
+++ b/nextcord/health_check.py
@@ -1,8 +1,7 @@
 # SPDX-License-Identifier: MIT
 
+from importlib.metadata import PackageNotFoundError, metadata
 from warnings import warn
-
-from pkg_resources import DistributionNotFound, get_distribution
 
 __all__ = ("incompatible_libraries",)
 
@@ -15,7 +14,7 @@ incompatible_libraries = ["discord.py", "discord", "pyfork", "enhanced-dpy", "py
 
 for library in incompatible_libraries:
     try:
-        get_distribution(library)
+        metadata(library)
         # Library is installed. Throw a warning
         message = (
             f"{library} is installed which is incompatible with nextcord. "
@@ -23,5 +22,5 @@ for library in incompatible_libraries:
         )
 
         warn(message, DistributionWarning, stacklevel=0)
-    except DistributionNotFound:
+    except PackageNotFoundError:
         pass


### PR DESCRIPTION
## Summary
`pkg_resources` is deprecated and emits a warning when used. Replace it with `importlib.metadata`.
https://docs.python.org/3/library/importlib.metadata.html

```
/.../nextcord/health_check.py:1: DeprecationWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html
    from pkg_resources import get_distribution, DistributionNotFound
```