### PR TITLE
fix(User): apply new user global_name on user update

### DIFF
--- a/nextcord/member.py
+++ b/nextcord/member.py
@@ -404,7 +404,7 @@ class Member(abc.Messageable, _UserTag):
             u.name, u._avatar, u.discriminator, u.global_name, u._public_flags = modified
             # Signal to dispatch on_user_update
             return to_return, u
-        return None`
+        return None
 
     @property
     def status(self) -> Union[Status, str]:

--- a/nextcord/member.py
+++ b/nextcord/member.py
@@ -390,20 +390,21 @@ class Member(abc.Messageable, _UserTag):
 
     def _update_inner_user(self, user: UserPayload) -> Optional[Tuple[User, User]]:
         u = self._user
-        original = (u.name, u._avatar, u.discriminator, u._public_flags)
+        original = (u.name, u._avatar, u.discriminator, u.global_name, u._public_flags)
         # These keys seem to always be available
         modified = (
             user["username"],
             user["avatar"],
             user["discriminator"],
+            user.get("global_name"),
             user.get("public_flags", 0),
         )
         if original != modified:
             to_return = User._copy(self._user)
-            u.name, u._avatar, u.discriminator, u._public_flags = modified
+            u.name, u._avatar, u.discriminator, u.global_name, u._public_flags = modified
             # Signal to dispatch on_user_update
             return to_return, u
-        return None
+        return None`
 
     @property
     def status(self) -> Union[Status, str]:


### PR DESCRIPTION
## Summary
This fixes a bug where a user's display name in the bot's cache (`User.global_name`) would not update when the user changes their display name on Discord.

## This is a **Code Change**

- [X] I have tested my changes.
- [ ] I have updated the documentation to reflect the changes.
- [ ] I have run `task pyright` and fixed the relevant issues.
