### PR TITLE
feat(utils): add `integration_type` to `oauth_url` helper

### DIFF
--- a/nextcord/utils.py
+++ b/nextcord/utils.py
@@ -501,7 +501,7 @@ def get_as_snowflake(data: Any, key: str) -> Optional[int]:
 
 
 def _get_mime_type_for_image(data: bytes) -> str:
-    if data.startswith(b"\x89\x50\x4e\x47\x0d\x0a\x1a\x0a"):
+    if data.startswith(b"\x89\x50\x4E\x47\x0D\x0A\x1A\x0A"):
         return "image/png"
     if data[0:3] == b"\xff\xd8\xff" or data[6:10] in (b"JFIF", b"Exif"):
         return "image/jpeg"

--- a/nextcord/utils.py
+++ b/nextcord/utils.py
@@ -291,7 +291,7 @@ def oauth_url(
     redirect_uri: str = MISSING,
     scopes: Iterable[str] = MISSING,
     disable_guild_select: bool = False,
-    integration_type: IntegrationType = IntegrationType.guild_install,
+    integration_type: IntegrationType = MISSING,
 ) -> str:
     """A helper function that returns the OAuth2 URL for inviting the bot
     into guilds.
@@ -317,7 +317,6 @@ def oauth_url(
         .. versionadded:: 2.0
     integration_type: :class:`~nextcord.IntegrationType`
         The integration type (otherwise known as installation context) that the invite is for.
-        Defaults to `~nextcord.IntegrationType.guild_install` if not provided
 
         .. versionadded:: 3.0
 
@@ -326,7 +325,7 @@ def oauth_url(
     :class:`str`
         The OAuth2 URL for inviting the bot into guilds.
     """
-    url = f"https://discord.com/oauth2/authorize?client_id={client_id}&integration_type={integration_type.value}"
+    url = f"https://discord.com/oauth2/authorize?client_id={client_id}"
     url += "&scope=" + "+".join(scopes or ("bot",))
     if permissions is not MISSING:
         url += f"&permissions={permissions.value}"
@@ -338,6 +337,8 @@ def oauth_url(
         url += "&response_type=code&" + urlencode({"redirect_uri": redirect_uri})
     if disable_guild_select:
         url += "&disable_guild_select=true"
+    if integration_type is not MISSING:
+        url += f"&integration_type={integration_type.value}"
     return url
 
 

--- a/nextcord/utils.py
+++ b/nextcord/utils.py
@@ -42,6 +42,7 @@ from typing import (
     overload,
 )
 
+from .enums import IntegrationType
 from .errors import InvalidArgument
 from .file import File
 
@@ -290,6 +291,7 @@ def oauth_url(
     redirect_uri: str = MISSING,
     scopes: Iterable[str] = MISSING,
     disable_guild_select: bool = False,
+    integration_type: IntegrationType = IntegrationType.guild_install,
 ) -> str:
     """A helper function that returns the OAuth2 URL for inviting the bot
     into guilds.
@@ -313,13 +315,18 @@ def oauth_url(
         Whether to disallow the user from changing the guild dropdown.
 
         .. versionadded:: 2.0
+    integration_type: :class:`~nextcord.IntegrationType`
+        The integration type (otherwise known as installation context) that the invite is for.
+        Defaults to `~nextcord.IntegrationType.guild_install` if not provided
+
+        .. versionadded:: 3.0
 
     Returns
     -------
     :class:`str`
         The OAuth2 URL for inviting the bot into guilds.
     """
-    url = f"https://discord.com/oauth2/authorize?client_id={client_id}"
+    url = f"https://discord.com/oauth2/authorize?client_id={client_id}&integration_type={integration_type.value}"
     url += "&scope=" + "+".join(scopes or ("bot",))
     if permissions is not MISSING:
         url += f"&permissions={permissions.value}"
@@ -494,7 +501,7 @@ def get_as_snowflake(data: Any, key: str) -> Optional[int]:
 
 
 def _get_mime_type_for_image(data: bytes) -> str:
-    if data.startswith(b"\x89\x50\x4E\x47\x0D\x0A\x1A\x0A"):
+    if data.startswith(b"\x89\x50\x4e\x47\x0d\x0a\x1a\x0a"):
         return "image/png"
     if data[0:3] == b"\xff\xd8\xff" or data[6:10] in (b"JFIF", b"Exif"):
         return "image/jpeg"


### PR DESCRIPTION
## Summary

Adds a `integration_type` parameters to `utils.oauth_url`
![image](https://github.com/user-attachments/assets/63ffe430-663b-4e00-a5f8-5b40c9c2a37c)


Tested with:
```python
from nextcord.enums import IntegrationType
from nextcord.utils import oauth_url

print(oauth_url(919680394863984721, integration_type=IntegrationType.user_install))
```

## This is a **Code Change**

- [x] I have tested my changes.
- [x] I have updated the documentation to reflect the changes.
- [x] I have run `task pyright` and fixed the relevant issues.
