### PR TITLE
refactor: simplify Client.run()

### DIFF
--- a/nextcord/client.py
+++ b/nextcord/client.py
@@ -827,7 +827,7 @@ class Client:
         await self.login(token)
         await self.connect(reconnect=reconnect)
 
-    def run(self, *args, **kwargs) -> None:
+    def run(self, token: str, *, reconnect: bool = True) -> None:
         """A blocking call that abstracts away the event loop
         initialisation from you.
 
@@ -853,7 +853,7 @@ class Client:
         """
         loop = self.loop  # TODO: Make this asyncio.new_event_loop() if self.loop is removed.
         try:
-            loop.run_until_complete(self.start(*args, **kwargs))
+            loop.run_until_complete(self.start(token, reconnect=reconnect))
         except KeyboardInterrupt:
             _log.info("Received keyboard interrupt, closing.")
         finally:


### PR DESCRIPTION
## Summary

<!-- What is this pull request for? Does it fix any issues? -->

Refactors `Client.run()` to use modern methods of running the asyncio loop.

This MAY technically be a breaking change, as much of the weird/older school asyncio loop shenanigans have been removed?

I have tested the changes locally, but I'd like to see testing done on more wacky/custom setups to see if the technically breaking changes have any actual effect.

<!-- Link any issues if applicable.
Use keywords from https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests
-->

<!-- Uncomment based on the type of your changes below -->


- [X] I have tested my changes.
- [ ] I have updated the documentation to reflect the changes.
- [ ] I have run `task pyright` and fixed the relevant issues.
