### PR TITLE
feat(webhooks): allow editing webhook messages that were sent in threads

### DIFF
--- a/nextcord/webhook/async_.py
+++ b/nextcord/webhook/async_.py
@@ -1684,7 +1684,7 @@ class Webhook(BaseWebhook):
         thread: :class:`~nextcord.abc.Snowflake`
             The thread that the message to be edited is in.
 
-            .. versionadded:: ?.?
+            .. versionadded:: 3.0
 
         Raises
         ------

--- a/nextcord/webhook/async_.py
+++ b/nextcord/webhook/async_.py
@@ -332,7 +332,9 @@ class AsyncWebhookAdapter:
             webhook_token=token,
             message_id=message_id,
         )
-        return self.request(route, session, payload=payload, multipart=multipart, files=files, params=params)
+        return self.request(
+            route, session, payload=payload, multipart=multipart, files=files, params=params
+        )
 
     def delete_webhook_message(
         self,
@@ -1677,11 +1679,11 @@ class Webhook(BaseWebhook):
             The updated view to update this message with. If ``None`` is passed then
             the view is removed. The webhook must have state attached, similar to
             :meth:`send`.
-            
+
             .. versionadded:: 2.0
         thread: :class:`~nextcord.abc.Snowflake`
             The thread that the message to be edited is in.
-            
+
             .. versionadded:: ?.?
 
         Raises
@@ -1731,7 +1733,7 @@ class Webhook(BaseWebhook):
         thread_id: Optional[int] = None
         if thread is not MISSING:
             thread_id = thread.id
-            
+
         data = await adapter.edit_webhook_message(
             self.id,
             self.token,

--- a/nextcord/webhook/async_.py
+++ b/nextcord/webhook/async_.py
@@ -1677,10 +1677,12 @@ class Webhook(BaseWebhook):
             The updated view to update this message with. If ``None`` is passed then
             the view is removed. The webhook must have state attached, similar to
             :meth:`send`.
-
-            .. versionadded:: ?.?
+            
+            .. versionadded:: 2.0
         thread: :class:`~nextcord.abc.Snowflake`
             The thread that the message to be edited is in.
+            
+            .. versionadded:: ?.?
 
         Raises
         ------

--- a/nextcord/webhook/async_.py
+++ b/nextcord/webhook/async_.py
@@ -591,7 +591,7 @@ def handle_message_parameters(
         multipart[0]["value"] = utils.to_json(payload)
         payload = None
 
-    return ExecuteWebhookParameters(payload=payload, multipart=multipart, files=files, thread_id=thread_id)
+    return ExecuteWebhookParameters(payload=payload, multipart=multipart, files=files)
 
 
 async_context: ContextVar[AsyncWebhookAdapter] = ContextVar(

--- a/nextcord/webhook/async_.py
+++ b/nextcord/webhook/async_.py
@@ -484,7 +484,6 @@ class ExecuteWebhookParameters(NamedTuple):
     payload: Optional[Dict[str, Any]]
     multipart: Optional[List[Dict[str, Any]]]
     files: Optional[List[File]]
-    thread_id: Optional[int]
 
 
 def handle_message_parameters(

--- a/nextcord/webhook/sync.py
+++ b/nextcord/webhook/sync.py
@@ -310,7 +310,11 @@ class WebhookAdapter:
         payload: Optional[Dict[str, Any]] = None,
         multipart: Optional[List[Dict[str, Any]]] = None,
         files: Optional[List[File]] = None,
+        thread_id: Optional[int] = None,
     ):
+        params = {}
+        if thread_id:
+            params["thread_id"] = thread_id
         route = Route(
             "PATCH",
             "/webhooks/{webhook_id}/{webhook_token}/messages/{message_id}",
@@ -318,7 +322,7 @@ class WebhookAdapter:
             webhook_token=token,
             message_id=message_id,
         )
-        return self.request(route, session, payload=payload, multipart=multipart, files=files)
+        return self.request(route, session, payload=payload, multipart=multipart, files=files, params=params)
 
     def delete_webhook_message(
         self,

--- a/nextcord/webhook/sync.py
+++ b/nextcord/webhook/sync.py
@@ -322,7 +322,9 @@ class WebhookAdapter:
             webhook_token=token,
             message_id=message_id,
         )
-        return self.request(route, session, payload=payload, multipart=multipart, files=files, params=params)
+        return self.request(
+            route, session, payload=payload, multipart=multipart, files=files, params=params
+        )
 
     def delete_webhook_message(
         self,

--- a/nextcord/webhook/sync.py
+++ b/nextcord/webhook/sync.py
@@ -1025,6 +1025,7 @@ class SyncWebhook(BaseWebhook):
         files: List[File] = MISSING,
         attachments: List[Attachment] = MISSING,
         allowed_mentions: Optional[AllowedMentions] = None,
+        thread: Snowflake = MISSING,
     ) -> SyncWebhookMessage:
         """Edits a message owned by this webhook.
 
@@ -1087,6 +1088,9 @@ class SyncWebhook(BaseWebhook):
             previous_allowed_mentions=previous_mentions,
         )
         adapter: WebhookAdapter = _get_webhook_adapter()
+        thread_id: Optional[int] = None
+        if thread is not MISSING:
+            thread_id = thread.id
         data = adapter.edit_webhook_message(
             self.id,
             self.token,
@@ -1095,6 +1099,7 @@ class SyncWebhook(BaseWebhook):
             payload=params.payload,
             multipart=params.multipart,
             files=params.files,
+            thread_id=thread_id,
         )
         return self._create_message(data)
 

--- a/nextcord/webhook/sync.py
+++ b/nextcord/webhook/sync.py
@@ -1052,7 +1052,8 @@ class SyncWebhook(BaseWebhook):
         allowed_mentions: :class:`AllowedMentions`
             Controls the mentions being processed in this message.
             See :meth:`.abc.Messageable.send` for more information.
-
+        thread: :class:`~nextcord.abc.Snowflake`
+            The thread that the message to be edited is in.
         Raises
         ------
         HTTPException

--- a/nextcord/webhook/sync.py
+++ b/nextcord/webhook/sync.py
@@ -1057,6 +1057,9 @@ class SyncWebhook(BaseWebhook):
             See :meth:`.abc.Messageable.send` for more information.
         thread: :class:`~nextcord.abc.Snowflake`
             The thread that the message to be edited is in.
+            
+            .. versionadded:: 3.0
+            
         Raises
         ------
         HTTPException

--- a/nextcord/webhook/sync.py
+++ b/nextcord/webhook/sync.py
@@ -1057,9 +1057,9 @@ class SyncWebhook(BaseWebhook):
             See :meth:`.abc.Messageable.send` for more information.
         thread: :class:`~nextcord.abc.Snowflake`
             The thread that the message to be edited is in.
-            
+
             .. versionadded:: 3.0
-            
+
         Raises
         ------
         HTTPException


### PR DESCRIPTION
## Summary

<!-- What is this pull request for? Does it fix any issues? -->

Nextcord doesn't currently allow editing webhook messages that were sent in threads. This aims to change that. I tested it preliminarily but it definitely needs more tests. Will sort it out soon. Most of it is copied straight from the implementation for sending webhook messages in threads.

<!-- Link any issues if applicable.
Use keywords from https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests
-->

<!-- Uncomment based on the type of your changes below -->

## This is a **Code Change**

- [x] I have tested my changes.
- [x] I have updated the documentation to reflect the changes.
- [ ] I have run `task pyright` and fixed the relevant issues.
