### PR TITLE
fix(DiscordWebSocket): Raise WebSocketClosure on protocol level errors

### DIFF
--- a/nextcord/gateway.py
+++ b/nextcord/gateway.py
@@ -597,8 +597,8 @@ class DiscordWebSocket:
             if msg.type is aiohttp.WSMsgType.TEXT or msg.type is aiohttp.WSMsgType.BINARY:
                 await self.received_message(msg.data)
             elif msg.type is aiohttp.WSMsgType.ERROR:
-                _log.debug("Received %s", msg)
-                raise msg.data
+                _log.debug("Received error %s", msg)
+                raise WebSocketClosure
             elif msg.type in (
                 aiohttp.WSMsgType.CLOSED,
                 aiohttp.WSMsgType.CLOSING,


### PR DESCRIPTION
## Summary

Prevents the bot from crashing with `aiohttp.http_websocket.WebSocketError: Received fragmented control frame`
Ported from Discord.py : https://github.com/Rapptz/discord.py/commit/163a86c4a031f7ecd856f45a74da47e63b17bb16
Closes #1170 


## This is a **Code Change**

- [X] I have tested my changes. (I tested that bots work properly. It is difficult to say if the crash is actually solved because it seems to occur randomly.)