### PR TITLE
feat(user): add `banner` param to ClientUser.edit

### DIFF
--- a/nextcord/user.py
+++ b/nextcord/user.py
@@ -389,7 +389,8 @@ class ClientUser(BaseUser):
             A :term:`py:bytes-like object`, :class:`File`, :class:`Attachment`, or :class:`Asset`
             representing the image to upload. Could be ``None`` to denote no avatar.
         banner: Optional[Union[:class:`bytes`, :class:`Asset`, :class:`Attachment`, :class:`File`]]
-            The banner that you wish to change to. Passing ``None`` denotes no banner.
+            A :term:`py:bytes-like object`, :class:`File`, :class:`Attachment`, or :class:`Asset`
+            representing the image to upload. Could be ``None`` to denote no banner.
 
         Raises
         ------

--- a/nextcord/user.py
+++ b/nextcord/user.py
@@ -357,6 +357,7 @@ class ClientUser(BaseUser):
         *,
         username: str = MISSING,
         avatar: Optional[Union[bytes, Asset, Attachment, File]] = MISSING,
+        banner: Optional[Union[bytes, Asset, Attachment, File]] = MISSING,
     ) -> ClientUser:
         """|coro|
 
@@ -377,6 +378,9 @@ class ClientUser(BaseUser):
         .. versionchanged:: 2.1
             The ``avatar`` parameter now accepts :class:`File`, :class:`Attachment`, and :class:`Asset`.
 
+        .. versionadded:: 3.0
+            The ``banner`` field has been added.
+
         Parameters
         ----------
         username: :class:`str`
@@ -384,13 +388,15 @@ class ClientUser(BaseUser):
         avatar: Optional[Union[:class:`bytes`, :class:`Asset`, :class:`Attachment`, :class:`File`]]
             A :term:`py:bytes-like object`, :class:`File`, :class:`Attachment`, or :class:`Asset`
             representing the image to upload. Could be ``None`` to denote no avatar.
+        banner: Optional[Union[:class:`bytes`, :class:`Asset`, :class:`Attachment`, :class:`File`]]
+            The banner that you wish to change to. Passing ``None`` denotes no banner.
 
         Raises
         ------
         HTTPException
             Editing your profile failed.
         InvalidArgument
-            Wrong image format passed for ``avatar``.
+            Wrong image format passed for ``avatar`` and/or ``banner``.
 
         Returns
         -------
@@ -402,6 +408,8 @@ class ClientUser(BaseUser):
             payload["username"] = username
         if avatar is not MISSING:
             payload["avatar"] = await obj_to_base64_data(avatar)
+        if banner is not MISSING:
+            payload["banner"] = await obj_to_base64_data(banner)
 
         data: UserPayload = await self._state.http.edit_profile(payload)
         return ClientUser(state=self._state, data=data)


### PR DESCRIPTION
## Summary

Implements discord/discord-api-docs#6710 by adding a `banner` parameter on ClientUser.edit

## This is a **Code Change**

- [ ] I have tested my changes.
- [x] I have updated the documentation to reflect the changes.
- [x] I have run `task pyright` and fixed the relevant issues.
