### PR TITLE
build(player): migrate to audioop-lts on Python >= 3.13

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ packages = [
 python = "^3.8"
 aiohttp = "^3.8.0"
 typing_extensions = "^4.2.0"
+audioop-lts = { version = "^0.2.1", python = "^3.13" }
 
 PyNaCl = { version = ">=1.3.0,<1.5", optional = true }
 orjson = { version = ">=3.5.4", optional = true }


### PR DESCRIPTION
## Summary

Reopening this because I borked my master on my fork. Sorry.

Audioop is a "dead battery" that has been removed by [PEP 594](https://peps.python.org/pep-0594/) in versions of Python >= 3.13.0. Thankfully, an LTS port has been created [here](https://github.com/AbstractUmbra/audioop). This PR would switch nextcord to audioop-lts for versions of Python that no longer include audioop OOTB.

Fixes #1174.

In terms of testing, I confirmed that, on Python 3.13., audioop-lts is installed; and on Python 3.12, nothing additional is installed.
