### PR TITLE
docs(enums): Add `InviteType` to the Enumerations section

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -1418,6 +1418,9 @@ of :class:`enum.Enum`.
 .. autoclass:: AuditLogAction
     :members:
 
+.. autoclass:: InviteType
+    :members:
+
 Async Iterator
 --------------
 

--- a/nextcord/enums.py
+++ b/nextcord/enums.py
@@ -49,6 +49,7 @@ __all__ = (
     "SortOrderType",
     "RoleConnectionMetadataType",
     "ForumLayoutType",
+    "InviteType",
 )
 
 


### PR DESCRIPTION
## Summary

This PR adds the `InviteType` enum to the docs, to make the links referring to it clickable.