### PR TITLE
test: create initial test setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,5 @@ build/
 
 # locks don't belong in libraries
 poetry.lock
+
+*.coverage

--- a/nextcord/abc.py
+++ b/nextcord/abc.py
@@ -385,7 +385,7 @@ class GuildChannel:
                 position, parent_id=parent_id, lock_permissions=lock_permissions, reason=reason
             )
 
-        overwrites = options.get("overwrites", None)
+        overwrites = options.pop("overwrites", None)
         if overwrites is not None:
             perms = []
             for target, perm in overwrites.items():

--- a/nextcord/channel.py
+++ b/nextcord/channel.py
@@ -75,6 +75,7 @@ if TYPE_CHECKING:
         DMChannel as DMChannelPayload,
         ForumChannel as ForumChannelPayload,
         ForumTag as ForumTagPayload,
+        ForumTagCreate as ForumTagCreatePayload,
         GroupDMChannel as GroupChannelPayload,
         StageChannel as StageChannelPayload,
         TextChannel as TextChannelPayload,
@@ -3062,9 +3063,9 @@ class ForumTag:
         return f"{type(self).__name__} {inner}"
 
     @property
-    def payload(self) -> ForumTagPayload:
+    def payload(self) -> Union[ForumTagPayload, ForumTagCreatePayload]:
         data: ForumTagPayload = {
-            "id": str(self.id),
+            "id": self.id,
             "name": self.name,
             "moderated": self.moderated,
         }

--- a/nextcord/channel.py
+++ b/nextcord/channel.py
@@ -3063,9 +3063,8 @@ class ForumTag:
         return f"{type(self).__name__} {inner}"
 
     @property
-    def payload(self) -> Union[ForumTagPayload, ForumTagCreatePayload]:
-        data: ForumTagPayload = {
-            "id": self.id,
+    def payload(self) -> ForumTagCreatePayload:
+        data: ForumTagCreatePayload = {
             "name": self.name,
             "moderated": self.moderated,
         }

--- a/nextcord/player.py
+++ b/nextcord/player.py
@@ -2,7 +2,6 @@
 from __future__ import annotations
 
 import asyncio
-import audioop
 import io
 import json
 import logging
@@ -13,6 +12,7 @@ import sys
 import threading
 import time
 import traceback
+import warnings
 from typing import IO, TYPE_CHECKING, Any, Callable, Generic, Optional, Tuple, TypeVar, Union
 
 from .enums import SpeakingState
@@ -25,6 +25,10 @@ if TYPE_CHECKING:
     from typing_extensions import Self
 
     from .voice_client import VoiceClient
+
+with warnings.catch_warnings():
+    warnings.simplefilter("ignore", DeprecationWarning)
+    import audioop
 
 
 AT = TypeVar("AT", bound="AudioSource")

--- a/nextcord/types/channel.py
+++ b/nextcord/types/channel.py
@@ -152,10 +152,14 @@ class StageInstance(TypedDict):
 
 class ForumTagCreate(TypedDict):
     name: str
+    moderated: NotRequired[bool]
+    emoji_id: NotRequired[Optional[Snowflake]]
+    emoji_name: NotRequired[Optional[str]]
+
+
+class ForumTag(TypedDict):
+    id: Snowflake
+    name: str
     moderated: bool
     emoji_id: Optional[Snowflake]
     emoji_name: Optional[str]
-
-
-class ForumTag(ForumTagCreate):
-    id: Snowflake

--- a/nextcord/types/channel.py
+++ b/nextcord/types/channel.py
@@ -150,9 +150,12 @@ class StageInstance(TypedDict):
     discoverable_disabled: bool
 
 
-class ForumTag(TypedDict):
-    id: Snowflake
+class ForumTagCreate(TypedDict):
     name: str
     moderated: bool
-    emoji_id: NotRequired[Optional[Snowflake]]
-    emoji_name: NotRequired[Optional[str]]
+    emoji_id: Optional[Snowflake]
+    emoji_name: Optional[str]
+
+
+class ForumTag(ForumTagCreate):
+    id: Snowflake

--- a/nextcord/types/emoji.py
+++ b/nextcord/types/emoji.py
@@ -25,6 +25,6 @@ class EditEmoji(TypedDict):
     roles: Optional[SnowflakeList]
 
 
-class DefaultReaction(TypedDict, total=False):
+class DefaultReaction(TypedDict):
     emoji_id: Optional[Snowflake]
     emoji_name: Optional[str]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,6 +65,12 @@ sphinx = "5.2.3"
 sphinxcontrib-trio = "1.1.2"
 sphinxcontrib-websupport = "^1.2.4"
 
+[tool.poetry.group.test.dependencies]
+pytest = "^7.4.2"
+pytest-asyncio = "^0.21.1"
+pytest-cov = "^4.1.0"
+coverage = { extras = ["toml"], version = "^7.3.1" }
+
 [tool.poetry.urls]
 "Documentation" = "https://docs.nextcord.dev/"
 "Issue tracker" = "https://github.com/nextcord/nextcord/issues"
@@ -121,6 +127,34 @@ precommit = { cmd = "pre-commit install --install-hooks", help = "Install the pr
 pyright = { cmd = "dotenv -f task.env run -- python -m pyright", help = "Run pyright" }
 slotscheck = { cmd = "python -m slotscheck --verbose -m nextcord", help = "Run slotscheck" }
 autotyping = { cmd = "task lint autotyping", help = "Refactor code to add automatic type annotations" }
+tests = { cmd = "pytest --cov --cov-report html --cov-context test", help = "Run tests" }
+coverage = { cmd = "python -m http.server 8188 --directory htmlcov" }
+
+
+[tool.pytest.ini_options]
+testpaths = "tests"
+addopts = "--strict-markers -Werror -s"
+xfail_strict = true
+asyncio_mode = "strict"
+
+[tool.coverage.run]
+branch = true
+include = ["nextcord/*", "tests/*"]
+omit = ["nextcord/types/*", "nextcord/__main__.py"]
+
+[tool.coverage.report]
+precision = 1
+exclude_lines = [
+    "# pragma: no cov(er(age)?)?$",
+    "^\\s*def __repr__",
+    "^\\s*@overload",
+    "^\\s*if TYPE_CHECKING",
+    "^\\s*raise NotImplementedError$",
+    "^\\s*\\.\\.\\.$",
+]
+
+[tool.coverage.html]
+show_contexts = true
 
 
 [tool.slotscheck]

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+# SPDX-License-Identifier: MIT

--- a/tests/test_abc.py
+++ b/tests/test_abc.py
@@ -1,0 +1,124 @@
+# SPDX-License-Identifier: MIT
+
+from unittest import mock
+
+import pytest
+
+import nextcord
+from nextcord import abc
+
+
+@pytest.mark.asyncio
+class TestGuildChannel:
+    @pytest.fixture
+    def channel(self):
+        channel = mock.Mock(
+            abc.GuildChannel,
+            id=1,
+            category_id=22,
+            position=1,
+            _state=mock.Mock(http=mock.AsyncMock()),
+            guild=mock.Mock(),
+        )
+        category = mock.Mock(_overwrites=[mock.Mock() for _ in range(2)])
+        channel.guild.get_channel.return_value = category
+        return channel
+
+    async def test_move(self, channel):
+        channel.guild.channels = [channel]
+        res = await abc.GuildChannel._move(channel, position=2, parent_id=5, reason="h")
+        assert res is None
+        channel._state.http.bulk_channel_update.assert_awaited_once_with(
+            channel.guild.id,
+            [{"id": 1, "position": 0, "parent_id": 5, "lock_permissions": False}],
+            reason="h",
+        )
+
+    async def test_move_called(self, channel):
+        res = await abc.GuildChannel._edit(
+            channel,
+            options={"position": 3, "category": nextcord.Object(5), "sync_permissions": True},
+            reason="h",
+        )
+        assert res is None
+        channel._move.assert_awaited_once_with(3, parent_id=5, lock_permissions=True, reason="h")
+        channel._state.http.edit_channel.assert_not_called()
+
+    async def test_edit_and_move(self, channel):
+        role = mock.Mock(nextcord.Role)
+        member = mock.Mock(nextcord.Member)
+        res = await abc.GuildChannel._edit(
+            channel,
+            {
+                "category": nextcord.Object(42),
+                "slowmode_delay": 5,
+                "rtc_region": nextcord.VoiceRegion.southafrica,
+                "video_quality_mode": nextcord.VideoQualityMode.full,
+                "default_sort_order": nextcord.SortOrderType.creation_date,
+                "default_forum_layout": nextcord.ForumLayoutType.gallery,
+                "sync_permissions": True,
+                "position": 5,
+                "overwrites": {
+                    member: nextcord.PermissionOverwrite(send_messages=True),
+                    role: nextcord.PermissionOverwrite(administrator=True),
+                },
+                "default_thread_slowmode_delay": 10,
+                "default_reaction": "<:tomsnotlikethis:1054064157726621796>",
+                "type": nextcord.ChannelType.news,
+                "available_tags": [nextcord.ForumTag(id=12, name="bad", moderated=True)],
+            },
+            reason="h",
+        )
+        assert res is channel._state.http.edit_channel.return_value
+        channel._state.http.edit_channel.assert_awaited_once_with(
+            channel.id,
+            reason="h",
+            type=5,
+            rate_limit_per_user=5,
+            rtc_region="southafrica",
+            video_quality_mode=2,
+            default_sort_order=1,
+            default_forum_layout=2,
+            permission_overwrites=[
+                {"allow": 2048, "deny": 0, "id": member.id, "type": 1},
+                {"allow": 8, "deny": 0, "id": role.id, "type": 0},
+            ],
+            default_thread_rate_limit_per_user=10,
+            default_reaction_emoji={
+                "emoji_id": 1054064157726621796,
+            },
+            available_tags=[{"id": 12, "name": "bad", "moderated": True}],
+        )
+        channel._move.assert_awaited_once_with(5, parent_id=42, lock_permissions=True, reason="h")
+
+    async def test_edit__sync_permissions(self, channel):
+        res = await abc.GuildChannel._edit(channel, {"sync_permissions": True}, reason="h")
+        assert res is channel._state.http.edit_channel.return_value
+        channel._state.http.edit_channel.assert_awaited_once_with(
+            channel.id,
+            reason="h",
+            permission_overwrites=[
+                o._asdict() for o in channel.guild.get_channel.return_value._overwrites
+            ],
+        )
+        channel._move.assert_not_called()
+
+    async def test_move__no_cache(self, channel):
+        channel.guild.channels = []
+        res = await abc.GuildChannel._move(channel, position=2, parent_id=5, reason="h")
+        assert res is None
+        assert channel._state.http.bulk_channel_update.called is False
+
+    async def test_edit__change_category(self, channel):
+        res = await abc.GuildChannel._edit(
+            channel, {"sync_permissions": True, "category": nextcord.Object(5)}, reason="h"
+        )
+        assert res is channel._state.http.edit_channel.return_value
+        channel._state.http.edit_channel.assert_awaited_once_with(
+            channel.id,
+            reason="h",
+            permission_overwrites=[
+                o._asdict() for o in channel.guild.get_channel.return_value._overwrites
+            ],
+            parent_id=5,
+        )

--- a/tests/test_abc.py
+++ b/tests/test_abc.py
@@ -8,9 +8,9 @@ import nextcord
 from nextcord import abc
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio()
 class TestGuildChannel:
-    @pytest.fixture
+    @pytest.fixture()
     def channel(self):
         channel = mock.Mock(
             abc.GuildChannel,

--- a/tests/test_test.py
+++ b/tests/test_test.py
@@ -1,5 +1,0 @@
-import nextcord
-
-
-def test_test():
-    assert nextcord is nextcord

--- a/tests/test_test.py
+++ b/tests/test_test.py
@@ -1,0 +1,5 @@
+import nextcord
+
+
+def test_test():
+    assert nextcord is nextcord


### PR DESCRIPTION
## Summary

> **Note**
> This is branched from #1126 as to not have to redo dependencies when that is merged. View the tests-only diff [here](https://github.com/nextcord/nextcord/pull/1130/files/4ecb5248b1b1e53f86db567a10bc7f75b08a15b3..1af786382d10949ebc368bb343db6e5b57adbe5b)

I am yet to add this to `CONTRIBUTING.md`, it probably won't be done in this PR as there are too few tests to enforce test styles right now.

This PR adds the initial setup for unit testing. I have added `test_abc.py` which does shallow testing of `abc.GuildChannel`'s `_edit` and `_move` methods as an example of sorts for adding more tests.

These have already fixed a couple of issues - forum tags using strings in outbound payloads and `audioop`-dependent code needing to be changed as it will be removed in a future Python version.

<!-- What is this pull request for? Does it fix any issues? -->

<!-- Link any issues if applicable.
Use keywords from https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests
-->

<!-- Uncomment based on the type of your changes below -->

<!--
## This is a **Code Change**

- [ ] I have tested my changes.
- [ ] I have updated the documentation to reflect the changes.
- [ ] I have run `task pyright` and fixed the relevant issues.
