### PR TITLE
feat!: async cache and object rewrite

### DIFF
--- a/nextcord/cache.py
+++ b/nextcord/cache.py
@@ -105,7 +105,7 @@ class MemoryCache(BaseCache):
         self._members[(int(member_data["user"]["id"]), guild_id)] = member_data
 
     async def remove_member(self, member_id: int, guild_id: int) -> bool:
-        return self._members.pop((member_id, guild_id)) is not None
+        return self._members.pop((member_id, guild_id), None) is not None
 
     async def get_member(self, member_id: int, guild_id: int) -> Optional[MemberData]:
         return self._members.get((member_id, guild_id), None)

--- a/nextcord/cache.py
+++ b/nextcord/cache.py
@@ -1,0 +1,109 @@
+from __future__ import annotations
+
+from typing import Dict, Iterable, Optional
+from collections.abc import Collection
+from .types.guild import Guild as GuildData
+from .types.message import Message as MessageData
+from .types.user import User as UserData
+
+
+__all__ = (
+    "BaseCache",
+    "MemoryCache",
+    "NullCache",
+)
+
+
+class BaseCache:
+    def __init__(self, **kwargs):
+        pass
+
+    """A non-functional, NotImplemented cache class that any Nextcord and user made cache should subclass."""
+
+    # Guilds
+    async def add_guild(self, guild_data: GuildData):
+        raise NotImplementedError
+
+    async def get_guild(self, guild_id: int) -> Optional[GuildData]:
+        raise NotImplementedError
+
+    async def get_guild_ids(self) -> Iterable[int]:
+        # TODO: Should this return an async interator?
+        raise NotImplementedError
+
+    # Messages
+    async def add_message(self, message_data: MessageData):
+        raise NotImplementedError
+
+    async def remove_message(self, message_id: int) -> bool:
+        """Must return True if the message corresponding to the ID was found and removed, False if not found."""
+        raise NotImplementedError
+
+    async def get_message(self, message_id: int) -> Optional[MessageData]:
+        raise NotImplementedError
+
+    async def get_message_ids(self) -> Iterable[int]:
+        # TODO: Should this return an async interator?
+        raise NotImplementedError
+
+    # Users
+    async def add_user(self, user_data: UserData):
+        raise NotImplementedError
+
+    async def get_user(self, user_id: int) -> Optional[UserData]:
+        raise NotImplementedError
+
+    async def get_user_ids(self) -> Iterable[int]:
+        # TODO: Should this return an async interator?
+        raise NotImplementedError
+
+
+class NullCache(BaseCache):
+    pass
+
+
+class MemoryCache(BaseCache):
+    _guilds: Dict[int, GuildData]
+    _messages: dict[int, MessageData]
+    _users: Dict[int, UserData]
+
+    def __init__(self, **kwargs):
+        super().__init__()
+        self._guilds = {}
+        self._messages = {}
+        self._users = {}
+
+    async def add_guild(self, guild_data: GuildData):
+        self._guilds[int(guild_data["id"])] = guild_data
+
+    async def get_guild(self, guild_id: int) -> Optional[GuildData]:
+        return self._guilds.get(guild_id, None)
+
+    async def get_guild_ids(self) -> Iterable[int]:
+        return tuple(self._guilds.keys())
+
+    async def add_message(self, message_data: MessageData):
+        self._messages[int(message_data["id"])] = message_data
+
+    async def remove_message(self, message_id: int) -> bool:
+        return True if self._messages.pop(message_id, None) is not None else False
+
+    async def get_message(self, message_id: int) -> Optional[MessageData]:
+        return self._messages.get(message_id, None)
+
+    async def get_message_ids(self) -> Iterable[int]:
+        return tuple(self._messages.keys())
+
+    async def add_user(self, user_data: UserData):
+        self._users[int(user_data["id"])] = user_data
+
+    async def get_user(self, user_id: int) -> Optional[UserData]:
+        return self._users.get(user_id, None)
+
+    async def get_user_ids(self) -> Iterable[int]:
+        return tuple(self._users.keys())
+
+
+
+
+

--- a/nextcord/cache.py
+++ b/nextcord/cache.py
@@ -1,11 +1,12 @@
 from __future__ import annotations
 
-from typing import Dict, Iterable, Optional
-from collections.abc import Collection
+from typing import Dict, Optional, Protocol, Tuple
+from collections.abc import Sequence
+
 from .types.guild import Guild as GuildData
+from .types.member import Member as MemberData
 from .types.message import Message as MessageData
 from .types.user import User as UserData
-
 
 __all__ = (
     "BaseCache",
@@ -14,25 +15,39 @@ __all__ = (
 )
 
 
-class BaseCache:
-    def __init__(self, **kwargs):
+class BaseCache(Protocol):
+    """A non-functional, NotImplemented cache class that any Nextcord and user made cache should subclass."""
+    def __init__(self, **kwargs) -> None:
         pass
 
-    """A non-functional, NotImplemented cache class that any Nextcord and user made cache should subclass."""
-
     # Guilds
-    async def add_guild(self, guild_data: GuildData):
+    async def add_guild(self, guild_data: GuildData) -> None:
         raise NotImplementedError
 
     async def get_guild(self, guild_id: int) -> Optional[GuildData]:
         raise NotImplementedError
 
-    async def get_guild_ids(self) -> Iterable[int]:
+    async def get_guild_ids(self) -> Sequence[int]:
         # TODO: Should this return an async interator?
         raise NotImplementedError
 
+    # Members
+    async def add_member(self, member_data: MemberData, guild_id: int) -> None:
+        raise NotImplementedError
+
+    async def remove_member(self, member_id: int, guild_id: int) -> bool:
+        """Must return True if the member corresponding to the IDs was found and removed, False if not found."""
+        raise NotImplementedError
+
+    async def get_member(self, member_id: int, guild_id: int) -> Optional[MemberData]:
+        raise NotImplementedError
+
+    async def get_member_ids(self) -> Sequence[Tuple[int, int]]:
+        """Must return a sequence of tuples containing the Member ID and Guild ID in that order."""
+        raise NotImplementedError
+
     # Messages
-    async def add_message(self, message_data: MessageData):
+    async def add_message(self, message_data: MessageData) -> None:
         raise NotImplementedError
 
     async def remove_message(self, message_id: int) -> bool:
@@ -42,18 +57,18 @@ class BaseCache:
     async def get_message(self, message_id: int) -> Optional[MessageData]:
         raise NotImplementedError
 
-    async def get_message_ids(self) -> Iterable[int]:
+    async def get_message_ids(self) -> Sequence[int]:
         # TODO: Should this return an async interator?
         raise NotImplementedError
 
     # Users
-    async def add_user(self, user_data: UserData):
+    async def add_user(self, user_data: UserData) -> None:
         raise NotImplementedError
 
     async def get_user(self, user_id: int) -> Optional[UserData]:
         raise NotImplementedError
 
-    async def get_user_ids(self) -> Iterable[int]:
+    async def get_user_ids(self) -> Sequence[int]:
         # TODO: Should this return an async interator?
         raise NotImplementedError
 
@@ -64,46 +79,57 @@ class NullCache(BaseCache):
 
 class MemoryCache(BaseCache):
     _guilds: Dict[int, GuildData]
+    _members: Dict[Tuple[int, int], MemberData]
+    """{(guild_id, member_id): MemberData}"""
     _messages: dict[int, MessageData]
     _users: Dict[int, UserData]
 
-    def __init__(self, **kwargs):
-        super().__init__()
+    # noinspection PyProtocol
+    def __init__(self, **kwargs) -> None:
+        super().__init__(**kwargs)
         self._guilds = {}
+        self._members = {}
         self._messages = {}
         self._users = {}
 
-    async def add_guild(self, guild_data: GuildData):
+    async def add_guild(self, guild_data: GuildData) -> None:
         self._guilds[int(guild_data["id"])] = guild_data
 
     async def get_guild(self, guild_id: int) -> Optional[GuildData]:
         return self._guilds.get(guild_id, None)
 
-    async def get_guild_ids(self) -> Iterable[int]:
+    async def get_guild_ids(self) -> Sequence[int]:
         return tuple(self._guilds.keys())
 
-    async def add_message(self, message_data: MessageData):
+    async def add_member(self, member_data: MemberData, guild_id: int) -> None:
+        self._members[(int(member_data["user"]["id"]), guild_id)] = member_data
+
+    async def remove_member(self, member_id: int, guild_id: int) -> bool:
+        return self._members.pop((member_id, guild_id)) is not None
+
+    async def get_member(self, member_id: int, guild_id: int) -> Optional[MemberData]:
+        return self._members.get((member_id, guild_id), None)
+
+    async def get_member_ids(self) -> Sequence[Tuple[int, int]]:
+        return tuple(self._members.keys())
+
+    async def add_message(self, message_data: MessageData) -> None:
         self._messages[int(message_data["id"])] = message_data
 
     async def remove_message(self, message_id: int) -> bool:
-        return True if self._messages.pop(message_id, None) is not None else False
+        return self._messages.pop(message_id, None) is not None
 
     async def get_message(self, message_id: int) -> Optional[MessageData]:
         return self._messages.get(message_id, None)
 
-    async def get_message_ids(self) -> Iterable[int]:
+    async def get_message_ids(self) -> Sequence[int]:
         return tuple(self._messages.keys())
 
-    async def add_user(self, user_data: UserData):
+    async def add_user(self, user_data: UserData) -> None:
         self._users[int(user_data["id"])] = user_data
 
     async def get_user(self, user_id: int) -> Optional[UserData]:
         return self._users.get(user_id, None)
 
-    async def get_user_ids(self) -> Iterable[int]:
+    async def get_user_ids(self) -> Sequence[int]:
         return tuple(self._users.keys())
-
-
-
-
-

--- a/nextcord/cache.py
+++ b/nextcord/cache.py
@@ -1,12 +1,15 @@
 from __future__ import annotations
 
-from typing import Dict, Optional, Protocol, Tuple
+from typing import Dict, Optional, Protocol, Tuple, TYPE_CHECKING
 from collections.abc import Sequence
 
-from .types.guild import Guild as GuildData
-from .types.member import Member as MemberData
-from .types.message import Message as MessageData
-from .types.user import User as UserData
+
+if TYPE_CHECKING:
+    from .types.guild import Guild as GuildPayload
+    from .types.member import Member as MemberPayload
+    from .types.message import Message as MessagePayload
+    from .types.activity import PartialPresenceUpdate as PresencePayload
+    from .types.user import User as UserPayload
 
 __all__ = (
     "BaseCache",
@@ -21,10 +24,10 @@ class BaseCache(Protocol):
         pass
 
     # Guilds
-    async def add_guild(self, guild_data: GuildData) -> None:
+    async def add_guild(self, guild_data: GuildPayload) -> None:
         raise NotImplementedError
 
-    async def get_guild(self, guild_id: int) -> Optional[GuildData]:
+    async def get_guild(self, guild_id: int) -> Optional[GuildPayload]:
         raise NotImplementedError
 
     async def get_guild_ids(self) -> Sequence[int]:
@@ -32,14 +35,14 @@ class BaseCache(Protocol):
         raise NotImplementedError
 
     # Members
-    async def add_member(self, member_data: MemberData, guild_id: int) -> None:
+    async def add_member(self, member_data: MemberPayload, guild_id: int) -> None:
         raise NotImplementedError
 
     async def remove_member(self, member_id: int, guild_id: int) -> bool:
         """Must return True if the member corresponding to the IDs was found and removed, False if not found."""
         raise NotImplementedError
 
-    async def get_member(self, member_id: int, guild_id: int) -> Optional[MemberData]:
+    async def get_member(self, member_id: int, guild_id: int) -> Optional[MemberPayload]:
         raise NotImplementedError
 
     async def get_member_ids(self) -> Sequence[Tuple[int, int]]:
@@ -47,25 +50,35 @@ class BaseCache(Protocol):
         raise NotImplementedError
 
     # Messages
-    async def add_message(self, message_data: MessageData) -> None:
+    async def add_message(self, message_data: MessagePayload) -> None:
         raise NotImplementedError
 
     async def remove_message(self, message_id: int) -> bool:
         """Must return True if the message corresponding to the ID was found and removed, False if not found."""
         raise NotImplementedError
 
-    async def get_message(self, message_id: int) -> Optional[MessageData]:
+    async def get_message(self, message_id: int) -> Optional[MessagePayload]:
         raise NotImplementedError
 
     async def get_message_ids(self) -> Sequence[int]:
         # TODO: Should this return an async interator?
         raise NotImplementedError
 
-    # Users
-    async def add_user(self, user_data: UserData) -> None:
+    # Presences
+    async def add_presence(self, payload: PresencePayload) -> None:
         raise NotImplementedError
 
-    async def get_user(self, user_id: int) -> Optional[UserData]:
+    async def remove_presence(self, member_id: int, guild_id: int) -> bool:
+        raise NotImplementedError
+
+    async def get_presence(self, member_id: int, guild_id: int) -> PresencePayload | None:
+        raise NotImplementedError
+
+    # Users
+    async def add_user(self, user_data: UserPayload) -> None:
+        raise NotImplementedError
+
+    async def get_user(self, user_id: int) -> Optional[UserPayload]:
         raise NotImplementedError
 
     async def get_user_ids(self) -> Sequence[int]:
@@ -78,11 +91,13 @@ class NullCache(BaseCache):
 
 
 class MemoryCache(BaseCache):
-    _guilds: Dict[int, GuildData]
-    _members: Dict[Tuple[int, int], MemberData]
-    """{(guild_id, member_id): MemberData}"""
-    _messages: dict[int, MessageData]
-    _users: Dict[int, UserData]
+    _guilds: Dict[int, GuildPayload]
+    _members: Dict[Tuple[int, int], MemberPayload]
+    """{(member_id, guild_id): MemberData}"""
+    _messages: dict[int, MessagePayload]
+    _presences: dict[tuple[int, int], PresencePayload]
+    """{(member_id, guild_id): PresencePayload}"""
+    _users: Dict[int, UserPayload]
 
     # noinspection PyProtocol
     def __init__(self, **kwargs) -> None:
@@ -90,45 +105,55 @@ class MemoryCache(BaseCache):
         self._guilds = {}
         self._members = {}
         self._messages = {}
+        self._presences = {}
         self._users = {}
 
-    async def add_guild(self, guild_data: GuildData) -> None:
+    async def add_guild(self, guild_data: GuildPayload) -> None:
         self._guilds[int(guild_data["id"])] = guild_data
 
-    async def get_guild(self, guild_id: int) -> Optional[GuildData]:
+    async def get_guild(self, guild_id: int) -> Optional[GuildPayload]:
         return self._guilds.get(guild_id, None)
 
     async def get_guild_ids(self) -> Sequence[int]:
         return tuple(self._guilds.keys())
 
-    async def add_member(self, member_data: MemberData, guild_id: int) -> None:
+    async def add_member(self, member_data: MemberPayload, guild_id: int) -> None:
         self._members[(int(member_data["user"]["id"]), guild_id)] = member_data
 
     async def remove_member(self, member_id: int, guild_id: int) -> bool:
         return self._members.pop((member_id, guild_id), None) is not None
 
-    async def get_member(self, member_id: int, guild_id: int) -> Optional[MemberData]:
+    async def get_member(self, member_id: int, guild_id: int) -> Optional[MemberPayload]:
         return self._members.get((member_id, guild_id), None)
 
     async def get_member_ids(self) -> Sequence[Tuple[int, int]]:
         return tuple(self._members.keys())
 
-    async def add_message(self, message_data: MessageData) -> None:
+    async def add_message(self, message_data: MessagePayload) -> None:
         self._messages[int(message_data["id"])] = message_data
 
     async def remove_message(self, message_id: int) -> bool:
         return self._messages.pop(message_id, None) is not None
 
-    async def get_message(self, message_id: int) -> Optional[MessageData]:
+    async def get_message(self, message_id: int) -> Optional[MessagePayload]:
         return self._messages.get(message_id, None)
 
     async def get_message_ids(self) -> Sequence[int]:
         return tuple(self._messages.keys())
 
-    async def add_user(self, user_data: UserData) -> None:
+    async def add_presence(self, payload: PresencePayload) -> None:
+        self._presences[(int(payload["user"]["id"]), int(payload["guild_id"]))] = payload
+
+    async def remove_presence(self, member_id: int, guild_id: int) -> bool:
+        return self._presences.pop((member_id, guild_id), None) is not None
+
+    async def get_presence(self, member_id: int, guild_id: int) -> PresencePayload | None:
+        return self._presences.get((member_id, guild_id))
+
+    async def add_user(self, user_data: UserPayload) -> None:
         self._users[int(user_data["id"])] = user_data
 
-    async def get_user(self, user_id: int) -> Optional[UserData]:
+    async def get_user(self, user_id: int) -> Optional[UserPayload]:
         return self._users.get(user_id, None)
 
     async def get_user_ids(self) -> Sequence[int]:

--- a/nextcord/client.py
+++ b/nextcord/client.py
@@ -56,6 +56,7 @@ from .interactions import Interaction
 from .invite import Invite
 from .iterators import GuildIterator
 from .mentions import AllowedMentions
+from .member import AsyncMember
 from .message import AsyncMessage
 from .object import Object
 from .stage_instance import StageInstance
@@ -1061,14 +1062,20 @@ class Client:
         return self._connection._get_guild(id)
 
     async def get_message(self, message_id: int) -> Optional[AsyncMessage]:
-        if message_data := await self.cache.get_message(message_id):
-            return await self.typesheet.create_message(message_data)
+        if message_payload := await self.cache.get_message(message_id):
+            return await self.typesheet.create_message(message_payload)
 
         return None
 
     async def get_user(self, user_id: int) -> Optional[AsyncUser]:
-        if user_data := await self.cache.get_user(user_id):
-            return await self.typesheet.create_user(user_data)
+        if user_payload := await self.cache.get_user(user_id):
+            return await self.typesheet.create_user(user_payload)
+
+        return None
+
+    async def get_member(self, member_id: int, guild_id: int) -> Optional[AsyncMember]:
+        if member_data := await self.cache.get_member(member_id, guild_id):
+            return await self.typesheet.create_member(member_data, guild_id)
 
         return None
 

--- a/nextcord/client.py
+++ b/nextcord/client.py
@@ -49,7 +49,7 @@ from .enums import (
 from .errors import *
 from .flags import ApplicationFlags, Intents
 from .gateway import *
-from .guild import Guild, AsyncGuild
+from .guild import AsyncGuild, Guild
 from .guild_preview import GuildPreview
 from .http import HTTPClient
 from .interactions import Interaction
@@ -67,7 +67,7 @@ from .types.interactions import ApplicationCommandInteractionData
 from .typesheet import BaseTypeSheet, DefaultTypeSheet
 from .ui.modal import Modal
 from .ui.view import View
-from .user import ClientUser, User, AsyncUser
+from .user import AsyncUser, ClientUser, User
 from .utils import MISSING
 from .voice_client import VoiceClient
 from .webhook import Webhook

--- a/nextcord/enums.py
+++ b/nextcord/enums.py
@@ -39,6 +39,7 @@ __all__ = (
     "ApplicationCommandType",
     "ApplicationCommandOptionType",
     "NSFWLevel",
+    "MFALevel",
     "ScheduledEventEntityType",
     "ScheduledEventPrivacyLevel",
     "ScheduledEventStatus",
@@ -1890,6 +1891,15 @@ class NSFWLevel(IntEnum):
     """The guild does not contain any NSFW content."""
     age_restricted = 3
     """The guild may contain NSFW content."""
+
+
+class MFALevel(IntEnum):
+    """Represents the MFA level of a guild."""
+
+    none = 0
+    """Guild has no MFA/2FA requirement for moderation actions."""
+    elevated = 1
+    """Guild has a 2FA requirement for moderation actions."""
 
 
 class ScheduledEventEntityType(IntEnum):

--- a/nextcord/gateway.py
+++ b/nextcord/gateway.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import concurrent.futures
+import inspect
 import logging
 import struct
 import sys
@@ -547,7 +548,10 @@ class DiscordWebSocket:
         except KeyError:
             _log.debug("Unknown event %s.", event)
         else:
-            func(data)
+            if inspect.iscoroutinefunction(func):
+                await func(data)
+            else:
+                func(data)
 
         # remove the dispatched listeners
         removed = []

--- a/nextcord/guild.py
+++ b/nextcord/guild.py
@@ -546,10 +546,11 @@ class Guild(Hashable):
 
         cache_joined = self._state.member_cache_flags.joined
         self_id = self._state.self_id
-        for mdata in guild.get("members", []):
-            member = Member(data=mdata, guild=self, state=state)  # type: ignore
-            if cache_joined or member.id == self_id:
-                self._add_member(member)
+        # TODO: Re-add this, you commented it because this function isn't async right now.
+        # for mdata in guild.get("members", []):
+        #     member = Member(data=mdata, guild=self, state=state)  # type: ignore
+        #     if cache_joined or member.id == self_id:
+        #         self._add_member(member)
 
         self._sync(guild)
         self._large: Optional[bool] = None if member_count is None else self._member_count >= 250

--- a/nextcord/guild.py
+++ b/nextcord/guild.py
@@ -47,6 +47,7 @@ from .enums import (
     ContentFilter,
     NotificationLevel,
     NSFWLevel,
+    MFALevel,
     ScheduledEventEntityType,
     ScheduledEventPrivacyLevel,
     VerificationLevel,
@@ -71,7 +72,10 @@ from .threads import Thread, ThreadMember
 from .user import User
 from .widget import Widget
 
-__all__ = ("Guild", "AsyncGuild",)
+__all__ = (
+    "Guild",
+    "AsyncGuild",
+)
 
 MISSING = utils.MISSING
 
@@ -84,7 +88,7 @@ if TYPE_CHECKING:
     from .auto_moderation import AutoModerationAction
     from .channel import ForumTag
     from .client import Client
-    from .enums import ForumLayoutType, SortOrderType, NSFWLevel
+    from .enums import ForumLayoutType, NSFWLevel, SortOrderType
     from .file import File
     from .message import Attachment
     from .permissions import Permissions
@@ -143,8 +147,6 @@ class AsyncGuild:
 
     def __repr__(self) -> str:
         return f"<{self.__class__.__name__} id={self.id} name={self.name}>"
-
-
 
 
 class _GuildLimit(NamedTuple):

--- a/nextcord/guild.py
+++ b/nextcord/guild.py
@@ -71,7 +71,7 @@ from .threads import Thread, ThreadMember
 from .user import User
 from .widget import Widget
 
-__all__ = ("Guild",)
+__all__ = ("Guild", "AsyncGuild",)
 
 MISSING = utils.MISSING
 
@@ -83,7 +83,8 @@ if TYPE_CHECKING:
     from .application_command import BaseApplicationCommand
     from .auto_moderation import AutoModerationAction
     from .channel import ForumTag
-    from .enums import ForumLayoutType, SortOrderType
+    from .client import Client
+    from .enums import ForumLayoutType, SortOrderType, NSFWLevel
     from .file import File
     from .message import Attachment
     from .permissions import Permissions
@@ -112,6 +113,38 @@ if TYPE_CHECKING:
     VocalGuildChannel = Union[VoiceChannel, StageChannel]
     GuildChannel = Union[VoiceChannel, StageChannel, TextChannel, CategoryChannel, ForumChannel]
     ByCategoryItem = Tuple[Optional[CategoryChannel], List[GuildChannel]]
+
+
+class AsyncGuild:
+    _bot: Client
+    approximate_member_count: Optional[int]
+    approximate_presence_count: Optional[int]
+    id: int
+    mfa_level: MFALevel
+    name: str
+    nsfw_level: NSFWLevel
+    # owner: Optional[bool] # TODO: How is this handled? Returned if querying guilds someone is in?
+    owner_id: int
+
+    @classmethod
+    def from_guild_payload(cls, guild_payload: GuildPayload, *, bot: Client):
+        ret = cls()
+        ret._bot = bot
+
+        ret.approximate_member_count = guild_payload.get("approximate_member_count", None)
+        ret.approximate_presence_count = guild_payload.get("approximate_presence_count", None)
+        ret.id = int(guild_payload["id"])
+        ret.mfa_level = try_enum(MFALevel, guild_payload["mfa_level"])
+        ret.name = guild_payload["name"]
+        ret.nsfw_level = try_enum(NSFWLevel, guild_payload["nsfw_level"])
+        ret.owner_id = int(guild_payload["owner_id"])
+
+        return ret
+
+    def __repr__(self) -> str:
+        return f"<{self.__class__.__name__} id={self.id} name={self.name}>"
+
+
 
 
 class _GuildLimit(NamedTuple):

--- a/nextcord/http.py
+++ b/nextcord/http.py
@@ -4124,6 +4124,7 @@ class HTTPClient:
         *,
         type: InteractionResponseType,
         data: Optional[interactions.InteractionApplicationCommandCallbackData] = None,
+        files: Optional[Sequence[File]] = None
     ) -> Response[None]:
         r = Route(
             "POST",
@@ -4141,6 +4142,7 @@ class HTTPClient:
         return self.request(
             r,
             json=payload,
+            files=files
         )
 
     def get_original_interaction_response(

--- a/nextcord/member.py
+++ b/nextcord/member.py
@@ -392,7 +392,7 @@ class Member(Object, abc.Messageable, _UserTag):
         return (
             f"<Member id={self._user.id} name={self._user.name!r} global_name={self._user.global_name!r}"
             + (f" discriminator={self._user.discriminator!r}" if self.discriminator != "0" else "")
-            + f" bot={self._user.bot} nick={self.nick!r} guild={self.guild!r}>"
+            + f" bot={self._user.bot} nick={self.nick!r} guild_id={self.guild_id}>"
         )
 
     def __eq__(self, other: Any) -> bool:
@@ -501,6 +501,14 @@ class Member(Object, abc.Messageable, _UserTag):
     #         # Signal to dispatch on_user_update
     #         return to_return, u
     #     return None
+
+    @property
+    def bot(self) -> bool:
+        return self._user.bot
+
+    @property
+    def discriminator(self) -> str:
+        return self._user.discriminator
 
     @property
     def status(self) -> Union[Status, str]:

--- a/nextcord/member.py
+++ b/nextcord/member.py
@@ -10,7 +10,7 @@ import sys
 from operator import attrgetter
 from typing import TYPE_CHECKING, Any, Dict, List, Literal, Optional, Tuple, Union
 
-from . import abc, utils
+from . import abc, utils, Client
 from .activity import ActivityTypes, create_activity
 from .asset import Asset
 from .colour import Colour
@@ -18,7 +18,7 @@ from .enums import Status, try_enum
 from .flags import MemberFlags
 from .object import Object
 from .permissions import Permissions
-from .user import BaseUser, User, _UserTag
+from .user import BaseUser, User, _UserTag, AsyncUser
 from .utils import MISSING
 
 __all__ = (
@@ -46,6 +46,14 @@ if TYPE_CHECKING:
     from .types.voice import VoiceState as VoiceStatePayload
 
     VocalGuildChannel = Union[VoiceChannel, StageChannel]
+
+
+class AsyncMember(AsyncUser):
+    nickname: Optional[str]
+
+    @classmethod
+    def from_payload(cls, payload: MemberPayload, *, bot: Client):
+
 
 
 class VoiceState:

--- a/nextcord/message.py
+++ b/nextcord/message.py
@@ -44,6 +44,7 @@ if TYPE_CHECKING:
 
     from .abc import GuildChannel, MessageableChannel, PartialMessageableChannel, Snowflake
     from .channel import TextChannel
+    from .client import Client
     from .components import Component
     from .mentions import AllowedMentions
     from .role import Role
@@ -68,6 +69,7 @@ if TYPE_CHECKING:
     EmojiInputType = Union[Emoji, PartialEmoji, str]
 
 __all__ = (
+    "AsyncMessage",
     "Attachment",
     "Message",
     "PartialMessage",
@@ -75,6 +77,33 @@ __all__ = (
     "DeletedReferencedMessage",
     "MessageInteraction",
 )
+
+
+class AsyncMessage:
+    _bot: Client
+
+    # author: User  # This is rather awkward, the user object is typically included with the message, but we want cached
+    #  async stuff?
+    channel_id: int
+    content: str
+    id: int
+    type: MessageType
+
+    @classmethod
+    def from_message_payload(cls, payload: MessagePayload, *, bot: Client):
+        ret = cls()
+        ret._bot = bot
+
+        ret.channel_id = int(payload["channel_id"])
+        ret.content = payload["content"]
+        ret.id = int(payload["id"])
+        ret.type = try_enum(MessageType, payload["type"])
+
+        return ret
+
+    def __repr__(self) -> str:
+        name = self.__class__.__name__
+        return f"<{name} id={self.id} channel_id={self.channel_id} type={self.type}>"
 
 
 def convert_emoji_reaction(emoji):

--- a/nextcord/state.py
+++ b/nextcord/state.py
@@ -1298,7 +1298,8 @@ class ConnectionState:
         channel, _ = self._get_guild_channel(data)
         await self._bot.cache.add_message(data)
         # channel would be the correct type here
-        message = Message(channel=channel, data=data, state=self)  # type: ignore
+        # message = Message(channel=channel, data=data, state=self)  # type: ignore
+        message = await Message.from_message_payload(data, bot=self._bot)
         self.dispatch("message", message)
         if self._messages is not None:
             self._messages.append(message)
@@ -2216,7 +2217,8 @@ class ConnectionState:
         if member_data:
             guild = self._get_guild(raw.guild_id)
             if guild is not None:
-                raw.member = Member(data=member_data, guild=guild, state=self)
+                # raw.member = Member(data=member_data, guild=guild, state=self)
+                raw.member = await self._bot.typesheet.create_member(member_data, None, guild.id)
             else:
                 raw.member = None
         else:

--- a/nextcord/state.py
+++ b/nextcord/state.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import copy
-import copy
 import inspect
 import itertools
 import logging
@@ -65,8 +64,10 @@ if TYPE_CHECKING:
     from .gateway import DiscordWebSocket
     from .guild import GuildChannel, VocalGuildChannel
     from .http import HTTPClient
-    from .types.activity import Activity as ActivityPayload
-    from .types.activity import PartialPresenceUpdate as PartialPresencePayload
+    from .types.activity import (
+        Activity as ActivityPayload,
+        PartialPresenceUpdate as PartialPresencePayload,
+    )
     from .types.channel import DMChannel as DMChannelPayload
     from .types.emoji import Emoji as EmojiPayload
     from .types.guild import Guild as GuildPayload
@@ -1476,7 +1477,9 @@ class ConnectionState:
 
         # TODO: Look at this and figure out if this is actually good?
         old_presence_data = await self._bot.cache.get_presence(member_id, guild_id)
-        old_member = await self._bot.typesheet.create_member(old_member_data, old_presence_data, guild_id)
+        old_member = await self._bot.typesheet.create_member(
+            old_member_data, old_presence_data, guild_id
+        )
         new_member = await self._bot.typesheet.create_member(new_member_data, data, guild_id)
 
         # user_update[0] is the old unmodified user object.
@@ -2044,6 +2047,8 @@ class ConnectionState:
                 member = member_dict.get(member_id)
                 if member is not None:
                     member._presence_update(presence, user)
+
+                await self._bot.cache.add_presence(presence)
 
         complete = data.get("chunk_index", 0) + 1 == data.get("chunk_count")
         await self.process_chunk_requests(guild_id, data.get("nonce"), members, complete)

--- a/nextcord/state.py
+++ b/nextcord/state.py
@@ -1421,8 +1421,9 @@ class ConnectionState:
                 if reaction:
                     self.dispatch("reaction_clear_emoji", reaction)
 
-    def parse_interaction_create(self, data) -> None:
-        interaction = self._get_client().get_interaction(data=data)
+    async def parse_interaction_create(self, data) -> None:
+        # interaction = self._get_client().get_interaction(data=data)
+        interaction = await self._get_client().typesheet.create_interaction(data)
         if data["type"] == 3:  # interaction component
             custom_id = interaction.data["custom_id"]  # type: ignore
             component_type = interaction.data["component_type"]  # type: ignore
@@ -1431,7 +1432,6 @@ class ConnectionState:
             custom_id = interaction.data["custom_id"]  # type: ignore
             # key exists if type is 5 etc
             self._modal_store.dispatch(custom_id, interaction)
-
         self.dispatch("interaction", interaction)
 
     def parse_presence_update(self, data) -> None:
@@ -1853,8 +1853,6 @@ class ConnectionState:
             # joined a guild with unavailable == True so..
             return
 
-        print(f"GUILD CREATE {data['id']}")
-
         guild = self._get_create_guild(data)
         await self._cache.add_guild(data)
         for mdata in data.get("members", []):
@@ -2140,6 +2138,9 @@ class ConnectionState:
                         guild._remove_member(member)
                     elif channel_id is not None:
                         guild._add_member(member)
+
+                    if "user" in data:
+                        # TODO: Address this?
                         await self._cache.add_member(data, int(data["guild_id"]))
 
                 self.dispatch("voice_state_update", member, before, after)

--- a/nextcord/typesheet.py
+++ b/nextcord/typesheet.py
@@ -3,12 +3,14 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Protocol
 
 from .guild import AsyncGuild
+from .interactions import Interaction
 from .member import AsyncMember
 from .message import AsyncMessage
-from .types.guild import Guild as GuildData
-from .types.member import Member as MemberData
-from .types.message import Message as MessageData
-from .types.user import User as UserData
+from .types.guild import Guild as GuildPayload
+from .types.interactions import Interaction as InteractionPayload
+from .types.member import Member as MemberPayload
+from .types.message import Message as MessagePayload
+from .types.user import User as UserPayload
 from .user import AsyncUser
 
 if TYPE_CHECKING:
@@ -27,28 +29,34 @@ class BaseTypeSheet(Protocol):
     def __init__(self, bot: Client, **kwargs) -> None:
         self._bot = bot
 
-    async def create_guild(self, guild_data: GuildData) -> AsyncGuild:
+    async def create_guild(self, payload: GuildPayload) -> AsyncGuild:
         raise NotImplementedError
 
-    async def create_member(self, member_data: MemberData, guild_id: int) -> AsyncMember:
+    async def create_interaction(self, payload: InteractionPayload) -> Interaction:
         raise NotImplementedError
 
-    async def create_message(self, message_data: MessageData) -> AsyncMessage:
+    async def create_member(self, payload: MemberPayload, guild_id: int) -> AsyncMember:
         raise NotImplementedError
 
-    async def create_user(self, user_data: UserData) -> AsyncUser:
+    async def create_message(self, payload: MessagePayload) -> AsyncMessage:
+        raise NotImplementedError
+
+    async def create_user(self, payload: UserPayload) -> AsyncUser:
         raise NotImplementedError
 
 
 class DefaultTypeSheet(BaseTypeSheet):
-    async def create_guild(self, guild_data: GuildData) -> AsyncGuild:
-        return AsyncGuild.from_guild_payload(guild_data, bot=self._bot)
+    async def create_guild(self, payload: GuildPayload) -> AsyncGuild:
+        return AsyncGuild.from_guild_payload(payload, bot=self._bot)
 
-    async def create_member(self, member_data: MemberData, guild_id: int) -> AsyncMember:
-        return AsyncMember.from_member_payload(member_data, guild_id, bot=self._bot)
+    async def create_interaction(self, payload: InteractionPayload) -> Interaction:
+        return await Interaction.from_interaction_payload(payload, bot=self._bot)
 
-    async def create_message(self, message_data: MessageData) -> AsyncMessage:
-        return AsyncMessage.from_message_payload(message_data, bot=self._bot)
+    async def create_member(self, payload: MemberPayload, guild_id: int) -> AsyncMember:
+        return AsyncMember.from_member_payload(payload, guild_id, bot=self._bot)
 
-    async def create_user(self, user_data: UserData) -> AsyncUser:
-        return AsyncUser.from_payload(user_data, bot=self._bot)
+    async def create_message(self, payload: MessagePayload) -> AsyncMessage:
+        return AsyncMessage.from_message_payload(payload, bot=self._bot)
+
+    async def create_user(self, payload: UserPayload) -> AsyncUser:
+        return AsyncUser.from_user_payload(payload, bot=self._bot)

--- a/nextcord/typesheet.py
+++ b/nextcord/typesheet.py
@@ -1,18 +1,15 @@
 from __future__ import annotations
 
-from typing import Dict, Iterable, Optional, TYPE_CHECKING
+from typing import TYPE_CHECKING, Protocol
 
 from .guild import AsyncGuild
-from .member import Member
+from .member import AsyncMember
 from .message import AsyncMessage
-
 from .types.guild import Guild as GuildData
-from .types.user import User as UserData
 from .types.member import Member as MemberData
 from .types.message import Message as MessageData
-
+from .types.user import User as UserData
 from .user import AsyncUser
-
 
 if TYPE_CHECKING:
     from .client import Client
@@ -24,16 +21,16 @@ __all__ = (
 )
 
 
-class BaseTypeSheet:
+class BaseTypeSheet(Protocol):
     _bot: Client
 
-    def __init__(self, bot: Client, **kwargs):
+    def __init__(self, bot: Client, **kwargs) -> None:
         self._bot = bot
 
     async def create_guild(self, guild_data: GuildData) -> AsyncGuild:
         raise NotImplementedError
 
-    async def create_member(self, member_data: MemberData) -> Member:
+    async def create_member(self, member_data: MemberData, guild_id: int) -> AsyncMember:
         raise NotImplementedError
 
     async def create_message(self, message_data: MessageData) -> AsyncMessage:
@@ -46,6 +43,9 @@ class BaseTypeSheet:
 class DefaultTypeSheet(BaseTypeSheet):
     async def create_guild(self, guild_data: GuildData) -> AsyncGuild:
         return AsyncGuild.from_guild_payload(guild_data, bot=self._bot)
+
+    async def create_member(self, member_data: MemberData, guild_id: int) -> AsyncMember:
+        return AsyncMember.from_member_payload(member_data, guild_id, bot=self._bot)
 
     async def create_message(self, message_data: MessageData) -> AsyncMessage:
         return AsyncMessage.from_message_payload(message_data, bot=self._bot)

--- a/nextcord/typesheet.py
+++ b/nextcord/typesheet.py
@@ -4,17 +4,18 @@ from typing import TYPE_CHECKING, Protocol
 
 from .guild import AsyncGuild
 from .interactions import Interaction
-from .member import AsyncMember
+from .member import Member
 from .message import AsyncMessage
-from .types.guild import Guild as GuildPayload
-from .types.interactions import Interaction as InteractionPayload
-from .types.member import Member as MemberPayload
-from .types.message import Message as MessagePayload
-from .types.user import User as UserPayload
-from .user import AsyncUser
+from .user import User
 
 if TYPE_CHECKING:
     from .client import Client
+    from .types.activity import PartialPresenceUpdate as PresencePayload
+    from .types.guild import Guild as GuildPayload
+    from .types.interactions import Interaction as InteractionPayload
+    from .types.member import Member as MemberPayload
+    from .types.message import Message as MessagePayload
+    from .types.user import User as UserPayload
 
 
 __all__ = (
@@ -35,13 +36,15 @@ class BaseTypeSheet(Protocol):
     async def create_interaction(self, payload: InteractionPayload) -> Interaction:
         raise NotImplementedError
 
-    async def create_member(self, payload: MemberPayload, guild_id: int) -> AsyncMember:
+    async def create_member(
+        self, member_payload: MemberPayload, presence_payload: PresencePayload | None, guild_id: int
+    ) -> Member:
         raise NotImplementedError
 
     async def create_message(self, payload: MessagePayload) -> AsyncMessage:
         raise NotImplementedError
 
-    async def create_user(self, payload: UserPayload) -> AsyncUser:
+    async def create_user(self, payload: UserPayload) -> User:
         raise NotImplementedError
 
 
@@ -52,11 +55,11 @@ class DefaultTypeSheet(BaseTypeSheet):
     async def create_interaction(self, payload: InteractionPayload) -> Interaction:
         return await Interaction.from_interaction_payload(payload, bot=self._bot)
 
-    async def create_member(self, payload: MemberPayload, guild_id: int) -> AsyncMember:
-        return AsyncMember.from_member_payload(payload, guild_id, bot=self._bot)
+    async def create_member(self, member_payload: MemberPayload, presence_payload: PresencePayload | None, guild_id: int) -> Member:
+        return await Member.from_member_payload(member_payload, presence_payload, guild_id, bot=self._bot)
 
     async def create_message(self, payload: MessagePayload) -> AsyncMessage:
         return AsyncMessage.from_message_payload(payload, bot=self._bot)
 
-    async def create_user(self, payload: UserPayload) -> AsyncUser:
-        return AsyncUser.from_user_payload(payload, bot=self._bot)
+    async def create_user(self, payload: UserPayload) -> User:
+        return await User.from_user_payload(payload, bot=self._bot)

--- a/nextcord/typesheet.py
+++ b/nextcord/typesheet.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING, Protocol
 from .guild import AsyncGuild
 from .interactions import Interaction
 from .member import Member
-from .message import AsyncMessage
+from .message import Message
 from .user import User
 
 if TYPE_CHECKING:
@@ -41,7 +41,7 @@ class BaseTypeSheet(Protocol):
     ) -> Member:
         raise NotImplementedError
 
-    async def create_message(self, payload: MessagePayload) -> AsyncMessage:
+    async def create_message(self, payload: MessagePayload) -> Message:
         raise NotImplementedError
 
     async def create_user(self, payload: UserPayload) -> User:
@@ -58,8 +58,8 @@ class DefaultTypeSheet(BaseTypeSheet):
     async def create_member(self, member_payload: MemberPayload, presence_payload: PresencePayload | None, guild_id: int) -> Member:
         return await Member.from_member_payload(member_payload, presence_payload, guild_id, bot=self._bot)
 
-    async def create_message(self, payload: MessagePayload) -> AsyncMessage:
-        return AsyncMessage.from_message_payload(payload, bot=self._bot)
+    async def create_message(self, payload: MessagePayload) -> Message:
+        return await Message.from_message_payload(payload, bot=self._bot)
 
     async def create_user(self, payload: UserPayload) -> User:
         return await User.from_user_payload(payload, bot=self._bot)

--- a/nextcord/typesheet.py
+++ b/nextcord/typesheet.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+from typing import Dict, Iterable, Optional, TYPE_CHECKING
+
+from .guild import AsyncGuild
+from .member import Member
+from .message import AsyncMessage
+
+from .types.guild import Guild as GuildData
+from .types.user import User as UserData
+from .types.member import Member as MemberData
+from .types.message import Message as MessageData
+
+from .user import AsyncUser
+
+
+if TYPE_CHECKING:
+    from .client import Client
+
+
+__all__ = (
+    "BaseTypeSheet",
+    "DefaultTypeSheet",
+)
+
+
+class BaseTypeSheet:
+    _bot: Client
+
+    def __init__(self, bot: Client, **kwargs):
+        self._bot = bot
+
+    async def create_guild(self, guild_data: GuildData) -> AsyncGuild:
+        raise NotImplementedError
+
+    async def create_member(self, member_data: MemberData) -> Member:
+        raise NotImplementedError
+
+    async def create_message(self, message_data: MessageData) -> AsyncMessage:
+        raise NotImplementedError
+
+    async def create_user(self, user_data: UserData) -> AsyncUser:
+        raise NotImplementedError
+
+
+class DefaultTypeSheet(BaseTypeSheet):
+    async def create_guild(self, guild_data: GuildData) -> AsyncGuild:
+        return AsyncGuild.from_guild_payload(guild_data, bot=self._bot)
+
+    async def create_message(self, message_data: MessageData) -> AsyncMessage:
+        return AsyncMessage.from_message_payload(message_data, bot=self._bot)
+
+    async def create_user(self, user_data: UserData) -> AsyncUser:
+        return AsyncUser.from_payload(user_data, bot=self._bot)

--- a/nextcord/user.py
+++ b/nextcord/user.py
@@ -17,6 +17,7 @@ if TYPE_CHECKING:
     from typing_extensions import Self
 
     from .channel import DMChannel
+    from .client import Client
     from .file import File
     from .guild import Guild
     from .message import Attachment, Message
@@ -26,9 +27,33 @@ if TYPE_CHECKING:
 
 
 __all__ = (
+    "AsyncUser",
     "User",
     "ClientUser",
 )
+
+
+class AsyncUser:
+    _bot: Client
+
+    _avatar: Optional[str]
+    discriminator: str
+    global_name: Optional[str]
+    id: int
+    username: str
+
+    @classmethod
+    def from_payload(cls, payload: UserPayload, *, bot: Client):
+        ret = cls()
+        ret._bot = bot
+
+        ret._avatar = payload["avatar"]
+        ret.discriminator = payload["discriminator"]
+        ret.global_name = payload["global_name"]
+        ret.id = int(payload["id"])
+        ret.username = payload["username"]
+
+        return ret
 
 
 class _UserTag:

--- a/nextcord/user.py
+++ b/nextcord/user.py
@@ -43,7 +43,7 @@ class AsyncUser:
     username: str
 
     @classmethod
-    def from_payload(cls, payload: UserPayload, *, bot: Client):
+    def from_user_payload(cls, payload: UserPayload, *, bot: Client):
         ret = cls()
         ret._bot = bot
 
@@ -54,6 +54,17 @@ class AsyncUser:
         ret.username = payload["username"]
 
         return ret
+
+    def __repr__(self) -> str:
+        return f"<{self.__class__.__name__} id={self.id} global_name={self.global_name} username={self.username}>"
+
+    @property
+    def created_at(self) -> datetime:
+        """:class:`datetime.datetime`: Returns the user's creation time in UTC.
+
+        This is when the user's Discord account was created.
+        """
+        return snowflake_time(self.id)
 
 
 class _UserTag:


### PR DESCRIPTION
## Summary

<!-- What is this pull request for? Does it fix any issues? -->

This PR aims to
* make accesses to the cache asynchronous,
* allow the cache to be modified and replaced by users,
* refine how Discord objects are created,
* centralize the creation of Discord objects in a way that is modifiable and replaceable by users,
* reduce the dependency on guild intents,
* and allow bots to be closer to stateless.

To say this is in progress is an understatement. It will likely be quite a while before anything here is relatively usable, let alone useful. This is being published so people can monitor this and raise issues about the architecture before I dive too far into the wrong direction.

<!-- Link any issues if applicable.
Use keywords from https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests
-->

<!-- Uncomment based on the type of your changes below -->

This is a **Code Change**

- [ ] I have tested my changes.
- [ ] I have updated the documentation to reflect the changes.
- [ ] I have run `task pyright` and fixed the relevant issues.
