### PR TITLE
feat(guild): add `fetch_role`

### DIFF
--- a/nextcord/guild.py
+++ b/nextcord/guild.py
@@ -2804,6 +2804,32 @@ class Guild(Hashable):
 
         return roles
 
+    async def fetch_role(self, role_id: int, /) -> Role:
+        """|coro|
+
+        Retrieves a :class:`Role` that a guild has.
+
+        .. versionadded:: 3.0
+
+        Parameters
+        ----------
+        role_id: int
+            The ID of the role to fetch.
+
+        Raises
+        ------
+        HTTPException
+            Retrieving the roles failed.
+
+        Returns
+        -------
+        :class:`Role`
+            The role in the guild.
+        """
+        data = await self._state.http.get_role(self.id, role_id)
+
+        return Role(guild=self, state=self._state, data=data)
+
     @overload
     async def create_role(
         self,

--- a/nextcord/guild.py
+++ b/nextcord/guild.py
@@ -2819,7 +2819,9 @@ class Guild(Hashable):
         Raises
         ------
         HTTPException
-            Retrieving the roles failed.
+            Retrieving the role failed.
+        NotFound
+            The role was not found.
 
         Returns
         -------
@@ -2827,7 +2829,6 @@ class Guild(Hashable):
             The role in the guild.
         """
         data = await self._state.http.get_role(self.id, role_id)
-
         return Role(guild=self, state=self._state, data=data)
 
     @overload

--- a/nextcord/guild.py
+++ b/nextcord/guild.py
@@ -2807,7 +2807,7 @@ class Guild(Hashable):
     async def fetch_role(self, role_id: int, /) -> Role:
         """|coro|
 
-        Retrieve a :class:`Role` that a guild has.
+        Retrieve a :class:`Role` from this guild by its ID.
 
         .. versionadded:: 3.0
 

--- a/nextcord/guild.py
+++ b/nextcord/guild.py
@@ -2807,7 +2807,7 @@ class Guild(Hashable):
     async def fetch_role(self, role_id: int, /) -> Role:
         """|coro|
 
-        Retrieves a :class:`Role` that a guild has.
+        Retrieve a :class:`Role` that a guild has.
 
         .. versionadded:: 3.0
 

--- a/nextcord/http.py
+++ b/nextcord/http.py
@@ -3507,6 +3507,20 @@ class HTTPClient:
             retry_request=retry_request,
         )
 
+    def get_role(
+        self,
+        guild_id: Snowflake,
+        role_id: Snowflake,
+        *,
+        auth: Optional[str] = MISSING,
+        retry_request: bool = True,
+    ) -> Response[role.Role]:
+        return self.request(
+            Route("GET", "/guilds/{guild_id}/roles/{role_id}", guild_id=guild_id, role_id=role_id),
+            auth=auth,
+            retry_request=retry_request,
+        )
+
     def edit_role(
         self,
         guild_id: Snowflake,


### PR DESCRIPTION
## Summary

- Implements discord/discord-api-docs#7074

Tested with
```py
from nextcord import Intents, Interaction, Role
from nextcord.ext.commands import Bot

bot = Bot(
    intents=Intents(guilds=True, message_content=True, messages=True),
    default_guild_ids=[...],
)

@bot.slash_command()
async def role(inter: Interaction, role: Role):
    assert inter.guild is not None
    fetched_role = await inter.guild.fetch_role(role.id)
    return await inter.send(repr(fetched_role))

bot.run(...)

```
![image](https://github.com/user-attachments/assets/aeb18cdd-b83d-4086-8f3e-7aa54fe339a7)


## This is a **Code Change**

- [x] I have tested my changes.
- [x] I have updated the documentation to reflect the changes.
- [x] I have run `task pyright` and fixed the relevant issues.
