### PR TITLE
fix: check View.prevent_update in Webhook.send and Webhook.edit_message

### DIFF
--- a/nextcord/ui/modal.py
+++ b/nextcord/ui/modal.py
@@ -164,7 +164,7 @@ class Modal:
         return self.__timeout_expiry
 
     def add_item(self, item: Item) -> Modal:
-        """Adds an item to the modal.
+        r"""Adds an item to the modal.
 
         Parameters
         ----------

--- a/nextcord/webhook/async_.py
+++ b/nextcord/webhook/async_.py
@@ -1527,7 +1527,7 @@ class Webhook(BaseWebhook):
         if view is not MISSING:
             if isinstance(self._state, _WebhookState):
                 raise InvalidArgument("Webhook views require an associated state with the webhook")
-            if ephemeral is True and view.timeout is None:
+            if ephemeral is True and view.timeout is None and view.prevent_update:
                 view.timeout = 15 * 60.0
 
         params = handle_message_parameters(
@@ -1566,7 +1566,7 @@ class Webhook(BaseWebhook):
         if wait:
             msg = self._create_message(data)
 
-        if view is not MISSING and not view.is_finished():
+        if view is not MISSING and not view.is_finished() and view.prevent_update:
             message_id = None if msg is None else msg.id
             self._state.store_view(view, message_id)
 
@@ -1730,7 +1730,7 @@ class Webhook(BaseWebhook):
         )
 
         message = self._create_message(data)
-        if view and not view.is_finished():
+        if view and not view.is_finished() and view.prevent_update:
             self._state.store_view(view, message_id)
         return message
 


### PR DESCRIPTION
## Summary

This PR makes webhooks respect the view.prevent_update value in a similar way as the other message sending or editing methods.

## This is a **Code Change**

- [X] I have tested my changes.
- [ ] I have updated the documentation to reflect the changes.
- [x] I have run `task pyright` and fixed the relevant issues.
