### PR TITLE
chore: Upgrade Sphinx to 6.2.0 to allow building on Python 3.13

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,7 +61,7 @@ pyright = "1.1.317"
 sphinx_autobuild = "2021.3.14"
 
 [tool.poetry.group.docs.dependencies]
-sphinx = "6.20"
+sphinx = "6.2.0"
 sphinxcontrib-trio = "1.1.2"
 sphinxcontrib-websupport = "^1.2.4"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,7 +61,7 @@ pyright = "1.1.317"
 sphinx_autobuild = "2021.3.14"
 
 [tool.poetry.group.docs.dependencies]
-sphinx = "5.2.3"
+sphinx = "6.20"
 sphinxcontrib-trio = "1.1.2"
 sphinxcontrib-websupport = "^1.2.4"
 


### PR DESCRIPTION
## Summary

Fixes https://github.com/nextcord/nextcord/issues/1220.

```
The HTML pages are in _build/html.
[I 241110 11:53:02 server:330] Serving on http://127.0.0.1:8069
[I 241110 11:53:02 handlers:62] Start watching changes
[I 241110 11:53:02 handlers:64] Start detecting changes
[I 241110 11:53:16 handlers:135] Browser Connected: http://localhost:8069/intro.html
```