### PR TITLE
chore: remove old autogen excludes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -203,7 +203,7 @@ ignore = [
     "TRY",     # TODO:
     "UP",      # TODO:
 ]
-exclude = ["aliasgen.py", "discord/*", "unaliased-setup.py", ".github/*"]
+exclude = [".github/*"]
 target-version = "py38"
 
 [tool.ruff.per-file-ignores]


### PR DESCRIPTION
## Summary

This removes the old `discord` module files and directories from pyproject.toml's `excludes` option. Finishes off https://github.com/nextcord/nextcord/pull/1095

<!--
## This is a **Code Change**

- [ ] I have tested my changes.
- [ ] I have updated the documentation to reflect the changes.
- [ ] I have run `task pyright` and fixed the relevant issues.
-->