### PR TITLE
fix(client): remove duplication of views in views/all_views

### DIFF
--- a/nextcord/ui/view.py
+++ b/nextcord/ui/view.py
@@ -500,7 +500,13 @@ class ViewStore:
         self._state: ConnectionState = state
 
     def all_views(self) -> List[View]:
-        return [v for (v, _) in self._views.values()]
+        # Create a unique list of views, as _views stores the same view multiple times,
+        # one for each dispatchable item.
+        views = {
+            view.id: view
+            for view, _ in self._views.values()
+        }
+        return list(views.values())
 
     def views(self, persistent: bool = True) -> List[View]:
         views = self.all_views()

--- a/nextcord/ui/view.py
+++ b/nextcord/ui/view.py
@@ -502,10 +502,7 @@ class ViewStore:
     def all_views(self) -> List[View]:
         # Create a unique list of views, as _views stores the same view multiple times,
         # one for each dispatchable item.
-        views = {
-            view.id: view
-            for view, _ in self._views.values()
-        }
+        views = {view.id: view for view, _ in self._views.values()}
         return list(views.values())
 
     def views(self, persistent: bool = True) -> List[View]:


### PR DESCRIPTION
## Summary

Introduced in #843 and discovered in [this help thread](https://discord.com/channels/881118111967883295/1310305439073828864), the new implementation for retrieving views via the client has duplicated views with multiple components.
This is due to removing the construction of a dictionary internally to make the list unqiue. This PR adds this method back and comments
it to ensure this isn't wrongly removed again.
<!-- What is this pull request for? Does it fix any issues? -->

With the following code, running `send_view` twice, and `all_views` once returns 4 views when it should be 2 unique, as seen in the new behaviour below.

```python
class MyView(View):
    @button(label="one")
    async def one(self, button, interaction: Interaction):
        await interaction.response.send_message("one")

    @button(label="two")
    async def two(self, button, interaction: Interaction):
        await interaction.response.send_message("two")

@bot.slash_command()
async def send_view(inter: Interaction):
    await inter.response.send_message("View", view=MyView())

@bot.slash_command()
async def all_views(inter: Interaction):
    views = bot.all_views
    views2 = bot.views(persistent=False)
    await inter.response.send_message(str(views) + "\n" + str(views2))
```

![old and new behaviour](https://cdn.discordapp.com/attachments/1310305439073828864/1310318383798943815/image.png?ex=6744c897&is=67437717&hm=4b171a11b9e2534928047920a0f98ba1e6a9b9682bd9619b7459f02aea3fb97a&)
<!-- Link any issues if applicable.
Use keywords from https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests
-->

<!-- Uncomment based on the type of your changes below -->

## This is a **Code Change**

- [x] I have tested my changes.
- [x] I have updated the documentation to reflect the changes.
- [x] I have run `task pyright` and fixed the relevant issues.
