### PR TITLE
feat(auto-reload): reloads extensions automatically when they are modified

### DIFF
--- a/nextcord/ext/commands/bot.py
+++ b/nextcord/ext/commands/bot.py
@@ -11,10 +11,10 @@ import importlib.util
 import inspect
 import os
 import sys
+import time
 import traceback
 import types
 import warnings
-import time
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -1466,11 +1466,12 @@ class BotBase(GroupMixin):
                 if file and os.stat(file).st_mtime > last:
                     extensions.add(name)
 
-            for name in extensions: 
+            for name in extensions:
                 self.reload_extension(name)
 
             await asyncio.sleep(2)
             last = t
+
 
 class Bot(BotBase, nextcord.Client):
     """Represents a discord bot.


### PR DESCRIPTION
## Summary

This pull request introduces a new feature into nextcord that allows users to enable debug mode. With this enabled, extensions will automatically reload when the file is modified whilst the bot is running.

Scope `ext/commands/bot.py`

## This is a **Code Change**

- [ ] I have tested my changes.
- [ ] I have updated the documentation to reflect the changes.
- [ ] I have run `task pyright` and fixed the relevant issues.
