### PR TITLE
feat(member): add guild banners

### DIFF
--- a/nextcord/asset.py
+++ b/nextcord/asset.py
@@ -232,6 +232,17 @@ class Asset(AssetMixin):
         )
 
     @classmethod
+    def _from_guild_banner(cls, state, guild_id: int, member_id: int, banner: str) -> Asset:
+        animated = banner.startswith("a_")
+        format = "gif" if animated else "webp"
+        return cls(
+            state,
+            url=f"{cls.BASE}/guilds/{guild_id}/users/{member_id}/banners/{banner}.{format}",
+            key=banner,
+            animated=animated,
+        )
+
+    @classmethod
     def _from_icon(cls, state, object_id: int, icon_hash: str, path: str) -> Asset:
         return cls(
             state,

--- a/nextcord/asset.py
+++ b/nextcord/asset.py
@@ -234,7 +234,7 @@ class Asset(AssetMixin):
     @classmethod
     def _from_guild_banner(cls, state, guild_id: int, member_id: int, banner: str) -> Asset:
         animated = banner.startswith("a_")
-        format = "gif" if animated else "webp"
+        format = "gif" if animated else "png"
         return cls(
             state,
             url=f"{cls.BASE}/guilds/{guild_id}/users/{member_id}/banners/{banner}.{format}",

--- a/nextcord/member.py
+++ b/nextcord/member.py
@@ -406,7 +406,7 @@ class Member(abc.Messageable, _UserTag):
         )
         if original != modified:
             to_return = User._copy(self._user)
-            u.name, u._avatar, u.discriminator, u.global_name, u._public_flags, u.banner = modified
+            u.name, u._avatar, u.discriminator, u.global_name, u._public_flags, u._banner = modified
             # Signal to dispatch on_user_update
             return to_return, u
         return None

--- a/nextcord/member.py
+++ b/nextcord/member.py
@@ -247,6 +247,7 @@ class Member(abc.Messageable, _UserTag):
         "_avatar",
         "_timeout",
         "_flags",
+        "_banner",
     )
 
     if TYPE_CHECKING:
@@ -287,6 +288,7 @@ class Member(abc.Messageable, _UserTag):
             data.get("communication_disabled_until")
         )
         self._flags: int = data.get("flags", 0)
+        self._banner: Optional[str] = data.get("banner")
 
     def __str__(self) -> str:
         return str(self._user)
@@ -351,6 +353,7 @@ class Member(abc.Messageable, _UserTag):
         self._avatar = member._avatar
         self._timeout = member._timeout
         self._flags = member._flags
+        self._banner = member._banner
 
         # Reference will not be copied unless necessary by PRESENCE_UPDATE
         # See below
@@ -374,6 +377,7 @@ class Member(abc.Messageable, _UserTag):
         self._avatar = data.get("avatar")
         self._timeout = utils.parse_time(data.get("communication_disabled_until"))
         self._flags = data.get("flags", 0)
+        self._banner = data.get("banner")
 
     def _presence_update(
         self, data: PartialPresenceUpdate, user: UserPayload
@@ -390,7 +394,7 @@ class Member(abc.Messageable, _UserTag):
 
     def _update_inner_user(self, user: UserPayload) -> Optional[Tuple[User, User]]:
         u = self._user
-        original = (u.name, u._avatar, u.discriminator, u.global_name, u._public_flags)
+        original = (u.name, u._avatar, u.discriminator, u.global_name, u._public_flags, u._banner)
         # These keys seem to always be available
         modified = (
             user["username"],
@@ -398,10 +402,11 @@ class Member(abc.Messageable, _UserTag):
             user["discriminator"],
             user.get("global_name"),
             user.get("public_flags", 0),
+            user.get("banner"),
         )
         if original != modified:
             to_return = User._copy(self._user)
-            u.name, u._avatar, u.discriminator, u.global_name, u._public_flags = modified
+            u.name, u._avatar, u.discriminator, u.global_name, u._public_flags, u.banner = modified
             # Signal to dispatch on_user_update
             return to_return, u
         return None
@@ -533,6 +538,30 @@ class Member(abc.Messageable, _UserTag):
         if self._avatar is None:
             return None
         return Asset._from_guild_avatar(self._state, self.guild.id, self.id, self._avatar)
+
+    @property
+    def guild_banner(self) -> Optional[Asset]:
+        """Optional[:class:`Asset`]: Returns an :class:`Asset` for the guild member's banner.
+        If unavailable, ``None`` is returned.
+
+        .. versionadded:: 3.0
+        """
+        if self._banner is None:
+            return None
+        return Asset._from_guild_banner(self._state, self.guild.id, self.id, self._banner)
+
+    @property
+    def display_banner(self) -> Optional[Asset]:
+        """Optional[:class:`Asset`]: Returns the member's display banner.
+        If unavailable, ``None`` is returned
+
+        For regular members this is just their banner, if any, but
+        if they have a guild specific banner then that
+        is returned instead.
+
+        .. versionadded:: 3.0
+        """
+        return self.guild_banner or self._user.banner
 
     @property
     def activity(self) -> Optional[ActivityTypes]:

--- a/nextcord/types/member.py
+++ b/nextcord/types/member.py
@@ -26,6 +26,7 @@ class Member(PartialMember, total=False):
     pending: bool
     permissions: str
     communication_disabled_until: str
+    banner: str
 
 
 class _OptionalMemberWithUser(PartialMember, total=False):
@@ -34,6 +35,7 @@ class _OptionalMemberWithUser(PartialMember, total=False):
     premium_since: str
     pending: bool
     permissions: str
+    banner: str
 
 
 class MemberWithUser(_OptionalMemberWithUser):


### PR DESCRIPTION
## Summary

- Implements discord/discord-api-docs#6986

Tested with:
```py
from nextcord import Intents, Interaction, Member
from nextcord.ext.commands import Bot

bot = Bot(
    intents=Intents(guilds=True, message_content=True, messages=True),
    default_guild_ids=[...],
)

@bot.user_command()
async def user_banner(inter: Interaction, member: Member):
    await inter.send(f"banner: {member.banner}")

    await inter.followup.send(f"guild banner: {member.guild_banner}")
    await inter.followup.send(f"display banner: {member.display_banner}")

bot.run(...)

```

![image](https://github.com/user-attachments/assets/e89cb8bc-2174-4420-ae01-6feb873fe762)


## This is a **Code Change**

- [x] I have tested my changes.
- [x] I have updated the documentation to reflect the changes.
- [x] I have run `task pyright` and fixed the relevant issues.
