### PR TITLE
docs: missing NotFound error on Message.edit

### DIFF
--- a/nextcord/message.py
+++ b/nextcord/message.py
@@ -1599,6 +1599,8 @@ class Message(Hashable):
 
         Raises
         ------
+        NotFound
+            The message was not found.
         HTTPException
             Editing the message failed.
         Forbidden


### PR DESCRIPTION
## Summary

This PR adds a NotFound error in Message.edit

<!-- Uncomment based on the type of your changes below -->

<!--
## This is a **Code Change**

- [ ] I have tested my changes.
- [ ] I have updated the documentation to reflect the changes.
- [ ] I have run `task pyright` and fixed the relevant issues.
