### PR TITLE
removal!: deprecations from 2.0

### DIFF
--- a/nextcord/application_command.py
+++ b/nextcord/application_command.py
@@ -2527,33 +2527,6 @@ class BaseApplicationCommand(CallbackMixin, CallbackWrapperMixin):
         """
         raise NotImplementedError
 
-    def check_against_raw_payload(
-        self, raw_payload: ApplicationCommandPayload, guild_id: Optional[int] = None
-    ) -> bool:
-        warnings.warn(
-            ".check_against_raw_payload() is deprecated, please use .is_payload_valid instead.",
-            stacklevel=2,
-            category=FutureWarning,
-        )
-        return self.is_payload_valid(raw_payload, guild_id)
-
-    def get_guild_payload(self, guild_id: int):
-        warnings.warn(
-            ".get_guild_payload is deprecated, use .get_payload(guild_id) instead.",
-            stacklevel=2,
-            category=FutureWarning,
-        )
-        return self.get_payload(guild_id)
-
-    @property
-    def global_payload(self) -> dict:
-        warnings.warn(
-            ".global_payload is deprecated, use .get_payload(None) instead.",
-            stacklevel=2,
-            category=FutureWarning,
-        )
-        return self.get_payload(None)
-
 
 class SlashApplicationSubcommand(SlashCommandMixin, AutocompleteCommandMixin, CallbackWrapperMixin):
     """Class representing a subcommand or subcommand group of a slash command."""

--- a/nextcord/client.py
+++ b/nextcord/client.py
@@ -7,7 +7,6 @@ import logging
 import signal
 import sys
 import traceback
-import warnings
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -2035,19 +2034,6 @@ class Client:
         """
         return self._connection.all_views()
 
-    @property
-    def persistent_views(self) -> List[View]:
-        """List[:class:`.View`]: A sequence of persistent views added to the client.
-
-        .. versionadded:: 2.0
-        """
-        warnings.warn(
-            ".persistent_views is deprecated, use .views instead.",
-            stacklevel=2,
-            category=FutureWarning,
-        )
-        return self.views()
-
     def views(self, *, persistent: bool = True) -> List[View]:
         """Returns all persistent or non-persistent views.
 
@@ -2325,6 +2311,11 @@ class Client:
         Syncs the locally added application commands with the Guild corresponding to the given ID, or syncs
         global commands if the guild_id is ``None``.
 
+        .. versionchanged:: 3.0
+            This replaces the now removed ``delete_unknown_application_commands``, 
+            ``associate_application_commands``, ``update_application_commands``, and ``rollout_application_commands``
+            methods.
+
         Parameters
         ----------
         data: Optional[List[:class:`dict`]]
@@ -2371,6 +2362,9 @@ class Client:
 
         Running this for global or the same guild multiple times at once may cause unexpected or unstable behavior.
 
+        .. versionchanged:: 3.0
+            This replaces the now removed ``deploy_application_commands`` method.
+
         Parameters
         ----------
         data: Optional[List[:class:`dict`]]
@@ -2396,64 +2390,6 @@ class Client:
             delete_unknown=delete_unknown,
             update_known=update_known,
         )
-
-    async def deploy_application_commands(
-        self,
-        data: Optional[List[ApplicationCommandPayload]] = None,
-        *,
-        guild_id: Optional[int] = None,
-        associate_known: bool = True,
-        delete_unknown: bool = True,
-        update_known: bool = True,
-    ) -> None:
-        warnings.warn(
-            ".deploy_application_commands is deprecated, use .discover_application_commands instead.",
-            stacklevel=2,
-            category=FutureWarning,
-        )
-        await self.discover_application_commands(
-            data=data,
-            guild_id=guild_id,
-            associate_known=associate_known,
-            delete_unknown=delete_unknown,
-            update_known=update_known,
-        )
-
-    async def delete_unknown_application_commands(
-        self, data: Optional[List[ApplicationCommandPayload]] = None
-    ) -> None:
-        """Deletes unknown global commands."""
-        warnings.warn(
-            ".delete_unknown_application_commands is deprecated, use .sync_application_commands and set "
-            "kwargs in it instead.",
-            stacklevel=2,
-            category=FutureWarning,
-        )
-        await self._connection.delete_unknown_application_commands(data=data, guild_id=None)
-
-    async def associate_application_commands(
-        self, data: Optional[List[ApplicationCommandPayload]] = None
-    ) -> None:
-        """Associates global commands registered with Discord with locally added commands."""
-        warnings.warn(
-            ".associate_application_commands is deprecated, use .sync_application_commands and set "
-            "kwargs in it instead.",
-            stacklevel=2,
-            category=FutureWarning,
-        )
-        await self._connection.associate_application_commands(data=data, guild_id=None)
-
-    async def update_application_commands(
-        self, data: Optional[List[ApplicationCommandPayload]] = None
-    ) -> None:
-        """Updates global commands that have slightly changed with Discord."""
-        warnings.warn(
-            ".update_application_commands is deprecated, use .sync_application_commands and set "
-            "kwargs in it instead.",
-            stacklevel=2,
-            category=FutureWarning,
-        )
-        await self._connection.update_application_commands(data=data, guild_id=None)
 
     async def register_new_application_commands(
         self, data: Optional[List[ApplicationCommandPayload]] = None, guild_id: Optional[int] = None
@@ -2546,16 +2482,9 @@ class Client:
         This does not register commands with Discord. If you want that, use
         :meth:`~Client.sync_all_application_commands` instead.
 
+        .. versionchanged:: 3.0
+            This replaces the now removed ``add_startup_application_commands`` method.
         """
-        self._add_decorated_application_commands()
-        self.add_all_cog_commands()
-
-    def add_startup_application_commands(self) -> None:
-        warnings.warn(
-            ".add_startup_application_commands is deprecated, use .add_all_application_commands instead.",
-            stacklevel=2,
-            category=FutureWarning,
-        )
         self._add_decorated_application_commands()
         self.add_all_cog_commands()
 
@@ -2584,30 +2513,6 @@ class Client:
                 f"nextcord.Client: Forbidden error for {guild.name}|{guild.id}, is the commands Oauth scope "
                 f"enabled? {e}"
             )
-
-    async def rollout_application_commands(self) -> None:
-        """|coro|
-        Deploys global application commands and registers new ones if enabled.
-        """
-        warnings.warn(
-            ".rollout_application_commands is deprecated, use .sync_application_commands and set "
-            "kwargs in it instead.",
-            stacklevel=2,
-            category=FutureWarning,
-        )
-
-        if self.application_id is None:
-            raise TypeError("Could not get the current application's id")
-
-        global_payload = await self.http.get_global_commands(self.application_id)
-        await self.deploy_application_commands(
-            data=global_payload,
-            associate_known=self._rollout_associate_known,
-            delete_unknown=self._rollout_delete_unknown,
-            update_known=self._rollout_update_known,
-        )
-        if self._rollout_register_new:
-            await self.register_new_application_commands(data=global_payload)
 
     def _add_decorated_application_commands(self) -> None:
         for command in self._application_commands_to_add:

--- a/nextcord/client.py
+++ b/nextcord/client.py
@@ -2312,7 +2312,7 @@ class Client:
         global commands if the guild_id is ``None``.
 
         .. versionchanged:: 3.0
-            This replaces the now removed ``delete_unknown_application_commands``, 
+            This replaces the now removed ``delete_unknown_application_commands``,
             ``associate_application_commands``, ``update_application_commands``, and ``rollout_application_commands``
             methods.
 

--- a/nextcord/embeds.py
+++ b/nextcord/embeds.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import datetime
-import warnings
 from typing import TYPE_CHECKING, Any, Dict, List, Mapping, Optional, Protocol, Union
 
 from . import utils
@@ -13,9 +12,6 @@ if TYPE_CHECKING:
     from typing_extensions import Self
 
 __all__ = ("Embed",)
-
-# Backwards compatibility
-EmptyEmbed = None
 
 
 class EmbedProxy:
@@ -96,6 +92,9 @@ class Embed:
             and is typed as ``Optional[...]`` over ``Embed.Empty``.
             This also means that you can no longer use ``len()`` on an empty field.
 
+    .. versionchanged:: 3.0
+        ``Embed.Empty`` has been removed in favor of ``None``.
+
     Attributes
     ----------
     title: :class:`str`
@@ -166,16 +165,6 @@ class Embed:
 
         if timestamp:
             self.timestamp = timestamp
-
-    # backwards compatibility
-    @property
-    def Empty(self) -> None:
-        warnings.warn(
-            "Empty is deprecated and will be removed in a future version. Use None instead.",
-            FutureWarning,
-            stacklevel=2,
-        )
-        return None
 
     @classmethod
     def from_dict(cls, data: Mapping[str, Any]) -> Self:

--- a/nextcord/guild.py
+++ b/nextcord/guild.py
@@ -13,7 +13,6 @@ from typing import (
     ClassVar,
     Dict,
     List,
-    Literal,
     NamedTuple,
     Optional,
     Sequence,

--- a/nextcord/guild.py
+++ b/nextcord/guild.py
@@ -3034,7 +3034,6 @@ class Guild(Hashable):
         *,
         reason: Optional[str] = None,
         delete_message_seconds: Optional[int] = None,
-        delete_message_days: Optional[Literal[0, 1, 2, 3, 4, 5, 6, 7]] = None,
     ) -> None:
         """|coro|
 
@@ -3047,9 +3046,8 @@ class Guild(Hashable):
 
         For backwards compatibility reasons, by default one day worth of messages will be deleted.
 
-        .. warning::
-            delete_message_days is deprecated and will be removed in a future version.
-            Use delete_message_seconds instead.
+        .. versionchanged:: 3.0
+            ``delete_message_days`` has been removed in favor of ``delete_message_seconds``.
 
         Parameters
         ----------
@@ -3060,11 +3058,6 @@ class Guild(Hashable):
             in the guild. The minimum is 0 and the maximum is 604800 (7 days).
 
             .. versionadded:: 2.3
-        delete_message_days: Optional[:class:`int`]
-            The number of days worth of messages to delete from the user
-            in the guild. The minimum is 0 and the maximum is 7.
-
-            .. deprecated:: 2.3
         reason: Optional[:class:`str`]
             The reason the user got banned.
 
@@ -3075,18 +3068,7 @@ class Guild(Hashable):
         HTTPException
             Banning failed.
         """
-        if delete_message_days is not None and delete_message_seconds is not None:
-            raise InvalidArgument(
-                "Cannot pass both delete_message_days and delete_message_seconds."
-            )
-        elif delete_message_days is not None:
-            warnings.warn(
-                DeprecationWarning(
-                    "delete_message_days is deprecated, use delete_message_seconds instead."
-                )
-            )
-            delete_message_seconds = delete_message_days * 24 * 60 * 60
-        elif delete_message_seconds is None:
+        if delete_message_seconds is None:
             # Default to one day
             delete_message_seconds = 24 * 60 * 60
 

--- a/nextcord/member.py
+++ b/nextcord/member.py
@@ -7,7 +7,7 @@ import datetime
 import itertools
 import sys
 from operator import attrgetter
-from typing import TYPE_CHECKING, Any, Dict, List, Literal, Optional, Tuple, Union
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Union
 
 from . import abc, utils
 from .activity import ActivityTypes, create_activity

--- a/nextcord/member.py
+++ b/nextcord/member.py
@@ -643,7 +643,6 @@ class Member(abc.Messageable, _UserTag):
         self,
         *,
         delete_message_seconds: Optional[int] = None,
-        delete_message_days: Optional[Literal[0, 1, 2, 3, 4, 5, 6, 7]] = None,
         reason: Optional[str] = None,
     ) -> None:
         """|coro|
@@ -654,7 +653,6 @@ class Member(abc.Messageable, _UserTag):
             self,
             reason=reason,
             delete_message_seconds=delete_message_seconds,
-            delete_message_days=delete_message_days,
         )
 
     async def unban(self, *, reason: Optional[str] = None) -> None:


### PR DESCRIPTION
## Summary

This PR removes all deprecations from 2.x.

What has been removed:
- BaseApplicationCommand
    - `check_against_raw_payload` -> `is_payload_valid`
    - `get_guild_payload` -> `get_payload(guild_id)`
    - `global_payload` -> `get_payload(None)`
- Client
    - `persistent_views` -> `views(persistent=True)`
    - `deploy_application_commands` -> `discover_application_commands`
    - `delete_unknown_application_commands` -> `sync_application_commands`
    - `associate_application_commands` -> `sync_application_commands`
    - `update_application_commands` -> `sync_application_commands`
    - `add_startup_application_commands` -> `add_all_application_commands`
    - `rollout_application_commands` -> `sync_application_commands`
- Embeds
    - `EmptyEmbed` -> `None`
    - `Embed.Empty` -> `None`
- `Guild/Member.ban`
    - `delete_message_days` -> `delete_message_seconds`

<!-- Link any issues if applicable.
Use keywords from https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests
-->

<!-- Uncomment based on the type of your changes below -->

<!--
## This is a **Code Change**

- [ ] I have tested my changes.
- [ ] I have updated the documentation to reflect the changes.
- [ ] I have run `task pyright` and fixed the relevant issues.
