### PR TITLE
feat(commands): add extras kwarg to bot.reload_extension

### DIFF
--- a/nextcord/ext/commands/bot.py
+++ b/nextcord/ext/commands/bot.py
@@ -937,7 +937,7 @@ class BotBase(GroupMixin):
                 def setup(bot, keyword_arg):
                     bot.add_cog(MeCog(bot, keyword_arg))
 
-            .. versionadded:: v3.0.0a
+            .. versionadded:: v3.0
 
         Raises
         ------


### PR DESCRIPTION
## Summary

Adds "extras" kwarg to bot.reload_extension method, this allows users to pass kwargs to a cog's setup function when reloading a cog.

Closes #1154 

## This is a **Code Change**

- [x] I have tested my changes.
- [x] I have updated the documentation to reflect the changes.
- [x] I have run `task pyright` and fixed the relevant issues.
