### PR TITLE
feat(widget): update display_name method to include global_name

### DIFF
--- a/nextcord/widget.py
+++ b/nextcord/widget.py
@@ -174,8 +174,15 @@ class WidgetMember(BaseUser):
 
     @property
     def display_name(self) -> str:
-        """:class:`str`: Returns the member's display name."""
-        return self.nick or self.name
+        """:class:`str`: Returns the user's display name.
+
+        This will return the name using the following hierarchy:
+
+        1. Guild specific nickname
+        2. Global Name (also known as 'Display Name' in the Discord UI)
+        3. Unique username
+        """
+        return self.nick or self.global_name or self.name
 
 
 class Widget:


### PR DESCRIPTION
## Summary

This is a follow-up to #1123 . I had suggested to also apply that change to WidgetMember as it also has a display_name property, but that PR got merged without it.
This PR applies that same change as Member to WidgetMember : the display_name property will return the name using the following hierarchy:
1. Guild specific nickname
2. Global Name (also known as 'Display Name' in the Discord UI)
3. Unique username

## This is a **Code Change**

- [X] I have tested my changes.
- [X] I have updated the documentation to reflect the changes.
- [X] I have run `task pyright` and fixed the relevant issues.