### PR TITLE
docs(contributing): add removal conventional commit type

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,13 +20,13 @@ Please try your best not to ask questions in our issue tracker. Most of them don
 Please be aware of the following things when filing bug reports.
 
 1. Don't open duplicate issues. Please search your issue to see if it has been asked already. Duplicate issues will be closed.
-2. When filing a bug about exceptions, please include the *complete* traceback. Without the complete traceback the issue might be **unsolvable** and you will be asked to provide more information.
+2. When filing a bug about exceptions, please include the _complete_ traceback. Without the complete traceback the issue might be **unsolvable** and you will be asked to provide more information.
 3. Make sure to provide enough information to make the issue workable. The issue template will generally walk you through the process but they are enumerated here as well:
-    - A **summary** of your bug report. This is generally a quick sentence or two to describe the issue in human terms.
-    - Guidance on **how to reproduce the issue**. Ideally, this should have a small code sample that allows us to run and see the issue for ourselves to debug. **Please make sure that the token is not displayed**. If you cannot provide a code snippet, then let us know what the steps were, how often it happens, etc.
-    - Tell us **what you expected to happen**, that way we can meet that expectation.
-    - Tell us **what actually happens**. What ends up happening in reality? It's not helpful to say "it fails" or "it doesn't work". Say *how* it failed, do you get an exception? Does it hang? How are the expectations different from reality?
-    - Tell us **information about your environment**. What version of nextcord are you using? How was it installed? What operating system are you running on? These are valuable questions and information that we use.
+   - A **summary** of your bug report. This is generally a quick sentence or two to describe the issue in human terms.
+   - Guidance on **how to reproduce the issue**. Ideally, this should have a small code sample that allows us to run and see the issue for ourselves to debug. **Please make sure that the token is not displayed**. If you cannot provide a code snippet, then let us know what the steps were, how often it happens, etc.
+   - Tell us **what you expected to happen**, that way we can meet that expectation.
+   - Tell us **what actually happens**. What ends up happening in reality? It's not helpful to say "it fails" or "it doesn't work". Say _how_ it failed, do you get an exception? Does it hang? How are the expectations different from reality?
+   - Tell us **information about your environment**. What version of nextcord are you using? How was it installed? What operating system are you running on? These are valuable questions and information that we use.
 
 If the bug report is missing this information then it'll take us longer to fix the issue. We will probably ask for clarification, and barring that if no response was given then the issue will be closed.
 
@@ -116,6 +116,7 @@ Co-Authored-By: Some Person <email@example.com>
 - **fix**: A bug fix
 - **perf**: A code change that improves performance
 - **refactor**: A code change that neither fixes a bug nor adds a feature
+- **removal**: A code change that removes user-facing code
 - **style**: Changes that do not affect the meaning of the code (white-space, formatting, etc)
 - **test**: Adding missing tests or correcting existing tests
 - **typing**: Changes that affect type annotations
@@ -219,7 +220,7 @@ class Guild(Hashable):
 
 We use [Roles](https://www.sphinx-doc.org/en/master/usage/restructuredtext/roles.html#roles) to link to other parts of documentation.
 
-`typing` is not linked to shorten the docstrings, and are simply described like this: ``List[:class:`str`]``.
+`typing` is not linked to shorten the docstrings, and are simply described like this: `` List[:class:`str`] ``.
 
 #### Links Example
 


### PR DESCRIPTION
## Summary

`removal` is a useful commit type over `refactor!` as it is more explicit on what the actual type of refactor this is - removal of API code.

<!-- What is this pull request for? Does it fix any issues? -->

<!-- Link any issues if applicable.
Use keywords from https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests
-->

<!-- Uncomment based on the type of your changes below -->

<!--
## This is a **Code Change**

- [ ] I have tested my changes.
- [ ] I have updated the documentation to reflect the changes.
- [ ] I have run `task pyright` and fixed the relevant issues.
