### PR TITLE
feat(app-cmds): Implement User-Installed Apps

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -68,6 +68,22 @@ AutoShardedClient
 Application Info
 ----------------
 
+InstallParams
+~~~~~~~~~~~~~
+
+.. attributetable:: InstallParams
+
+.. autoclass:: InstallParams()
+    :members:
+
+ApplicationIntegrationTypeConfig
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. attributetable:: ApplicationIntegrationTypeConfig
+
+.. autoclass:: ApplicationIntegrationTypeConfig()
+    :members:
+
 AppInfo
 ~~~~~~~
 
@@ -2419,6 +2435,14 @@ MessageInteraction
 .. attributetable:: MessageInteraction
 
 .. autoclass:: MessageInteraction()
+    :members:
+
+MessageInteractionMetadata
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. attributetable:: MessageInteractionMetadata
+
+.. autoclass:: MessageInteractionMetadata()
     :members:
 
 Member

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -1418,6 +1418,12 @@ of :class:`enum.Enum`.
 .. autoclass:: AuditLogAction
     :members:
 
+.. autoclass:: IntegrationType
+    :members:
+
+.. autoclass:: InteractionContextType
+    :members:
+
 Async Iterator
 --------------
 

--- a/examples/application_commands/user_installed_command.py
+++ b/examples/application_commands/user_installed_command.py
@@ -1,0 +1,33 @@
+from nextcord import IntegrationType, Interaction, InteractionContextType
+from nextcord.ext import commands
+
+bot = commands.Bot()
+
+
+@bot.slash_command(
+    description="An example slash command demonstrating user installed apps",
+    # These parameters can be used on any application command type
+    integration_types=[
+        IntegrationType.user_install,  # Command will be available when the app is installed on a user.
+        IntegrationType.guild_install,  # Command will be available when the app is added to a server.
+    ],
+    contexts=[
+        InteractionContextType.guild,  # Command can be used within servers.
+        InteractionContextType.bot_dm,  # Command can be used within DMs with the app's bot user.
+        InteractionContextType.private_channel,  # Command can be used within Group DMs and DMs other than the app's bot user.
+    ],
+)
+async def example_slash_command(interaction: Interaction):
+    if interaction.context == InteractionContextType.guild:
+        place = "within a server"
+    elif interaction.context == InteractionContextType.bot_dm:
+        place = "within DMs with the app's bot user"
+    elif interaction.context == InteractionContextType.private_channel:
+        place = "within a Group DM or DM other than the app's bot user"
+    else:
+        place = "somewhere nextcord doesn't support yet"
+
+    await interaction.response.send_message(f"This command was run {place}.")
+
+
+bot.run("token")

--- a/nextcord/appinfo.py
+++ b/nextcord/appinfo.py
@@ -65,12 +65,15 @@ class ApplicationIntegrationTypeConfig:
         The scopes and permissions for this installation context.
     """
 
-    __slots__ = ("oauth2_install_params",)
+    __slots__ = (
+        "_oauth2_install_params",
+        "oauth2_install_params",
+    )
 
     def __init__(self, data: ApplicationIntegrationTypeConfigPayload) -> None:
-        install_params = data.get("oauth2_install_params")
+        self._oauth2_install_params = data.get("oauth2_install_params")
         self.oauth2_install_params: Optional[InstallParams] = (
-            InstallParams(install_params) if install_params else None
+            InstallParams(self._oauth2_install_params) if self._oauth2_install_params else None
         )
 
     def __repr__(self) -> str:
@@ -141,6 +144,7 @@ class AppInfo:
         "team",
         "terms_of_service_url",
         "privacy_policy_url",
+        "_integration_types_config",
         "integration_types_config",
     )
 
@@ -165,16 +169,16 @@ class AppInfo:
         self.terms_of_service_url: Optional[str] = data.get("terms_of_service_url")
         self.privacy_policy_url: Optional[str] = data.get("privacy_policy_url")
 
-        integration_types_config: Optional[IntegrationTypesConfigPayload] = data.get(
+        self._integration_types_config: Optional[IntegrationTypesConfigPayload] = data.get(
             "integration_types_config"
         )
         self.integration_types_config: Optional[
             Dict[IntegrationType, ApplicationIntegrationTypeConfig]
         ]
-        if integration_types_config:
+        if self._integration_types_config:
             self.integration_types_config = {
                 IntegrationType(int(integration_type)): ApplicationIntegrationTypeConfig(data)
-                for integration_type, data in integration_types_config.items()
+                for integration_type, data in self._integration_types_config.items()
             }
         else:
             self.integration_types_config = None

--- a/nextcord/appinfo.py
+++ b/nextcord/appinfo.py
@@ -2,23 +2,79 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, List, Optional
+from typing import TYPE_CHECKING, Dict, List, Optional
 
 from .asset import Asset
+from .enums import IntegrationType
+from .permissions import Permissions
 
 if TYPE_CHECKING:
     from .state import ConnectionState
     from .types.appinfo import (
         AppInfo as AppInfoPayload,
+        ApplicationIntegrationTypeConfig as ApplicationIntegrationTypeConfigPayload,
+        InstallParams as InstallParamsPayload,
+        IntegrationTypesConfig as IntegrationTypesConfigPayload,
         PartialAppInfo as PartialAppInfoPayload,
         Team as TeamPayload,
     )
     from .user import User
 
 __all__ = (
+    "InstallParams",
+    "ApplicationIntegrationTypeConfig",
     "AppInfo",
     "PartialAppInfo",
 )
+
+
+class InstallParams:
+    """Represents the default scopes and permissions for an installation context.
+
+    .. versionadded:: 3.0
+
+    Attributes
+    ----------
+    scopes: List[:class:`str`]
+        Scopes to add the application to this installation context with.
+    permissions: :class:`Permissions`
+        Permissions to request for the bot role.
+    """
+
+    __slots__ = (
+        "scopes",
+        "permissions",
+    )
+
+    def __init__(self, data: InstallParamsPayload) -> None:
+        self.scopes: List[str] = data["scopes"]
+        self.permissions: Permissions = Permissions(int(data["permissions"]))
+
+    def __repr__(self) -> str:
+        return f"<{self.__class__.__name__} scopes={self.scopes} permissions={self.permissions!r}>"
+
+
+class ApplicationIntegrationTypeConfig:
+    """Represents the default scopes and permissions for an installation context.
+
+    .. versionadded:: 3.0
+
+    Attributes
+    ----------
+    oauth2_install_params: :class:`InstallParams`
+        The scopes and permissions for this installation context.
+    """
+
+    __slots__ = ("oauth2_install_params",)
+
+    def __init__(self, data: ApplicationIntegrationTypeConfigPayload) -> None:
+        install_params = data.get("oauth2_install_params")
+        self.oauth2_install_params: Optional[InstallParams] = (
+            InstallParams(install_params) if install_params else None
+        )
+
+    def __repr__(self) -> str:
+        return f"<{self.__class__.__name__} oauth2_install_params={self.oauth2_install_params!r}>"
 
 
 class AppInfo:
@@ -64,6 +120,11 @@ class AppInfo:
         The application's privacy policy URL, if set.
 
         .. versionadded:: 2.0
+
+    integration_types_config: Optional[Dict[:class:`IntegrationType`, :class:`ApplicationIntegrationTypeConfig`]]
+        The default scopes and permissions for each supported installation context.
+
+        .. versionadded:: 3.0
     """
 
     __slots__ = (
@@ -80,6 +141,7 @@ class AppInfo:
         "team",
         "terms_of_service_url",
         "privacy_policy_url",
+        "integration_types_config",
     )
 
     def __init__(self, state: ConnectionState, data: AppInfoPayload) -> None:
@@ -102,6 +164,20 @@ class AppInfo:
 
         self.terms_of_service_url: Optional[str] = data.get("terms_of_service_url")
         self.privacy_policy_url: Optional[str] = data.get("privacy_policy_url")
+
+        integration_types_config: Optional[IntegrationTypesConfigPayload] = data.get(
+            "integration_types_config"
+        )
+        self.integration_types_config: Optional[
+            Dict[IntegrationType, ApplicationIntegrationTypeConfig]
+        ]
+        if integration_types_config:
+            self.integration_types_config = {
+                IntegrationType(int(integration_type)): ApplicationIntegrationTypeConfig(data)
+                for integration_type, data in integration_types_config.items()
+            }
+        else:
+            self.integration_types_config = None
 
     def __repr__(self) -> str:
         return (
@@ -152,6 +228,7 @@ class PartialAppInfo:
         "terms_of_service_url",
         "privacy_policy_url",
         "_icon",
+        "integration_types_config",
     )
 
     def __init__(self, *, state: ConnectionState, data: PartialAppInfoPayload) -> None:
@@ -164,6 +241,19 @@ class PartialAppInfo:
         self.verify_key: str = data["verify_key"]
         self.terms_of_service_url: Optional[str] = data.get("terms_of_service_url")
         self.privacy_policy_url: Optional[str] = data.get("privacy_policy_url")
+        integration_types_config: Optional[IntegrationTypesConfigPayload] = data.get(
+            "integration_types_config"
+        )
+        self.integration_types_config: Optional[
+            Dict[IntegrationType, ApplicationIntegrationTypeConfig]
+        ]
+        if integration_types_config:
+            self.integration_types_config = {
+                IntegrationType(int(integration_type)): ApplicationIntegrationTypeConfig(data)
+                for integration_type, data in integration_types_config.items()
+            }
+        else:
+            self.integration_types_config = None
 
     def __repr__(self) -> str:
         return f"<{self.__class__.__name__} id={self.id} name={self.name!r} description={self.description!r}>"

--- a/nextcord/application_command.py
+++ b/nextcord/application_command.py
@@ -41,7 +41,14 @@ from .channel import (
     TextChannel,
     VoiceChannel,
 )
-from .enums import ApplicationCommandOptionType, ApplicationCommandType, ChannelType, Locale
+from .enums import (
+    ApplicationCommandOptionType,
+    ApplicationCommandType,
+    ChannelType,
+    Locale,
+    IntegrationType,
+    InteractionContextType
+)
 from .errors import (
     ApplicationCheckFailure,
     ApplicationCommandOptionMissing,
@@ -1953,6 +1960,8 @@ class BaseApplicationCommand(CallbackMixin, CallbackWrapperMixin):
         dm_permission: Optional[bool] = None,
         default_member_permissions: Optional[Union[Permissions, int]] = None,
         nsfw: bool = False,
+        integration_types: Optional[Iterable[IntegrationType]] = None,
+        contexts: Optional[Iterable[InteractionContextType]] = None,
         parent_cog: Optional[ClientCog] = None,
         force_global: bool = False,
     ) -> None:
@@ -1982,6 +1991,10 @@ class BaseApplicationCommand(CallbackMixin, CallbackWrapperMixin):
         dm_permission: :class:`bool`
             If the command should be usable in DMs or not. Setting to ``False`` will disable the command from being
             usable in DMs. Only for global commands, but will not error on guild.
+
+            .. warning::
+                This field is deprecated, use ``contexts`` instead.
+            .. deprecated:: 3.0
         default_member_permissions: Optional[Union[:class:`Permissions`, :class:`int`]]
             Permission(s) required to use the command. Inputting ``8`` or ``Permissions(administrator=True)`` for
             example will only allow Administrators to use the command. If set to 0, nobody will be able to use it by
@@ -1990,6 +2003,14 @@ class BaseApplicationCommand(CallbackMixin, CallbackWrapperMixin):
             Whether the command can only be used in age-restricted channels. Defaults to ``False``.
 
             .. versionadded:: 2.4
+        integration_types: Optional[Iterable[:class:`IntegrationType`]]
+            Where the command is available, only for globally-scoped commands. Defaults to ``guild_install``.
+
+            .. versionadded:: 3.0
+        contexts: Optional[Iterable[:class:`InteractionContextType`]]
+            Where the command can be used, only for globally-scoped commands. By default, all interaction context types included for new commands.
+
+            .. versionadded:: 3.0
         parent_cog: Optional[:class:`ClientCog`]
             ``ClientCog`` to forward to the callback as the ``self`` argument.
         force_global: :class:`bool`
@@ -2007,11 +2028,22 @@ class BaseApplicationCommand(CallbackMixin, CallbackWrapperMixin):
         ] = description_localizations
         self.guild_ids_to_rollout: Set[int] = set(guild_ids) if guild_ids else set()
         self.use_default_guild_ids: bool = guild_ids is MISSING and not force_global
-        self.dm_permission: Optional[bool] = dm_permission
         self.default_member_permissions: Optional[
             Union[Permissions, int]
         ] = default_member_permissions
         self.nsfw: bool = nsfw
+        self.integration_types = integration_types
+
+        if dm_permission is not None:
+            if contexts is not None:
+                raise ValueError("Cannot pass both contexts and dm_permission")
+            if dm_permission:
+                contexts = [InteractionContextType.bot_dm]
+            else:
+                contexts = []
+            if integration_types is None or IntegrationType.guild_install in integration_types:
+                contexts.append(InteractionContextType.guild)
+        self.contexts = contexts
 
         self.force_global: bool = force_global
 
@@ -2263,14 +2295,14 @@ class BaseApplicationCommand(CallbackMixin, CallbackWrapperMixin):
         if guild_id:  # Guild-command specific payload options.
             ret["guild_id"] = guild_id
         # Global command specific payload options.
-        elif self.dm_permission is not None:
-            ret["dm_permission"] = self.dm_permission
-        else:
-            # Discord seems to send back the DM permission as True regardless if we sent it or not, so we send as
-            #  the default (True) to ensure payload parity for comparisons.
-            ret["dm_permission"] = True
 
         ret["nsfw"] = self.nsfw
+
+        if self.integration_types is not None:
+            ret["integration_types"] = [x.value for x in self.integration_types]
+
+        if self.contexts is not None:
+            ret["contexts"] = [x.value for x in self.contexts]
 
         return ret
 
@@ -2332,7 +2364,6 @@ class BaseApplicationCommand(CallbackMixin, CallbackWrapperMixin):
             "name",
             "name_localizations",
             "description_localizations",
-            "dm_permission",
             "nsfw",
         ):
             _log.debug("Failed check dictionary values, not valid payload.")
@@ -2361,6 +2392,24 @@ class BaseApplicationCommand(CallbackMixin, CallbackWrapperMixin):
             if not found_correct_value:
                 _log.debug("Discord is missing an option we have, not valid payload.")
                 return False
+
+        # Default value for returned "integration_types" when not specified at registration is [0] (only guild_install)
+        if set(cmd_payload.get("integration_types", [0])) != set(raw_payload.get("integration_types", [0])):
+            _log.debug("Integration types between commands not equal, not valid payload.")
+            return False
+
+        # The API documentation mentions that "all interaction context types included for new commands".
+        # This field can sometimes be explicitly None, so we cannot use the default argument for get
+        raw_contexts = raw_payload.get("contexts")
+        cmd_contexts = cmd_payload.get("contexts")
+
+        if cmd_contexts is None:
+            if raw_contexts is not None:
+                _log.debug("Contexts between commands not equal, not valid payload.")
+                return False
+        elif raw_contexts is None or set(cmd_contexts) != set(raw_contexts):
+            _log.debug("Contexts between commands not equal, not valid payload.")
+            return False
 
         return True
 
@@ -2839,6 +2888,8 @@ class SlashApplicationCommand(SlashCommandMixin, BaseApplicationCommand, Autocom
         dm_permission: Optional[bool] = None,
         default_member_permissions: Optional[Union[Permissions, int]] = None,
         nsfw: bool = False,
+        integration_types: Optional[Iterable[IntegrationType]] = None,
+        contexts: Optional[Iterable[InteractionContextType]] = None,
         parent_cog: Optional[ClientCog] = None,
         force_global: bool = False,
     ) -> None:
@@ -2864,6 +2915,10 @@ class SlashApplicationCommand(SlashCommandMixin, BaseApplicationCommand, Autocom
         dm_permission: :class:`bool`
             If the command should be usable in DMs or not. Setting to ``False`` will disable the command from being
             usable in DMs. Only for global commands.
+
+            .. warning::
+                This field is deprecated, use ``contexts`` instead.
+            .. deprecated:: 3.0
         default_member_permissions: Optional[Union[:class:`Permissions`, :class:`int`]]
             Permission(s) required to use the command. Inputting ``8`` or ``Permissions(administrator=True)`` for
             example will only allow Administrators to use the command. If set to 0, nobody will be able to use it by
@@ -2876,6 +2931,14 @@ class SlashApplicationCommand(SlashCommandMixin, BaseApplicationCommand, Autocom
                 Due to a discord limitation, this can only be set for the parent command in case of a subcommand.
 
             .. versionadded:: 2.4
+        integration_types: Optional[Iterable[:class:`IntegrationType`]]
+            Where the command is available, only for globally-scoped commands. Defaults to ``guild_install``.
+
+            .. versionadded:: 3.0
+        contexts: Optional[Iterable[:class:`InteractionContextType`]]
+            Where the command can be used, only for globally-scoped commands. By default, all interaction context types included for new commands.
+
+            .. versionadded:: 3.0
         parent_cog: Optional[:class:`ClientCog`]
             ``ClientCog`` to forward to the callback as the ``self`` argument.
         force_global: :class:`bool`
@@ -2893,6 +2956,8 @@ class SlashApplicationCommand(SlashCommandMixin, BaseApplicationCommand, Autocom
             default_member_permissions=default_member_permissions,
             dm_permission=dm_permission,
             nsfw=nsfw,
+            integration_types=integration_types,
+            contexts=contexts,
             parent_cog=parent_cog,
             force_global=force_global,
         )
@@ -3013,6 +3078,8 @@ class UserApplicationCommand(BaseApplicationCommand):
         dm_permission: Optional[bool] = None,
         default_member_permissions: Optional[Union[Permissions, int]] = None,
         nsfw: bool = False,
+        integration_types: Optional[Iterable[IntegrationType]] = None,
+        contexts: Optional[Iterable[InteractionContextType]] = None,
         parent_cog: Optional[ClientCog] = None,
         force_global: bool = False,
     ) -> None:
@@ -3033,6 +3100,10 @@ class UserApplicationCommand(BaseApplicationCommand):
         dm_permission: :class:`bool`
             If the command should be usable in DMs or not. Setting to ``False`` will disable the command from being
             usable in DMs. Only for global commands, but will not error on guild.
+
+            .. warning::
+                This field is deprecated, use ``contexts`` instead.
+            .. deprecated:: 3.0
         default_member_permissions: Optional[Union[:class:`Permissions`, :class:`int`]]
             Permission(s) required to use the command. Inputting ``8`` or ``Permissions(administrator=True)`` for
             example will only allow Administrators to use the command. If set to 0, nobody will be able to use it by
@@ -3041,6 +3112,14 @@ class UserApplicationCommand(BaseApplicationCommand):
             Whether the command can only be used in age-restricted channels. Defaults to ``False``.
 
             .. versionadded:: 2.4
+        integration_types: Optional[Iterable[:class:`IntegrationType`]]
+            Where the command is available, only for globally-scoped commands. Defaults to ``guild_install``.
+
+            .. versionadded:: 3.0
+        contexts: Optional[Iterable[:class:`InteractionContextType`]]
+            Where the command can be used, only for globally-scoped commands. By default, all interaction context types included for new commands.
+
+            .. versionadded:: 3.0
         parent_cog: Optional[:class:`ClientCog`]
             ``ClientCog`` to forward to the callback as the ``self`` argument.
         force_global: :class:`bool`
@@ -3056,6 +3135,8 @@ class UserApplicationCommand(BaseApplicationCommand):
             dm_permission=dm_permission,
             default_member_permissions=default_member_permissions,
             nsfw=nsfw,
+            integration_types=integration_types,
+            contexts=contexts,
             parent_cog=parent_cog,
             force_global=force_global,
         )
@@ -3095,6 +3176,8 @@ class MessageApplicationCommand(BaseApplicationCommand):
         dm_permission: Optional[bool] = None,
         default_member_permissions: Optional[Union[Permissions, int]] = None,
         nsfw: bool = False,
+        integration_types: Optional[Iterable[IntegrationType]] = None,
+        contexts: Optional[Iterable[InteractionContextType]] = None,
         parent_cog: Optional[ClientCog] = None,
         force_global: bool = False,
     ) -> None:
@@ -3115,6 +3198,10 @@ class MessageApplicationCommand(BaseApplicationCommand):
         dm_permission: :class:`bool`
             If the command should be usable in DMs or not. Setting to ``False`` will disable the command from being
             usable in DMs. Only for global commands, but will not error on guild.
+
+            .. warning::
+                This field is deprecated, use ``contexts`` instead.
+            .. deprecated:: 3.0
         default_member_permissions: Optional[Union[:class:`Permissions`, :class:`int`]]
             Permission(s) required to use the command. Inputting ``8`` or ``Permissions(administrator=True)`` for
             example will only allow Administrators to use the command. If set to 0, nobody will be able to use it by
@@ -3123,6 +3210,14 @@ class MessageApplicationCommand(BaseApplicationCommand):
             Whether the command can only be used in age-restricted channels. Defaults to ``False``.
 
             .. versionadded:: 2.4
+        integration_types: Optional[Iterable[:class:`IntegrationType`]]
+            Where the command is available, only for globally-scoped commands. Defaults to ``guild_install``.
+
+            .. versionadded:: 3.0
+        contexts: Optional[Iterable[:class:`InteractionContextType`]]
+            Where the command can be used, only for globally-scoped commands. By default, all interaction context types included for new commands.
+
+            .. versionadded:: 3.0
         parent_cog: Optional[:class:`ClientCog`]
             ``ClientCog`` to forward to the callback as the ``self`` argument.
         force_global: :class:`bool`
@@ -3138,6 +3233,8 @@ class MessageApplicationCommand(BaseApplicationCommand):
             dm_permission=dm_permission,
             default_member_permissions=default_member_permissions,
             nsfw=nsfw,
+            integration_types=integration_types,
+            contexts=contexts,
             parent_cog=parent_cog,
             force_global=force_global,
         )
@@ -3174,6 +3271,8 @@ def slash_command(
     dm_permission: Optional[bool] = None,
     default_member_permissions: Optional[Union[Permissions, int]] = None,
     nsfw: bool = False,
+    integration_types: Optional[Iterable[IntegrationType]] = None,
+    contexts: Optional[Iterable[InteractionContextType]] = None,
     force_global: bool = False,
 ):
     """Creates a Slash application command from the decorated function.
@@ -3199,6 +3298,10 @@ def slash_command(
     dm_permission: :class:`bool`
         If the command should be usable in DMs or not. Setting to ``False`` will disable the command from being
         usable in DMs. Only for global commands, but will not error on guild.
+
+        .. warning::
+            This field is deprecated, use ``contexts`` instead.
+        .. deprecated:: 3.0
     default_member_permissions: Optional[Union[:class:`Permissions`, :class:`int`]]
         Permission(s) required to use the command. Inputting ``8`` or ``Permissions(administrator=True)`` for
         example will only allow Administrators to use the command. If set to 0, nobody will be able to use it by
@@ -3211,6 +3314,14 @@ def slash_command(
             Due to a discord limitation, this can only be set for the parent command in case of a subcommand.
 
         .. versionadded:: 2.4
+    integration_types: Optional[Iterable[:class:`IntegrationType`]]
+        Where the command is available, only for globally-scoped commands. Defaults to ``guild_install``.
+
+        .. versionadded:: 3.0
+    contexts: Optional[Iterable[:class:`InteractionContextType`]]
+        Where the command can be used, only for globally-scoped commands. By default, all interaction context types included for new commands.
+
+        .. versionadded:: 3.0
     force_global: :class:`bool`
         If True, will force this command to register as a global command, even if ``guild_ids`` is set. Will still
         register to guilds. Has no effect if ``guild_ids`` are never set or added to.
@@ -3230,6 +3341,8 @@ def slash_command(
             dm_permission=dm_permission,
             default_member_permissions=default_member_permissions,
             nsfw=nsfw,
+            integration_types=integration_types,
+            contexts=contexts,
             force_global=force_global,
         )
 
@@ -3244,6 +3357,8 @@ def message_command(
     dm_permission: Optional[bool] = None,
     default_member_permissions: Optional[Union[Permissions, int]] = None,
     nsfw: bool = False,
+    integration_types: Optional[Iterable[IntegrationType]] = None,
+    contexts: Optional[Iterable[InteractionContextType]] = None,
     force_global: bool = False,
 ):
     """Creates a Message context command from the decorated function.
@@ -3263,6 +3378,10 @@ def message_command(
     dm_permission: :class:`bool`
         If the command should be usable in DMs or not. Setting to ``False`` will disable the command from being
         usable in DMs. Only for global commands, but will not error on guild.
+
+        .. warning::
+            This field is deprecated, use ``contexts`` instead.
+        .. deprecated:: 3.0
     default_member_permissions: Optional[Union[:class:`Permissions`, :class:`int`]]
         Permission(s) required to use the command. Inputting ``8`` or ``Permissions(administrator=True)`` for
         example will only allow Administrators to use the command. If set to 0, nobody will be able to use it by
@@ -3271,6 +3390,14 @@ def message_command(
         Whether the command can only be used in age-restricted channels. Defaults to ``False``.
 
         .. versionadded:: 2.4
+    integration_types: Optional[Iterable[:class:`IntegrationType`]]
+        Where the command is available, only for globally-scoped commands. Defaults to ``guild_install``.
+
+        .. versionadded:: 3.0
+    contexts: Optional[Iterable[:class:`InteractionContextType`]]
+        Where the command can be used, only for globally-scoped commands. By default, all interaction context types included for new commands.
+
+        .. versionadded:: 3.0
     force_global: :class:`bool`
         If True, will force this command to register as a global command, even if ``guild_ids`` is set. Will still
         register to guilds. Has no effect if ``guild_ids`` are never set or added to.
@@ -3288,6 +3415,8 @@ def message_command(
             dm_permission=dm_permission,
             default_member_permissions=default_member_permissions,
             nsfw=nsfw,
+            integration_types=integration_types,
+            contexts=contexts,
             force_global=force_global,
         )
 
@@ -3302,6 +3431,8 @@ def user_command(
     dm_permission: Optional[bool] = None,
     default_member_permissions: Optional[Union[Permissions, int]] = None,
     nsfw: bool = False,
+    integration_types: Optional[Iterable[IntegrationType]] = None,
+    contexts: Optional[Iterable[InteractionContextType]] = None,
     force_global: bool = False,
 ):
     """Creates a User context command from the decorated function.
@@ -3321,6 +3452,10 @@ def user_command(
     dm_permission: :class:`bool`
         If the command should be usable in DMs or not. Setting to ``False`` will disable the command from being
         usable in DMs. Only for global commands, but will not error on guild.
+
+        .. warning::
+            This field is deprecated, use ``contexts`` instead.
+        .. deprecated:: 3.0
     default_member_permissions: Optional[Union[:class:`Permissions`, :class:`int`]]
         Permission(s) required to use the command. Inputting ``8`` or ``Permissions(administrator=True)`` for
         example will only allow Administrators to use the command. If set to 0, nobody will be able to use it by
@@ -3329,6 +3464,14 @@ def user_command(
         Whether the command can only be used in age-restricted channels. Defaults to ``False``.
 
         .. versionadded:: 2.4
+    integration_types: Optional[Iterable[:class:`IntegrationType`]]
+        Where the command is available, only for globally-scoped commands. Defaults to ``guild_install``.
+
+        .. versionadded:: 3.0
+    contexts: Optional[Iterable[:class:`InteractionContextType`]]
+        Where the command can be used, only for globally-scoped commands. By default, all interaction context types included for new commands.
+
+        .. versionadded:: 3.0
     force_global: :class:`bool`
         If True, will force this command to register as a global command, even if ``guild_ids`` is set. Will still
         register to guilds. Has no effect if ``guild_ids`` are never set or added to.
@@ -3346,6 +3489,8 @@ def user_command(
             dm_permission=dm_permission,
             default_member_permissions=default_member_permissions,
             nsfw=nsfw,
+            integration_types=integration_types,
+            contexts=contexts,
             force_global=force_global,
         )
 

--- a/nextcord/application_command.py
+++ b/nextcord/application_command.py
@@ -1960,8 +1960,8 @@ class BaseApplicationCommand(CallbackMixin, CallbackWrapperMixin):
         dm_permission: Optional[bool] = None,
         default_member_permissions: Optional[Union[Permissions, int]] = None,
         nsfw: bool = False,
-        integration_types: Optional[Iterable[IntegrationType]] = None,
-        contexts: Optional[Iterable[InteractionContextType]] = None,
+        integration_types: Optional[Iterable[Union[IntegrationType, int]]] = None,
+        contexts: Optional[Iterable[Union[InteractionContextType, int]]] = None,
         parent_cog: Optional[ClientCog] = None,
         force_global: bool = False,
     ) -> None:
@@ -2003,11 +2003,11 @@ class BaseApplicationCommand(CallbackMixin, CallbackWrapperMixin):
             Whether the command can only be used in age-restricted channels. Defaults to ``False``.
 
             .. versionadded:: 2.4
-        integration_types: Optional[Iterable[:class:`IntegrationType`]]
+        integration_types: Optional[Iterable[Union[:class:`IntegrationType`, :class:`int`]]]
             Where the command is available, only for globally-scoped commands. Defaults to ``guild_install``.
 
             .. versionadded:: 3.0
-        contexts: Optional[Iterable[:class:`InteractionContextType`]]
+        contexts: Optional[Iterable[Union[:class:`InteractionContextType`, :class:`int`]]]
             Where the command can be used, only for globally-scoped commands. By default, all interaction context types included for new commands.
 
             .. versionadded:: 3.0
@@ -2032,7 +2032,9 @@ class BaseApplicationCommand(CallbackMixin, CallbackWrapperMixin):
             Union[Permissions, int]
         ] = default_member_permissions
         self.nsfw: bool = nsfw
-        self.integration_types = integration_types
+        self.integration_types = (
+            None if integration_types is None else [IntegrationType(x) for x in integration_types]
+        )
 
         if dm_permission is not None:
             if contexts is not None:
@@ -2040,7 +2042,7 @@ class BaseApplicationCommand(CallbackMixin, CallbackWrapperMixin):
             contexts = [InteractionContextType.bot_dm] if dm_permission else []
             if integration_types is None or IntegrationType.guild_install in integration_types:
                 contexts.append(InteractionContextType.guild)
-        self.contexts = contexts
+        self.contexts = None if contexts is None else [InteractionContextType(x) for x in contexts]
 
         self.force_global: bool = force_global
 
@@ -2887,8 +2889,8 @@ class SlashApplicationCommand(SlashCommandMixin, BaseApplicationCommand, Autocom
         dm_permission: Optional[bool] = None,
         default_member_permissions: Optional[Union[Permissions, int]] = None,
         nsfw: bool = False,
-        integration_types: Optional[Iterable[IntegrationType]] = None,
-        contexts: Optional[Iterable[InteractionContextType]] = None,
+        integration_types: Optional[Iterable[Union[IntegrationType, int]]] = None,
+        contexts: Optional[Iterable[Union[InteractionContextType, int]]] = None,
         parent_cog: Optional[ClientCog] = None,
         force_global: bool = False,
     ) -> None:
@@ -2930,11 +2932,11 @@ class SlashApplicationCommand(SlashCommandMixin, BaseApplicationCommand, Autocom
                 Due to a discord limitation, this can only be set for the parent command in case of a subcommand.
 
             .. versionadded:: 2.4
-        integration_types: Optional[Iterable[:class:`IntegrationType`]]
+        integration_types: Optional[Iterable[Union[:class:`IntegrationType`, :class:`int`]]]
             Where the command is available, only for globally-scoped commands. Defaults to ``guild_install``.
 
             .. versionadded:: 3.0
-        contexts: Optional[Iterable[:class:`InteractionContextType`]]
+        contexts: Optional[Iterable[Union[:class:`InteractionContextType`, :class:`int`]]]
             Where the command can be used, only for globally-scoped commands. By default, all interaction context types included for new commands.
 
             .. versionadded:: 3.0
@@ -3077,8 +3079,8 @@ class UserApplicationCommand(BaseApplicationCommand):
         dm_permission: Optional[bool] = None,
         default_member_permissions: Optional[Union[Permissions, int]] = None,
         nsfw: bool = False,
-        integration_types: Optional[Iterable[IntegrationType]] = None,
-        contexts: Optional[Iterable[InteractionContextType]] = None,
+        integration_types: Optional[Iterable[Union[IntegrationType, int]]] = None,
+        contexts: Optional[Iterable[Union[InteractionContextType, int]]] = None,
         parent_cog: Optional[ClientCog] = None,
         force_global: bool = False,
     ) -> None:
@@ -3111,11 +3113,11 @@ class UserApplicationCommand(BaseApplicationCommand):
             Whether the command can only be used in age-restricted channels. Defaults to ``False``.
 
             .. versionadded:: 2.4
-        integration_types: Optional[Iterable[:class:`IntegrationType`]]
+        integration_types: Optional[Iterable[Union[:class:`IntegrationType`, :class:`int`]]]
             Where the command is available, only for globally-scoped commands. Defaults to ``guild_install``.
 
             .. versionadded:: 3.0
-        contexts: Optional[Iterable[:class:`InteractionContextType`]]
+        contexts: Optional[Iterable[Union[:class:`InteractionContextType`, :class:`int`]]]
             Where the command can be used, only for globally-scoped commands. By default, all interaction context types included for new commands.
 
             .. versionadded:: 3.0
@@ -3175,8 +3177,8 @@ class MessageApplicationCommand(BaseApplicationCommand):
         dm_permission: Optional[bool] = None,
         default_member_permissions: Optional[Union[Permissions, int]] = None,
         nsfw: bool = False,
-        integration_types: Optional[Iterable[IntegrationType]] = None,
-        contexts: Optional[Iterable[InteractionContextType]] = None,
+        integration_types: Optional[Iterable[Union[IntegrationType, int]]] = None,
+        contexts: Optional[Iterable[Union[InteractionContextType, int]]] = None,
         parent_cog: Optional[ClientCog] = None,
         force_global: bool = False,
     ) -> None:
@@ -3209,11 +3211,11 @@ class MessageApplicationCommand(BaseApplicationCommand):
             Whether the command can only be used in age-restricted channels. Defaults to ``False``.
 
             .. versionadded:: 2.4
-        integration_types: Optional[Iterable[:class:`IntegrationType`]]
+        integration_types: Optional[Iterable[Union[:class:`IntegrationType`, :class:`int`]]]
             Where the command is available, only for globally-scoped commands. Defaults to ``guild_install``.
 
             .. versionadded:: 3.0
-        contexts: Optional[Iterable[:class:`InteractionContextType`]]
+        contexts: Optional[Iterable[Union[:class:`InteractionContextType`, :class:`int`]]]
             Where the command can be used, only for globally-scoped commands. By default, all interaction context types included for new commands.
 
             .. versionadded:: 3.0
@@ -3270,8 +3272,8 @@ def slash_command(
     dm_permission: Optional[bool] = None,
     default_member_permissions: Optional[Union[Permissions, int]] = None,
     nsfw: bool = False,
-    integration_types: Optional[Iterable[IntegrationType]] = None,
-    contexts: Optional[Iterable[InteractionContextType]] = None,
+    integration_types: Optional[Iterable[Union[IntegrationType, int]]] = None,
+    contexts: Optional[Iterable[Union[InteractionContextType, int]]] = None,
     force_global: bool = False,
 ):
     """Creates a Slash application command from the decorated function.
@@ -3313,11 +3315,11 @@ def slash_command(
             Due to a discord limitation, this can only be set for the parent command in case of a subcommand.
 
         .. versionadded:: 2.4
-    integration_types: Optional[Iterable[:class:`IntegrationType`]]
+    integration_types: Optional[Iterable[Union[:class:`IntegrationType`, :class:`int`]]]
         Where the command is available, only for globally-scoped commands. Defaults to ``guild_install``.
 
         .. versionadded:: 3.0
-    contexts: Optional[Iterable[:class:`InteractionContextType`]]
+    contexts: Optional[Iterable[Union[:class:`InteractionContextType`, :class:`int`]]]
         Where the command can be used, only for globally-scoped commands. By default, all interaction context types included for new commands.
 
         .. versionadded:: 3.0
@@ -3356,8 +3358,8 @@ def message_command(
     dm_permission: Optional[bool] = None,
     default_member_permissions: Optional[Union[Permissions, int]] = None,
     nsfw: bool = False,
-    integration_types: Optional[Iterable[IntegrationType]] = None,
-    contexts: Optional[Iterable[InteractionContextType]] = None,
+    integration_types: Optional[Iterable[Union[IntegrationType, int]]] = None,
+    contexts: Optional[Iterable[Union[InteractionContextType, int]]] = None,
     force_global: bool = False,
 ):
     """Creates a Message context command from the decorated function.
@@ -3389,11 +3391,11 @@ def message_command(
         Whether the command can only be used in age-restricted channels. Defaults to ``False``.
 
         .. versionadded:: 2.4
-    integration_types: Optional[Iterable[:class:`IntegrationType`]]
+    integration_types: Optional[Iterable[Union[:class:`IntegrationType`, :class:`int`]]]
         Where the command is available, only for globally-scoped commands. Defaults to ``guild_install``.
 
         .. versionadded:: 3.0
-    contexts: Optional[Iterable[:class:`InteractionContextType`]]
+    contexts: Optional[Iterable[Union[:class:`InteractionContextType`, :class:`int`]]]
         Where the command can be used, only for globally-scoped commands. By default, all interaction context types included for new commands.
 
         .. versionadded:: 3.0
@@ -3430,8 +3432,8 @@ def user_command(
     dm_permission: Optional[bool] = None,
     default_member_permissions: Optional[Union[Permissions, int]] = None,
     nsfw: bool = False,
-    integration_types: Optional[Iterable[IntegrationType]] = None,
-    contexts: Optional[Iterable[InteractionContextType]] = None,
+    integration_types: Optional[Iterable[Union[IntegrationType, int]]] = None,
+    contexts: Optional[Iterable[Union[InteractionContextType, int]]] = None,
     force_global: bool = False,
 ):
     """Creates a User context command from the decorated function.
@@ -3463,11 +3465,11 @@ def user_command(
         Whether the command can only be used in age-restricted channels. Defaults to ``False``.
 
         .. versionadded:: 2.4
-    integration_types: Optional[Iterable[:class:`IntegrationType`]]
+    integration_types: Optional[Iterable[Union[:class:`IntegrationType`, :class:`int`]]]
         Where the command is available, only for globally-scoped commands. Defaults to ``guild_install``.
 
         .. versionadded:: 3.0
-    contexts: Optional[Iterable[:class:`InteractionContextType`]]
+    contexts: Optional[Iterable[Union[:class:`InteractionContextType`, :class:`int`]]]
         Where the command can be used, only for globally-scoped commands. By default, all interaction context types included for new commands.
 
         .. versionadded:: 3.0

--- a/nextcord/application_command.py
+++ b/nextcord/application_command.py
@@ -2008,7 +2008,7 @@ class BaseApplicationCommand(CallbackMixin, CallbackWrapperMixin):
 
             .. versionadded:: 3.0
         contexts: Optional[Iterable[Union[:class:`InteractionContextType`, :class:`int`]]]
-            Where the command can be used, only for globally-scoped commands. By default, all interaction context types included for new commands.
+            Where the command can be used, only for globally-scoped commands. By default, all interaction context types are included for new commands.
 
             .. versionadded:: 3.0
         parent_cog: Optional[:class:`ClientCog`]

--- a/nextcord/application_command.py
+++ b/nextcord/application_command.py
@@ -45,9 +45,9 @@ from .enums import (
     ApplicationCommandOptionType,
     ApplicationCommandType,
     ChannelType,
-    Locale,
     IntegrationType,
-    InteractionContextType
+    InteractionContextType,
+    Locale,
 )
 from .errors import (
     ApplicationCheckFailure,
@@ -2394,7 +2394,9 @@ class BaseApplicationCommand(CallbackMixin, CallbackWrapperMixin):
                 return False
 
         # Default value for returned "integration_types" when not specified at registration is [0] (only guild_install)
-        if set(cmd_payload.get("integration_types", [0])) != set(raw_payload.get("integration_types", [0])):
+        if set(cmd_payload.get("integration_types", [0])) != set(
+            raw_payload.get("integration_types", [0])
+        ):
             _log.debug("Integration types between commands not equal, not valid payload.")
             return False
 

--- a/nextcord/application_command.py
+++ b/nextcord/application_command.py
@@ -2037,10 +2037,7 @@ class BaseApplicationCommand(CallbackMixin, CallbackWrapperMixin):
         if dm_permission is not None:
             if contexts is not None:
                 raise ValueError("Cannot pass both contexts and dm_permission")
-            if dm_permission:
-                contexts = [InteractionContextType.bot_dm]
-            else:
-                contexts = []
+            contexts = [InteractionContextType.bot_dm] if dm_permission else []
             if integration_types is None or IntegrationType.guild_install in integration_types:
                 contexts.append(InteractionContextType.guild)
         self.contexts = contexts

--- a/nextcord/application_command.py
+++ b/nextcord/application_command.py
@@ -1957,7 +1957,6 @@ class BaseApplicationCommand(CallbackMixin, CallbackWrapperMixin):
         description_localizations: Optional[Dict[Union[Locale, str], str]] = None,
         callback: Optional[Callable] = None,
         guild_ids: Optional[Iterable[int]] = MISSING,
-        dm_permission: Optional[bool] = None,
         default_member_permissions: Optional[Union[Permissions, int]] = None,
         nsfw: bool = False,
         integration_types: Optional[Iterable[Union[IntegrationType, int]]] = None,
@@ -1988,13 +1987,6 @@ class BaseApplicationCommand(CallbackMixin, CallbackWrapperMixin):
             An iterable list/set/whatever of guild ID's that the application command should register to.
             If not passed and :attr:`Client.default_guild_ids` is set, then those default guild ids will
             be used instead. If both of those are unset, then the command will be a global command.
-        dm_permission: :class:`bool`
-            If the command should be usable in DMs or not. Setting to ``False`` will disable the command from being
-            usable in DMs. Only for global commands, but will not error on guild.
-
-            .. warning::
-                This field is deprecated, use ``contexts`` instead.
-            .. deprecated:: 3.0
         default_member_permissions: Optional[Union[:class:`Permissions`, :class:`int`]]
             Permission(s) required to use the command. Inputting ``8`` or ``Permissions(administrator=True)`` for
             example will only allow Administrators to use the command. If set to 0, nobody will be able to use it by
@@ -2036,12 +2028,6 @@ class BaseApplicationCommand(CallbackMixin, CallbackWrapperMixin):
             None if integration_types is None else [IntegrationType(x) for x in integration_types]
         )
 
-        if dm_permission is not None:
-            if contexts is not None:
-                raise ValueError("Cannot pass both contexts and dm_permission")
-            contexts = [InteractionContextType.bot_dm] if dm_permission else []
-            if integration_types is None or IntegrationType.guild_install in integration_types:
-                contexts.append(InteractionContextType.guild)
         self.contexts = None if contexts is None else [InteractionContextType(x) for x in contexts]
 
         self.force_global: bool = force_global
@@ -2859,7 +2845,6 @@ class SlashApplicationCommand(SlashCommandMixin, BaseApplicationCommand, Autocom
         description_localizations: Optional[Dict[Union[Locale, str], str]] = None,
         callback: Optional[Callable] = None,
         guild_ids: Optional[Iterable[int]] = None,
-        dm_permission: Optional[bool] = None,
         default_member_permissions: Optional[Union[Permissions, int]] = None,
         nsfw: bool = False,
         integration_types: Optional[Iterable[Union[IntegrationType, int]]] = None,
@@ -2886,13 +2871,6 @@ class SlashApplicationCommand(SlashCommandMixin, BaseApplicationCommand, Autocom
             Callback to make the application command from, and to run when the application command is called.
         guild_ids: Iterable[:class:`int`]
             An iterable list of guild ID's that the application command should register to.
-        dm_permission: :class:`bool`
-            If the command should be usable in DMs or not. Setting to ``False`` will disable the command from being
-            usable in DMs. Only for global commands.
-
-            .. warning::
-                This field is deprecated, use ``contexts`` instead.
-            .. deprecated:: 3.0
         default_member_permissions: Optional[Union[:class:`Permissions`, :class:`int`]]
             Permission(s) required to use the command. Inputting ``8`` or ``Permissions(administrator=True)`` for
             example will only allow Administrators to use the command. If set to 0, nobody will be able to use it by
@@ -2928,7 +2906,6 @@ class SlashApplicationCommand(SlashCommandMixin, BaseApplicationCommand, Autocom
             cmd_type=ApplicationCommandType.chat_input,
             guild_ids=guild_ids,
             default_member_permissions=default_member_permissions,
-            dm_permission=dm_permission,
             nsfw=nsfw,
             integration_types=integration_types,
             contexts=contexts,
@@ -3049,7 +3026,6 @@ class UserApplicationCommand(BaseApplicationCommand):
         name_localizations: Optional[Dict[Union[Locale, str], str]] = None,
         callback: Optional[Callable] = None,
         guild_ids: Optional[Iterable[int]] = None,
-        dm_permission: Optional[bool] = None,
         default_member_permissions: Optional[Union[Permissions, int]] = None,
         nsfw: bool = False,
         integration_types: Optional[Iterable[Union[IntegrationType, int]]] = None,
@@ -3071,13 +3047,6 @@ class UserApplicationCommand(BaseApplicationCommand):
             Callback to run with the application command is called.
         guild_ids: Iterable[:class:`int`]
             An iterable list of guild ID's that the application command should register to.
-        dm_permission: :class:`bool`
-            If the command should be usable in DMs or not. Setting to ``False`` will disable the command from being
-            usable in DMs. Only for global commands, but will not error on guild.
-
-            .. warning::
-                This field is deprecated, use ``contexts`` instead.
-            .. deprecated:: 3.0
         default_member_permissions: Optional[Union[:class:`Permissions`, :class:`int`]]
             Permission(s) required to use the command. Inputting ``8`` or ``Permissions(administrator=True)`` for
             example will only allow Administrators to use the command. If set to 0, nobody will be able to use it by
@@ -3106,7 +3075,6 @@ class UserApplicationCommand(BaseApplicationCommand):
             callback=callback,
             cmd_type=ApplicationCommandType.user,
             guild_ids=guild_ids,
-            dm_permission=dm_permission,
             default_member_permissions=default_member_permissions,
             nsfw=nsfw,
             integration_types=integration_types,
@@ -3147,7 +3115,6 @@ class MessageApplicationCommand(BaseApplicationCommand):
         name_localizations: Optional[Dict[Union[Locale, str], str]] = None,
         callback: Optional[Callable] = None,
         guild_ids: Optional[Iterable[int]] = None,
-        dm_permission: Optional[bool] = None,
         default_member_permissions: Optional[Union[Permissions, int]] = None,
         nsfw: bool = False,
         integration_types: Optional[Iterable[Union[IntegrationType, int]]] = None,
@@ -3169,13 +3136,6 @@ class MessageApplicationCommand(BaseApplicationCommand):
             Callback to run with the application command is called.
         guild_ids: Iterable[:class:`int`]
             An iterable list of guild ID's that the application command should register to.
-        dm_permission: :class:`bool`
-            If the command should be usable in DMs or not. Setting to ``False`` will disable the command from being
-            usable in DMs. Only for global commands, but will not error on guild.
-
-            .. warning::
-                This field is deprecated, use ``contexts`` instead.
-            .. deprecated:: 3.0
         default_member_permissions: Optional[Union[:class:`Permissions`, :class:`int`]]
             Permission(s) required to use the command. Inputting ``8`` or ``Permissions(administrator=True)`` for
             example will only allow Administrators to use the command. If set to 0, nobody will be able to use it by
@@ -3204,7 +3164,6 @@ class MessageApplicationCommand(BaseApplicationCommand):
             callback=callback,
             cmd_type=ApplicationCommandType.message,
             guild_ids=guild_ids,
-            dm_permission=dm_permission,
             default_member_permissions=default_member_permissions,
             nsfw=nsfw,
             integration_types=integration_types,
@@ -3242,7 +3201,6 @@ def slash_command(
     name_localizations: Optional[Dict[Union[Locale, str], str]] = None,
     description_localizations: Optional[Dict[Union[Locale, str], str]] = None,
     guild_ids: Optional[Iterable[int]] = MISSING,
-    dm_permission: Optional[bool] = None,
     default_member_permissions: Optional[Union[Permissions, int]] = None,
     nsfw: bool = False,
     integration_types: Optional[Iterable[Union[IntegrationType, int]]] = None,
@@ -3269,13 +3227,6 @@ def slash_command(
         IDs of :class:`Guild`'s to add this command to. If not passed and :attr:`Client.default_guild_ids` is
         set, then those default guild ids will be used instead. If both of those are unset, then the command will
         be a global command.
-    dm_permission: :class:`bool`
-        If the command should be usable in DMs or not. Setting to ``False`` will disable the command from being
-        usable in DMs. Only for global commands, but will not error on guild.
-
-        .. warning::
-            This field is deprecated, use ``contexts`` instead.
-        .. deprecated:: 3.0
     default_member_permissions: Optional[Union[:class:`Permissions`, :class:`int`]]
         Permission(s) required to use the command. Inputting ``8`` or ``Permissions(administrator=True)`` for
         example will only allow Administrators to use the command. If set to 0, nobody will be able to use it by
@@ -3312,7 +3263,6 @@ def slash_command(
             description=description,
             description_localizations=description_localizations,
             guild_ids=guild_ids,
-            dm_permission=dm_permission,
             default_member_permissions=default_member_permissions,
             nsfw=nsfw,
             integration_types=integration_types,
@@ -3328,7 +3278,6 @@ def message_command(
     *,
     name_localizations: Optional[Dict[Union[Locale, str], str]] = None,
     guild_ids: Optional[Iterable[int]] = MISSING,
-    dm_permission: Optional[bool] = None,
     default_member_permissions: Optional[Union[Permissions, int]] = None,
     nsfw: bool = False,
     integration_types: Optional[Iterable[Union[IntegrationType, int]]] = None,
@@ -3349,13 +3298,6 @@ def message_command(
         IDs of :class:`Guild`'s to add this command to. If not passed and :attr:`Client.default_guild_ids` is
         set, then those default guild ids will be used instead. If both of those are unset, then the command will
         be a global command.
-    dm_permission: :class:`bool`
-        If the command should be usable in DMs or not. Setting to ``False`` will disable the command from being
-        usable in DMs. Only for global commands, but will not error on guild.
-
-        .. warning::
-            This field is deprecated, use ``contexts`` instead.
-        .. deprecated:: 3.0
     default_member_permissions: Optional[Union[:class:`Permissions`, :class:`int`]]
         Permission(s) required to use the command. Inputting ``8`` or ``Permissions(administrator=True)`` for
         example will only allow Administrators to use the command. If set to 0, nobody will be able to use it by
@@ -3386,7 +3328,6 @@ def message_command(
             name=name,
             name_localizations=name_localizations,
             guild_ids=guild_ids,
-            dm_permission=dm_permission,
             default_member_permissions=default_member_permissions,
             nsfw=nsfw,
             integration_types=integration_types,
@@ -3402,7 +3343,6 @@ def user_command(
     *,
     name_localizations: Optional[Dict[Union[Locale, str], str]] = None,
     guild_ids: Optional[Iterable[int]] = MISSING,
-    dm_permission: Optional[bool] = None,
     default_member_permissions: Optional[Union[Permissions, int]] = None,
     nsfw: bool = False,
     integration_types: Optional[Iterable[Union[IntegrationType, int]]] = None,
@@ -3423,13 +3363,6 @@ def user_command(
         IDs of :class:`Guild`'s to add this command to. If not passed and :attr:`Client.default_guild_ids` is
         set, then those default guild ids will be used instead. If both of those are unset, then the command will
         be a global command.
-    dm_permission: :class:`bool`
-        If the command should be usable in DMs or not. Setting to ``False`` will disable the command from being
-        usable in DMs. Only for global commands, but will not error on guild.
-
-        .. warning::
-            This field is deprecated, use ``contexts`` instead.
-        .. deprecated:: 3.0
     default_member_permissions: Optional[Union[:class:`Permissions`, :class:`int`]]
         Permission(s) required to use the command. Inputting ``8`` or ``Permissions(administrator=True)`` for
         example will only allow Administrators to use the command. If set to 0, nobody will be able to use it by
@@ -3460,7 +3393,6 @@ def user_command(
             name=name,
             name_localizations=name_localizations,
             guild_ids=guild_ids,
-            dm_permission=dm_permission,
             default_member_permissions=default_member_permissions,
             nsfw=nsfw,
             integration_types=integration_types,

--- a/nextcord/client.py
+++ b/nextcord/client.py
@@ -77,7 +77,7 @@ if TYPE_CHECKING:
     from .application_command import BaseApplicationCommand, ClientCog, SlashApplicationSubcommand
     from .asset import Asset
     from .channel import DMChannel
-    from .enums import Locale
+    from .enums import IntegrationType, InteractionContextType, Locale
     from .file import File
     from .flags import MemberCacheFlags
     from .member import Member
@@ -2682,6 +2682,8 @@ class Client:
         dm_permission: Optional[bool] = None,
         default_member_permissions: Optional[Union[Permissions, int]] = None,
         nsfw: bool = False,
+        integration_types: Optional[Iterable[IntegrationType]] = None,
+        contexts: Optional[Iterable[InteractionContextType]] = None,
         force_global: bool = False,
     ):
         """Creates a User context command from the decorated function.
@@ -2708,6 +2710,14 @@ class Client:
             Whether the command can only be used in age-restricted channels. Defaults to ``False``.
 
             .. versionadded:: 2.4
+        integration_types: Optional[Iterable[:class:`IntegrationType`]]
+            Where the command is available, only for globally-scoped commands. Defaults to ``guild_install``.
+
+            .. versionadded:: 3.0
+        contexts: Optional[Iterable[:class:`InteractionContextType`]]
+            Where the command can be used, only for globally-scoped commands. By default, all interaction context types included for new commands.
+
+            .. versionadded:: 3.0
         force_global: :class:`bool`
             If True, will force this command to register as a global command, even if ``guild_ids`` is set. Will still
             register to guilds. Has no effect if ``guild_ids`` are never set or added to.
@@ -2721,6 +2731,8 @@ class Client:
                 dm_permission=dm_permission,
                 default_member_permissions=default_member_permissions,
                 nsfw=nsfw,
+                integration_types=integration_types,
+                contexts=contexts,
                 force_global=force_global,
             )(func)
             self._application_commands_to_add.add(result)
@@ -2737,6 +2749,8 @@ class Client:
         dm_permission: Optional[bool] = None,
         default_member_permissions: Optional[Union[Permissions, int]] = None,
         nsfw: bool = False,
+        integration_types: Optional[Iterable[IntegrationType]] = None,
+        contexts: Optional[Iterable[InteractionContextType]] = None,
         force_global: bool = False,
     ):
         """Creates a Message context command from the decorated function.
@@ -2763,6 +2777,14 @@ class Client:
             Whether the command can only be used in age-restricted channels. Defaults to ``False``.
 
             .. versionadded:: 2.4
+        integration_types: Optional[Iterable[:class:`IntegrationType`]]
+            Where the command is available, only for globally-scoped commands. Defaults to ``guild_install``.
+
+            .. versionadded:: 3.0
+        contexts: Optional[Iterable[:class:`InteractionContextType`]]
+            Where the command can be used, only for globally-scoped commands. By default, all interaction context types included for new commands.
+
+            .. versionadded:: 3.0
         force_global: :class:`bool`
             If True, will force this command to register as a global command, even if ``guild_ids`` is set. Will still
             register to guilds. Has no effect if ``guild_ids`` are never set or added to.
@@ -2775,6 +2797,9 @@ class Client:
                 guild_ids=guild_ids,
                 dm_permission=dm_permission,
                 default_member_permissions=default_member_permissions,
+                nsfw=nsfw,
+                integration_types=integration_types,
+                contexts=contexts,
                 force_global=force_global,
             )(func)
             self._application_commands_to_add.add(result)
@@ -2793,6 +2818,8 @@ class Client:
         dm_permission: Optional[bool] = None,
         nsfw: bool = False,
         default_member_permissions: Optional[Union[Permissions, int]] = None,
+        integration_types: Optional[Iterable[IntegrationType]] = None,
+        contexts: Optional[Iterable[InteractionContextType]] = None,
         force_global: bool = False,
     ):
         """Creates a Slash application command from the decorated function.
@@ -2825,6 +2852,14 @@ class Client:
             Whether the command can only be used in age-restricted channels. Defaults to ``False``.
 
             .. versionadded:: 2.4
+        integration_types: Optional[Iterable[:class:`IntegrationType`]]
+            Where the command is available, only for globally-scoped commands. Defaults to ``guild_install``.
+
+            .. versionadded:: 3.0
+        contexts: Optional[Iterable[:class:`InteractionContextType`]]
+            Where the command can be used, only for globally-scoped commands. By default, all interaction context types included for new commands.
+
+            .. versionadded:: 3.0
         force_global: :class:`bool`
             If True, will force this command to register as a global command, even if ``guild_ids`` is set. Will still
             register to guilds. Has no effect if ``guild_ids`` are never set or added to.
@@ -2840,6 +2875,8 @@ class Client:
                 dm_permission=dm_permission,
                 default_member_permissions=default_member_permissions,
                 nsfw=nsfw,
+                integration_types=integration_types,
+                contexts=contexts,
                 force_global=force_global,
             )(func)
             self._application_commands_to_add.add(result)

--- a/nextcord/client.py
+++ b/nextcord/client.py
@@ -2586,7 +2586,6 @@ class Client:
         *,
         name_localizations: Optional[Dict[Union[Locale, str], str]] = None,
         guild_ids: Optional[Iterable[int]] = MISSING,
-        dm_permission: Optional[bool] = None,
         default_member_permissions: Optional[Union[Permissions, int]] = None,
         nsfw: bool = False,
         integration_types: Optional[Iterable[Union[IntegrationType, int]]] = None,
@@ -2606,9 +2605,6 @@ class Client:
             IDs of :class:`Guild`'s to add this command to. If not passed and :attr:`Client.default_guild_ids` is
             set, then those default guild ids will be used instead. If both of those are unset, then the command will
             be a global command.
-        dm_permission: :class:`bool`
-            If the command should be usable in DMs or not. Setting to ``False`` will disable the command from being
-            usable in DMs. Only for global commands, but will not error on guild.
         default_member_permissions: Optional[Union[:class:`Permissions`, :class:`int`]]
             Permission(s) required to use the command. Inputting ``8`` or ``Permissions(administrator=True)`` for
             example will only allow Administrators to use the command. If set to 0, nobody will be able to use it by
@@ -2635,7 +2631,6 @@ class Client:
                 name=name,
                 name_localizations=name_localizations,
                 guild_ids=guild_ids,
-                dm_permission=dm_permission,
                 default_member_permissions=default_member_permissions,
                 nsfw=nsfw,
                 integration_types=integration_types,
@@ -2653,7 +2648,6 @@ class Client:
         *,
         name_localizations: Optional[Dict[Union[Locale, str], str]] = None,
         guild_ids: Optional[Iterable[int]] = MISSING,
-        dm_permission: Optional[bool] = None,
         default_member_permissions: Optional[Union[Permissions, int]] = None,
         nsfw: bool = False,
         integration_types: Optional[Iterable[Union[IntegrationType, int]]] = None,
@@ -2673,9 +2667,6 @@ class Client:
             IDs of :class:`Guild`'s to add this command to. If not passed and :attr:`Client.default_guild_ids` is
             set, then those default guild ids will be used instead. If both of those are unset, then the command will
             be a global command.
-        dm_permission: :class:`bool`
-            If the command should be usable in DMs or not. Setting to ``False`` will disable the command from being
-            usable in DMs. Only for global commands, but will not error on guild.
         default_member_permissions: Optional[Union[:class:`Permissions`, :class:`int`]]
             Permission(s) required to use the command. Inputting ``8`` or ``Permissions(administrator=True)`` for
             example will only allow Administrators to use the command. If set to 0, nobody will be able to use it by
@@ -2702,7 +2693,6 @@ class Client:
                 name=name,
                 name_localizations=name_localizations,
                 guild_ids=guild_ids,
-                dm_permission=dm_permission,
                 default_member_permissions=default_member_permissions,
                 nsfw=nsfw,
                 integration_types=integration_types,
@@ -2722,7 +2712,6 @@ class Client:
         name_localizations: Optional[Dict[Union[Locale, str], str]] = None,
         description_localizations: Optional[Dict[Union[Locale, str], str]] = None,
         guild_ids: Optional[Iterable[int]] = MISSING,
-        dm_permission: Optional[bool] = None,
         nsfw: bool = False,
         default_member_permissions: Optional[Union[Permissions, int]] = None,
         integration_types: Optional[Iterable[Union[IntegrationType, int]]] = None,
@@ -2748,9 +2737,6 @@ class Client:
             IDs of :class:`Guild`'s to add this command to. If not passed and :attr:`Client.default_guild_ids` is
             set, then those default guild ids will be used instead. If both of those are unset, then the command will
             be a global command.
-        dm_permission: :class:`bool`
-            If the command should be usable in DMs or not. Setting to ``False`` will disable the command from being
-            usable in DMs. Only for global commands, but will not error on guild.
         default_member_permissions: Optional[Union[:class:`Permissions`, :class:`int`]]
             Permission(s) required to use the command. Inputting ``8`` or ``Permissions(administrator=True)`` for
             example will only allow Administrators to use the command. If set to 0, nobody will be able to use it by
@@ -2779,7 +2765,6 @@ class Client:
                 description=description,
                 description_localizations=description_localizations,
                 guild_ids=guild_ids,
-                dm_permission=dm_permission,
                 default_member_permissions=default_member_permissions,
                 nsfw=nsfw,
                 integration_types=integration_types,

--- a/nextcord/client.py
+++ b/nextcord/client.py
@@ -2682,8 +2682,8 @@ class Client:
         dm_permission: Optional[bool] = None,
         default_member_permissions: Optional[Union[Permissions, int]] = None,
         nsfw: bool = False,
-        integration_types: Optional[Iterable[IntegrationType]] = None,
-        contexts: Optional[Iterable[InteractionContextType]] = None,
+        integration_types: Optional[Iterable[Union[IntegrationType, int]]] = None,
+        contexts: Optional[Iterable[Union[InteractionContextType, int]]] = None,
         force_global: bool = False,
     ):
         """Creates a User context command from the decorated function.
@@ -2710,11 +2710,11 @@ class Client:
             Whether the command can only be used in age-restricted channels. Defaults to ``False``.
 
             .. versionadded:: 2.4
-        integration_types: Optional[Iterable[:class:`IntegrationType`]]
+        integration_types: Optional[Iterable[Union[:class:`IntegrationType`, :class:`int`]]]
             Where the command is available, only for globally-scoped commands. Defaults to ``guild_install``.
 
             .. versionadded:: 3.0
-        contexts: Optional[Iterable[:class:`InteractionContextType`]]
+        contexts: Optional[Iterable[Union[:class:`InteractionContextType`, :class:`int`]]]
             Where the command can be used, only for globally-scoped commands. By default, all interaction context types included for new commands.
 
             .. versionadded:: 3.0
@@ -2749,8 +2749,8 @@ class Client:
         dm_permission: Optional[bool] = None,
         default_member_permissions: Optional[Union[Permissions, int]] = None,
         nsfw: bool = False,
-        integration_types: Optional[Iterable[IntegrationType]] = None,
-        contexts: Optional[Iterable[InteractionContextType]] = None,
+        integration_types: Optional[Iterable[Union[IntegrationType, int]]] = None,
+        contexts: Optional[Iterable[Union[InteractionContextType, int]]] = None,
         force_global: bool = False,
     ):
         """Creates a Message context command from the decorated function.
@@ -2777,11 +2777,11 @@ class Client:
             Whether the command can only be used in age-restricted channels. Defaults to ``False``.
 
             .. versionadded:: 2.4
-        integration_types: Optional[Iterable[:class:`IntegrationType`]]
+        integration_types: Optional[Iterable[Union[:class:`IntegrationType`, :class:`int`]]]
             Where the command is available, only for globally-scoped commands. Defaults to ``guild_install``.
 
             .. versionadded:: 3.0
-        contexts: Optional[Iterable[:class:`InteractionContextType`]]
+        contexts: Optional[Iterable[Union[:class:`InteractionContextType`, :class:`int`]]]
             Where the command can be used, only for globally-scoped commands. By default, all interaction context types included for new commands.
 
             .. versionadded:: 3.0
@@ -2818,8 +2818,8 @@ class Client:
         dm_permission: Optional[bool] = None,
         nsfw: bool = False,
         default_member_permissions: Optional[Union[Permissions, int]] = None,
-        integration_types: Optional[Iterable[IntegrationType]] = None,
-        contexts: Optional[Iterable[InteractionContextType]] = None,
+        integration_types: Optional[Iterable[Union[IntegrationType, int]]] = None,
+        contexts: Optional[Iterable[Union[InteractionContextType, int]]] = None,
         force_global: bool = False,
     ):
         """Creates a Slash application command from the decorated function.
@@ -2852,11 +2852,11 @@ class Client:
             Whether the command can only be used in age-restricted channels. Defaults to ``False``.
 
             .. versionadded:: 2.4
-        integration_types: Optional[Iterable[:class:`IntegrationType`]]
+        integration_types: Optional[Iterable[Union[:class:`IntegrationType`, :class:`int`]]]
             Where the command is available, only for globally-scoped commands. Defaults to ``guild_install``.
 
             .. versionadded:: 3.0
-        contexts: Optional[Iterable[:class:`InteractionContextType`]]
+        contexts: Optional[Iterable[Union[:class:`InteractionContextType`, :class:`int`]]]
             Where the command can be used, only for globally-scoped commands. By default, all interaction context types included for new commands.
 
             .. versionadded:: 3.0

--- a/nextcord/enums.py
+++ b/nextcord/enums.py
@@ -2040,29 +2040,29 @@ class ForumLayoutType(IntEnum):
 
 
 class IntegrationType(IntEnum):
-    """Where the :class:`BaseApplicationCommand` is available, only for globally-scoped commands
+    """Where the :class:`BaseApplicationCommand` is available, only for globally-scoped commands.
 
     .. versionadded:: 3.0
     """
 
     guild_install = 0
-    """App is installable to servers"""
+    """App is installable to servers."""
     user_install = 1
-    """App is installable to users"""
+    """App is installable to users."""
 
 
 class InteractionContextType(IntEnum):
-    """Where the :class:`BaseApplicationCommand` can be used, only for globally-scoped commands
+    """Where the :class:`BaseApplicationCommand` can be used, only for globally-scoped commands.
 
     .. versionadded:: 3.0
     """
 
     guild = 0
-    """Interaction can be used within servers"""
+    """Interaction can be used within servers."""
     bot_dm = 1
-    """Interaction can be used within DMs with the app's bot user"""
+    """Interaction can be used within DMs with the app's bot user."""
     private_channel = 2
-    """Interaction can be used within Group DMs and DMs other than the app's bot user"""
+    """Interaction can be used within Group DMs and DMs other than the app's bot user."""
 
 
 T = TypeVar("T")

--- a/nextcord/enums.py
+++ b/nextcord/enums.py
@@ -50,7 +50,7 @@ __all__ = (
     "RoleConnectionMetadataType",
     "ForumLayoutType",
     "IntegrationType",
-    "InteractionContextType"
+    "InteractionContextType",
 )
 
 

--- a/nextcord/enums.py
+++ b/nextcord/enums.py
@@ -2040,7 +2040,7 @@ class ForumLayoutType(IntEnum):
 
 
 class IntegrationType(IntEnum):
-    """Where the :class:`BaseApplicationCommand` is available, only for globally-scoped commands.
+    """Where a :class:`BaseApplicationCommand` is available, only for globally-scoped commands.
 
     .. versionadded:: 3.0
     """
@@ -2052,17 +2052,17 @@ class IntegrationType(IntEnum):
 
 
 class InteractionContextType(IntEnum):
-    """Where the :class:`BaseApplicationCommand` can be used, only for globally-scoped commands.
+    """Where a :class:`BaseApplicationCommand` can be used, only for globally-scoped commands, or where a :class:`Interaction` originates from.
 
     .. versionadded:: 3.0
     """
 
     guild = 0
-    """Interaction can be used within servers."""
+    """The :class:`BaseApplicationCommand` can be used within servers, or the :class:`Interaction` originates from a server."""
     bot_dm = 1
-    """Interaction can be used within DMs with the app's bot user."""
+    """The :class:`BaseApplicationCommand` can be used within DMs with the app's bot user, or the :class:`Interaction` originates from such DMs."""
     private_channel = 2
-    """Interaction can be used within Group DMs and DMs other than the app's bot user."""
+    """The :class:`BaseApplicationCommand` can be used within Group DMs and DMs other than the app's bot user, or the :class:`Interaction` originates from such channels."""
 
 
 T = TypeVar("T")

--- a/nextcord/enums.py
+++ b/nextcord/enums.py
@@ -49,6 +49,8 @@ __all__ = (
     "SortOrderType",
     "RoleConnectionMetadataType",
     "ForumLayoutType",
+    "IntegrationType",
+    "InteractionContextType"
 )
 
 
@@ -2035,6 +2037,32 @@ class ForumLayoutType(IntEnum):
     """Display posts as a list, more text focused."""
     gallery = 2
     """Display posts as a collection of posts with images, this is more image focused."""
+
+
+class IntegrationType(IntEnum):
+    """Where the :class:`BaseApplicationCommand` is available, only for globally-scoped commands
+
+    .. versionadded:: 3.0
+    """
+
+    guild_install = 0
+    """App is installable to servers"""
+    user_install = 1
+    """App is installable to users"""
+
+
+class InteractionContextType(IntEnum):
+    """Where the :class:`BaseApplicationCommand` can be used, only for globally-scoped commands
+
+    .. versionadded:: 3.0
+    """
+
+    guild = 0
+    """Interaction can be used within servers"""
+    bot_dm = 1
+    """Interaction can be used within DMs with the app's bot user"""
+    private_channel = 2
+    """Interaction can be used within Group DMs and DMs other than the app's bot user"""
 
 
 T = TypeVar("T")

--- a/nextcord/interactions.py
+++ b/nextcord/interactions.py
@@ -268,12 +268,12 @@ class Interaction(Hashable, Generic[ClientT]):
             self.authorizing_integration_owners = None
         else:
             self.authorizing_integration_owners = {
-                IntegrationType(int(integration_type)): int(details)
+                try_enum(IntegrationType, int(integration_type)): int(details)
                 for integration_type, details in authorizing_integration_owners.items()
             }
 
         self.context: Optional[InteractionContextType] = (
-            InteractionContextType(data["context"]) if "context" in data else None
+            try_enum(InteractionContextType, data["context"]) if "context" in data else None
         )
 
     @property

--- a/nextcord/message.py
+++ b/nextcord/message.py
@@ -658,8 +658,6 @@ class MessageInteractionMetadata(Hashable):
         The interaction's ID.
     type: :class:`InteractionType`
         The interaction type.
-    user_id: :class:`abc.Snowflake`
-        The ID of the user who invoked the interaction.
     user: Union[:class:`User`, :class:`Member`]
         The :class:`User` who invoked the interaction or :class:`Member` if the interaction
         occurred in a guild and that member is cached.
@@ -685,7 +683,6 @@ class MessageInteractionMetadata(Hashable):
         "data",
         "id",
         "type",
-        "user_id",
         "user",
         "authorizing_integration_owners",
         "name",
@@ -706,7 +703,6 @@ class MessageInteractionMetadata(Hashable):
         self.data: MessageInteractionMetadataPayload = data
         self.id: int = int(data["id"])
         self.type: int = data["type"]
-        self.user_id: int = int(data["user_id"])
 
         # No member data is provided, retrieve from cache if possible
         self.user = None if guild is None else guild.get_member(self.user_id)

--- a/nextcord/message.py
+++ b/nextcord/message.py
@@ -26,7 +26,7 @@ from . import utils
 from .components import _component_factory
 from .embeds import Embed
 from .emoji import Emoji
-from .enums import ChannelType, MessageType, try_enum
+from .enums import ChannelType, IntegrationType, MessageType, try_enum
 from .errors import HTTPException, InvalidArgument
 from .file import File
 from .flags import AttachmentFlags, MessageFlags
@@ -50,7 +50,10 @@ if TYPE_CHECKING:
     from .state import ConnectionState
     from .types.components import Component as ComponentPayload
     from .types.embed import Embed as EmbedPayload
-    from .types.interactions import MessageInteraction as MessageInteractionPayload
+    from .types.interactions import (
+        MessageInteraction as MessageInteractionPayload,
+        MessageInteractionMetadata as MessageInteractionMetadataPayload,
+    )
     from .types.member import Member as MemberPayload, UserWithMember as UserWithMemberPayload
     from .types.message import (
         Attachment as AttachmentPayload,
@@ -74,6 +77,7 @@ __all__ = (
     "MessageReference",
     "DeletedReferencedMessage",
     "MessageInteraction",
+    "MessageInteractionMetadata",
 )
 
 
@@ -584,6 +588,10 @@ class MessageInteraction(Hashable):
     user: Union[:class:`User`, :class:`Member`]
         The :class:`User` who invoked the interaction or :class:`Member` if the interaction
         occurred in a guild.
+
+    .. warning::
+        This class is deprecated, use :attr:`Message.interaction_metadata` instead.
+    .. deprecated:: 3.0
     """
 
     __slots__ = (
@@ -618,6 +626,138 @@ class MessageInteraction(Hashable):
     def created_at(self) -> datetime.datetime:
         """:class:`datetime.datetime`: The interaction's creation time in UTC."""
         return utils.snowflake_time(self.id)
+
+
+class MessageInteractionMetadata(Hashable):
+    """Represents a message's interaction metadata.
+
+    A message's interaction metadata is a property of a message when the message
+    is a response to an interaction from any bot.
+
+    .. versionadded:: 3.0
+
+    .. container:: operations
+
+        .. describe:: x == y
+
+            Checks if two message interactions are equal.
+
+        .. describe:: x != y
+
+            Checks if two interaction messages are not equal.
+
+        .. describe:: hash(x)
+
+            Returns the message interaction's hash.
+
+    Attributes
+    ----------
+    data: Dict[:class:`str`, Any]
+        The raw data from the interaction metadata.
+    id: :class:`int`
+        The interaction's ID.
+    type: :class:`InteractionType`
+        The interaction type.
+    user_id: :class:`abc.Snowflake`
+        The ID of the user who invoked the interaction.
+    user: Union[:class:`User`, :class:`Member`]
+        The :class:`User` who invoked the interaction or :class:`Member` if the interaction
+        occurred in a guild and that member is cached.
+    authorizing_integration_owners: Dict[:class:`IntegrationType`, :class:`str`]
+        Mapping of installation contexts that the interaction was authorized for to related user or guild IDs.
+        You can find out about this field in the `official Discord documentation`__.
+
+        .. _DiscordDocs: https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-object-authorizing-integration-owners-object
+
+        .. versionadded:: 3.0
+    name: Optional[:class:`str`]
+        The name of the application command.
+    original_response_message_id: Optional[:class:`int`]
+        The ID of the original response message, present only on follow-up messages.
+    interacted_message_id: Optional[:class:`int`]
+        The ID of the message that contained the interactive component, present only on messages created from component interactions.
+    triggering_interaction_metadata: Optional[:class:`MessageInteractionMetadata`]
+        Metadata for the interaction that was used to open the modal, present only on modal submit interactions.
+    """
+
+    __slots__ = (
+        "_state",
+        "data",
+        "id",
+        "type",
+        "user_id",
+        "user",
+        "authorizing_integration_owners",
+        "name",
+        "original_response_message_id",
+        "interacted_message_id",
+        "triggering_interaction_metadata",
+    )
+
+    def __init__(
+        self,
+        *,
+        data: MessageInteractionMetadataPayload,
+        guild: Optional[Guild],
+        state: ConnectionState,
+    ) -> None:
+        self._state: ConnectionState = state
+
+        self.data: MessageInteractionMetadataPayload = data
+        self.id: int = int(data["id"])
+        self.type: int = data["type"]
+        self.user_id: int = int(data["user_id"])
+
+        # No member data is provided, retrieve from cache if possible
+        self.user = None if guild is None else guild.get_member(self.user_id)
+        if self.user is None:
+            self.user = self._state.create_user(data=data["user"])
+
+        self.authorizing_integration_owners: Dict[IntegrationType, int] = {
+            IntegrationType(int(integration_type)): int(details)
+            for integration_type, details in data["authorizing_integration_owners"].items()
+        }
+
+        self.name: Optional[str] = data.get("name")
+        self.original_response_message_id: Optional[int] = (
+            int(data["original_response_message_id"])
+            if "original_response_message_id" in data
+            else None
+        )
+        self.interacted_message_id: Optional[int] = (
+            int(data["interacted_message_id"]) if "interacted_message_id" in data else None
+        )
+        self.triggering_interaction_metadata: Optional[MessageInteractionMetadata] = (
+            MessageInteractionMetadata(
+                data=data["triggering_interaction_metadata"], guild=guild, state=state
+            )
+            if "triggering_interaction_metadata" in data
+            else None
+        )
+
+    def __repr__(self) -> str:
+        return (
+            f"<{self.__class__.__name__} id={self.id} type={self.type} user={self.user!r} "
+            f"authorizing_integration_owners={self.authorizing_integration_owners} name={self.name!r} "
+            f"original_response_message_id={self.original_response_message_id} "
+            f"interacted_message_id={self.interacted_message_id} "
+            f"triggering_interaction_metadata={self.triggering_interaction_metadata!r}>"
+        )
+
+    @property
+    def created_at(self) -> datetime.datetime:
+        """:class:`datetime.datetime`: The interaction's creation time in UTC."""
+        return utils.snowflake_time(self.id)
+
+    @property
+    def cached_original_response_message(self) -> Optional[Message]:
+        """Optional[:class:`~nextcord.Message`]: The original response message, if found in the internal message cache."""
+        return self._state._get_message(self.original_response_message_id)
+
+    @property
+    def cached_interacted_message(self) -> Optional[Message]:
+        """Optional[:class:`~nextcord.Message`]: The interacted message, if found in the internal message cache."""
+        return self._state._get_message(self.interacted_message_id)
 
 
 @flatten_handlers
@@ -737,6 +877,14 @@ class Message(Hashable):
         The guild that the message belongs to, if applicable.
     interaction: Optional[:class:`MessageInteraction`]
         The interaction data of a message, if applicable.
+
+        .. warning::
+            This field is deprecated, use ``interaction_metadata`` instead.
+        .. deprecated:: 3.0
+    interaction_metadata: Optional[:class:`MessageInteractionMetadata`]
+        The interaction metadata of a message. Present if the message is sent as a result of an interaction.
+
+        .. versionadded:: 3.0
     """
 
     __slots__ = (
@@ -756,6 +904,7 @@ class Message(Hashable):
         "embeds",
         "id",
         "interaction",
+        "interaction_metadata",
         "mentions",
         "author",
         "attachments",
@@ -869,6 +1018,13 @@ class Message(Hashable):
         self.interaction: Optional[MessageInteraction] = (
             MessageInteraction(data=data["interaction"], guild=self.guild, state=self._state)
             if "interaction" in data
+            else None
+        )
+        self.interaction_metadata: Optional[MessageInteractionMetadata] = (
+            MessageInteractionMetadata(
+                data=data["interaction_metadata"], guild=self.guild, state=self._state
+            )
+            if "interaction_metadata" in data
             else None
         )
 

--- a/nextcord/message.py
+++ b/nextcord/message.py
@@ -736,7 +736,7 @@ class MessageInteractionMetadata(Hashable):
         )
 
     def __repr__(self) -> str:
-        return f"<{self.__class__.__name__} id={self.id} type={self.type} user={self.user!r} name={self.name!r}"
+        return f"<{self.__class__.__name__} id={self.id} type={self.type} user={self.user!r} name={self.name!r}>"
 
     @property
     def created_at(self) -> datetime.datetime:

--- a/nextcord/message.py
+++ b/nextcord/message.py
@@ -736,13 +736,7 @@ class MessageInteractionMetadata(Hashable):
         )
 
     def __repr__(self) -> str:
-        return (
-            f"<{self.__class__.__name__} id={self.id} type={self.type} user={self.user!r} "
-            f"authorizing_integration_owners={self.authorizing_integration_owners} name={self.name!r} "
-            f"original_response_message_id={self.original_response_message_id} "
-            f"interacted_message_id={self.interacted_message_id} "
-            f"triggering_interaction_metadata={self.triggering_interaction_metadata!r}>"
-        )
+        return f"<{self.__class__.__name__} id={self.id} type={self.type} user={self.user!r} name={self.name!r}"
 
     @property
     def created_at(self) -> datetime.datetime:

--- a/nextcord/message.py
+++ b/nextcord/message.py
@@ -705,7 +705,7 @@ class MessageInteractionMetadata(Hashable):
         self.type: int = data["type"]
 
         # No member data is provided, retrieve from cache if possible
-        self.user = None if guild is None else guild.get_member(self.user_id)
+        self.user = None if guild is None else guild.get_member(int(data["user"]["id"]))
         if self.user is None:
             self.user = self._state.create_user(data=data["user"])
 

--- a/nextcord/types/appinfo.py
+++ b/nextcord/types/appinfo.py
@@ -2,13 +2,25 @@
 
 from __future__ import annotations
 
-from typing import List, Optional, TypedDict
+from typing import Dict, List, Literal, Optional, TypedDict
 
 from typing_extensions import NotRequired
 
 from .snowflake import Snowflake
 from .team import Team
 from .user import User
+
+
+class InstallParams(TypedDict):
+    scopes: List[str]
+    permissions: str
+
+
+class ApplicationIntegrationTypeConfig(TypedDict):
+    oauth2_install_params: NotRequired[InstallParams]
+
+
+IntegrationTypesConfig = Dict[Literal["0", "1"], ApplicationIntegrationTypeConfig]
 
 
 class BaseAppInfo(TypedDict):
@@ -18,6 +30,7 @@ class BaseAppInfo(TypedDict):
     icon: Optional[str]
     summary: str
     description: str
+    integration_types_config: NotRequired[IntegrationTypesConfig]
 
 
 class AppInfo(BaseAppInfo):

--- a/nextcord/types/interactions.py
+++ b/nextcord/types/interactions.py
@@ -34,7 +34,6 @@ class ApplicationCommand(TypedDict):
     guild_id: NotRequired[Snowflake]
     options: NotRequired[List[ApplicationCommandOption]]
     default_permission: NotRequired[bool]
-    dm_permission: NotRequired[bool]
     nsfw: NotRequired[bool]
     integration_types: NotRequired[List[IntegrationType]]
     contexts: NotRequired[List[InteractionContextType]]

--- a/nextcord/types/interactions.py
+++ b/nextcord/types/interactions.py
@@ -198,7 +198,7 @@ class ModalSubmitInteractionData(TypedDict):
 InteractionData = Union[
     ApplicationCommandInteractionData, ComponentInteractionData, ModalSubmitInteractionData
 ]
-AuthorizingIntegrationOwners = Dict[str, Union[str]]
+AuthorizingIntegrationOwners = Dict[str, str]
 
 
 class Interaction(TypedDict):

--- a/nextcord/types/interactions.py
+++ b/nextcord/types/interactions.py
@@ -198,6 +198,7 @@ class ModalSubmitInteractionData(TypedDict):
 InteractionData = Union[
     ApplicationCommandInteractionData, ComponentInteractionData, ModalSubmitInteractionData
 ]
+AuthorizingIntegrationOwners = Dict[str, Union[str, Literal[0]]]
 
 
 class Interaction(TypedDict):
@@ -215,6 +216,8 @@ class Interaction(TypedDict):
     locale: NotRequired[str]
     guild_locale: NotRequired[str]
     app_permissions: NotRequired[str]
+    authorizing_integration_owners: NotRequired[AuthorizingIntegrationOwners]
+    context: NotRequired[InteractionContextType]
 
 
 class InteractionApplicationCommandCallbackData(TypedDict, total=False):
@@ -240,6 +243,18 @@ class MessageInteraction(TypedDict):
     name: str
     user: User
     member: NotRequired[Member]
+
+
+class MessageInteractionMetadata(TypedDict):
+    id: Snowflake
+    type: InteractionType
+    user_id: Snowflake
+    user: User
+    authorizing_integration_owners: AuthorizingIntegrationOwners
+    name: NotRequired[str]
+    original_response_message_id: NotRequired[Snowflake]
+    interacted_message_id: NotRequired[Snowflake]
+    triggering_interaction_metadata: NotRequired[MessageInteractionMetadata]
 
 
 class EditApplicationCommand(TypedDict):

--- a/nextcord/types/interactions.py
+++ b/nextcord/types/interactions.py
@@ -19,6 +19,8 @@ if TYPE_CHECKING:
 
 
 ApplicationCommandType = Literal[1, 2, 3]
+IntegrationType = Literal[0, 1]
+InteractionContextType = Literal[0, 1, 2]
 
 
 class ApplicationCommand(TypedDict):
@@ -34,6 +36,8 @@ class ApplicationCommand(TypedDict):
     default_permission: NotRequired[bool]
     dm_permission: NotRequired[bool]
     nsfw: NotRequired[bool]
+    integration_types: NotRequired[List[IntegrationType]]
+    contexts: NotRequired[List[InteractionContextType]]
     name_localizations: NotRequired[Dict[str, str]]
     description_localizations: NotRequired[Dict[str, str]]
 

--- a/nextcord/types/interactions.py
+++ b/nextcord/types/interactions.py
@@ -198,7 +198,7 @@ class ModalSubmitInteractionData(TypedDict):
 InteractionData = Union[
     ApplicationCommandInteractionData, ComponentInteractionData, ModalSubmitInteractionData
 ]
-AuthorizingIntegrationOwners = Dict[str, Union[str, Literal[0]]]
+AuthorizingIntegrationOwners = Dict[str, Union[str]]
 
 
 class Interaction(TypedDict):
@@ -248,7 +248,6 @@ class MessageInteraction(TypedDict):
 class MessageInteractionMetadata(TypedDict):
     id: Snowflake
     type: InteractionType
-    user_id: Snowflake
     user: User
     authorizing_integration_owners: AuthorizingIntegrationOwners
     name: NotRequired[str]

--- a/nextcord/types/message.py
+++ b/nextcord/types/message.py
@@ -10,7 +10,7 @@ from .channel import ChannelType
 from .components import Component
 from .embed import Embed
 from .emoji import PartialEmoji
-from .interactions import MessageInteraction
+from .interactions import MessageInteraction, MessageInteractionMetadata
 from .member import Member, UserWithMember
 from .snowflake import Snowflake, SnowflakeList
 from .sticker import StickerItem
@@ -98,6 +98,7 @@ class Message(TypedDict):
     flags: NotRequired[int]
     sticker_items: NotRequired[List[StickerItem]]
     referenced_message: NotRequired[Optional[Message]]
+    interaction_metadata: NotRequired[MessageInteractionMetadata]
     interaction: NotRequired[MessageInteraction]
     components: NotRequired[List[Component]]
 


### PR DESCRIPTION
## Summary

This PR implements the "integration_types" and "contexts" fields on app commands to support User-Installed Apps. It also deprecates the "dm_permission" parameter in all application commands, as it has been replaced by "contexts".
The PR is marked as draft because user apps are still in preview.

## This is a **Code Change**

- [X] I have tested my changes.
- [X] I have updated the documentation to reflect the changes.
- [X] I have run `task pyright` and fixed the relevant issues.