### PR TITLE
refactor: update pyright to 1.1.391

### DIFF
--- a/nextcord/abc.py
+++ b/nextcord/abc.py
@@ -149,9 +149,9 @@ class User(Snowflake, Protocol):
     __slots__ = ()
 
     name: str
-    global_name: str
+    global_name: Optional[str]
     discriminator: str
-    avatar: Asset
+    avatar: Optional[Asset]
     bot: bool
 
     @property

--- a/nextcord/activity.py
+++ b/nextcord/activity.py
@@ -256,22 +256,16 @@ class Activity(BaseActivity):
     @property
     def start(self) -> Optional[datetime.datetime]:
         """Optional[:class:`datetime.datetime`]: When the user started doing this activity in UTC, if applicable."""
-        try:
-            timestamp = self.timestamps["start"] / 1000
-        except KeyError:
-            return None
-        else:
-            return datetime.datetime.fromtimestamp(timestamp, tz=datetime.timezone.utc)
+        if (timestamp := self.timestamps.get("start")) is not None:
+            return datetime.datetime.fromtimestamp(timestamp / 1000, tz=datetime.timezone.utc)
+        return None
 
     @property
     def end(self) -> Optional[datetime.datetime]:
         """Optional[:class:`datetime.datetime`]: When the user will stop doing this activity in UTC, if applicable."""
-        try:
-            timestamp = self.timestamps["end"] / 1000
-        except KeyError:
-            return None
-        else:
-            return datetime.datetime.fromtimestamp(timestamp, tz=datetime.timezone.utc)
+        if (timestamp := self.timestamps.get("end")) is not None:
+            return datetime.datetime.fromtimestamp(timestamp / 1000, tz=datetime.timezone.utc)
+        return None
 
     @property
     def large_image_url(self) -> Optional[str]:
@@ -279,12 +273,11 @@ class Activity(BaseActivity):
         if self.application_id is None:
             return None
 
-        try:
-            large_image = self.assets["large_image"]
-        except KeyError:
-            return None
-        else:
-            return Asset.BASE + f"/app-assets/{self.application_id}/{large_image}.png"
+        if "large_image" in self.assets:
+            return (
+                Asset.BASE + f"/app-assets/{self.application_id}/{self.assets['large_image']}.png"
+            )
+        return None
 
     @property
     def small_image_url(self) -> Optional[str]:
@@ -292,12 +285,11 @@ class Activity(BaseActivity):
         if self.application_id is None:
             return None
 
-        try:
-            small_image = self.assets["small_image"]
-        except KeyError:
-            return None
-        else:
-            return Asset.BASE + f"/app-assets/{self.application_id}/{small_image}.png"
+        if "small_image" in self.assets:
+            return (
+                Asset.BASE + f"/app-assets/{self.application_id}/{self.assets['small_image']}.png"
+            )
+        return None
 
     @property
     def large_image_text(self) -> Optional[str]:
@@ -489,12 +481,9 @@ class Streaming(BaseActivity):
         dictionary if it starts with ``twitch:``. Typically set by the Discord client.
         """
 
-        try:
-            name = self.assets["large_image"]
-        except KeyError:
-            return None
-        else:
+        if (name := self.assets.get("large_image")) is not None:
             return name[7:] if name[:7] == "twitch:" else None
+        return None
 
     def to_dict(self) -> Dict[str, Any]:
         ret: Dict[str, Any] = {

--- a/nextcord/application_command.py
+++ b/nextcord/application_command.py
@@ -19,6 +19,7 @@ from typing import (
     List,
     Literal,
     Optional,
+    Self,
     Set,
     Tuple,
     Type,
@@ -120,6 +121,7 @@ DEFAULT_SLASH_DESCRIPTION = "No description provided."
 
 T = TypeVar("T")
 FuncT = TypeVar("FuncT", bound=Callable[..., Any])
+CmdT = TypeVar("CmdT", bound="Union[BaseApplicationCommand, SlashApplicationCommand]")
 # As nextcord.types exist, we cannot import types
 if TYPE_CHECKING:
     EllipsisType = ellipsis  # noqa: F821
@@ -170,6 +172,12 @@ class CallbackWrapper:
         async def test(interaction):
             await interaction.send("The description of this command should be in all uppercase!")
     """
+
+    @overload
+    def __new__(cls, callback: Union[Callable, CallbackWrapper]) -> Self: ...
+
+    @overload
+    def __new__(cls, callback: CmdT) -> CmdT: ...
 
     def __new__(
         cls,

--- a/nextcord/application_command.py
+++ b/nextcord/application_command.py
@@ -174,10 +174,12 @@ class CallbackWrapper:
     """
 
     @overload
-    def __new__(cls, callback: Union[Callable, CallbackWrapper]) -> Self: ...
+    def __new__(
+        cls, callback: Union[Callable, CallbackWrapper], *args: Any, **kwargs: Any
+    ) -> Self: ...
 
     @overload
-    def __new__(cls, callback: CmdT) -> CmdT: ...
+    def __new__(cls, callback: CmdT, *args: Any, **kwargs: Any) -> CmdT: ...
 
     def __new__(
         cls,

--- a/nextcord/audit_logs.py
+++ b/nextcord/audit_logs.py
@@ -28,8 +28,8 @@ from .object import Object
 from .permissions import PermissionOverwrite, Permissions
 
 __all__ = (
-    "AuditLogDiff",
     "AuditLogChanges",
+    "AuditLogDiff",
     "AuditLogEntry",
 )
 
@@ -464,7 +464,7 @@ class AuditLogEntry(Hashable):
         # I gave up trying to fix this
 
         elems: Dict[str, Any] = {}
-        channel_id = int(self.extra["channel_id"]) if self.extra.get("channel_id", None) else None
+        channel_id = int(self.extra["channel_id"]) if self.extra.get("channel_id", None) else None  # type: ignore
 
         if isinstance(self.action, enums.AuditLogAction) and self.extra:
             if self.action is enums.AuditLogAction.member_prune:
@@ -477,22 +477,22 @@ class AuditLogEntry(Hashable):
                 or self.action is enums.AuditLogAction.message_delete
             ):
                 elems = {
-                    "count": int(self.extra["count"]),
+                    "count": int(self.extra["count"]),  # type: ignore
                 }
             elif self.action is enums.AuditLogAction.member_disconnect:
                 # The member disconnect action has a dict with some information
                 elems = {
-                    "count": int(self.extra["count"]),
+                    "count": int(self.extra["count"]),  # type: ignore
                 }
             elif self.action.name.endswith("pin"):
                 # the pin actions have a dict with some information
                 elems = {
-                    "message_id": int(self.extra["message_id"]),
+                    "message_id": int(self.extra["message_id"]),  # type: ignore
                 }
             elif self.action.name.startswith("overwrite_"):
                 # the overwrite_ actions have a dict with some information
-                instance_id = int(self.extra["id"])
-                the_type = self.extra.get("type")
+                instance_id = int(self.extra["id"])  # type: ignore
+                the_type = self.extra.get("type")  # type: ignore
                 if the_type == "1":
                     self.extra = self._get_member(instance_id)
                 elif the_type == "0":
@@ -502,7 +502,7 @@ class AuditLogEntry(Hashable):
                         role.name = self.extra.get("role_name")  # type: ignore
                     self.extra = role  # type: ignore
             elif self.action.name.startswith("stage_instance"):
-                channel_id = int(self.extra["channel_id"])
+                channel_id = int(self.extra["channel_id"])  # type: ignore
                 elems = {"channel": self.guild.get_channel(channel_id) or Object(id=channel_id)}
             elif (
                 self.action is enums.AuditLogAction.auto_moderation_block_message
@@ -510,10 +510,10 @@ class AuditLogEntry(Hashable):
                 or self.action is enums.AuditLogAction.auto_moderation_user_communication_disabled
             ):
                 elems = {
-                    "rule_name": self.extra["auto_moderation_rule_name"],
+                    "rule_name": self.extra["auto_moderation_rule_name"],  # type: ignore
                     "rule_trigger_type": enums.try_enum(
                         enums.AutoModerationTriggerType,
-                        int(self.extra["auto_moderation_rule_trigger_type"]),
+                        int(self.extra["auto_moderation_rule_trigger_type"]),  # type: ignore
                     ),
                 }
 
@@ -521,7 +521,7 @@ class AuditLogEntry(Hashable):
         if channel_id and self.action:
             elems["channel"] = self.guild.get_channel_or_thread(channel_id) or Object(id=channel_id)
 
-        if type(self.extra) is dict:
+        if type(self.extra) is dict:  # type: ignore
             self.extra = type("_AuditLogProxy", (), elems)()  # type: ignore
 
         # this key is not present when the above is present, typically.

--- a/nextcord/channel.py
+++ b/nextcord/channel.py
@@ -297,7 +297,7 @@ class TextChannel(abc.Messageable, abc.GuildChannel, Hashable, PinsMixin):
     @overload
     async def edit(self) -> Optional[TextChannel]: ...
 
-    async def edit(self, *, reason: Optional[str] = None, **options):
+    async def edit(self, *, reason: Optional[str] = None, **options) -> Optional[TextChannel]:
         """|coro|
 
         Edits the channel.
@@ -1754,7 +1754,7 @@ class VoiceChannel(VocalGuildChannel, abc.Messageable):
     @overload
     async def edit(self) -> Optional[VoiceChannel]: ...
 
-    async def edit(self, *, reason: Optional[str] = None, **options):
+    async def edit(self, *, reason: Optional[str] = None, **options) -> Optional[VoiceChannel]:
         """|coro|
 
         Edits the channel.
@@ -2324,7 +2324,7 @@ class StageChannel(VocalGuildChannel, abc.Messageable):
     @overload
     async def edit(self) -> Optional[StageChannel]: ...
 
-    async def edit(self, *, reason: Optional[str] = None, **options):
+    async def edit(self, *, reason: Optional[str] = None, **options) -> Optional[StageChannel]:
         """|coro|
 
         Edits the channel.
@@ -2529,7 +2529,7 @@ class CategoryChannel(abc.GuildChannel, Hashable):
     @overload
     async def edit(self) -> Optional[CategoryChannel]: ...
 
-    async def edit(self, *, reason: Optional[str] = None, **options):
+    async def edit(self, *, reason: Optional[str] = None, **options) -> Optional[CategoryChannel]:
         """|coro|
 
         Edits the channel.

--- a/nextcord/client.py
+++ b/nextcord/client.py
@@ -1448,7 +1448,7 @@ class Client:
 
         for guild in self._connection.guilds:
             me = guild.me
-            if me is None:  # pyright: ignore[reportUnnecessaryComparison]
+            if me is None:
                 continue
 
             if activity is not None:

--- a/nextcord/components.py
+++ b/nextcord/components.py
@@ -169,11 +169,9 @@ class Button(Component):
         self.url: Optional[str] = data.get("url")
         self.disabled: bool = data.get("disabled", False)
         self.label: Optional[str] = data.get("label")
-        self.emoji: Optional[PartialEmoji]
-        try:
+        self.emoji: Optional[PartialEmoji] = None
+        if "emoji" in data:
             self.emoji = PartialEmoji.from_dict(data["emoji"])
-        except KeyError:
-            self.emoji = None
 
     def to_dict(self) -> ButtonComponentPayload:
         payload = {
@@ -556,10 +554,8 @@ class SelectOption:
 
     @classmethod
     def from_dict(cls, data: SelectOptionPayload) -> SelectOption:
-        try:
+        if "emoji" in data:
             emoji = PartialEmoji.from_dict(data["emoji"])
-        except KeyError:
-            emoji = None
 
         return cls(
             label=data["label"],

--- a/nextcord/emoji.py
+++ b/nextcord/emoji.py
@@ -148,7 +148,7 @@ class Emoji(_EmojiTag, AssetMixin):
         If roles is empty, the emoji is unrestricted.
         """
         guild = self.guild
-        if guild is None:  # pyright: ignore[reportUnnecessaryComparison]
+        if guild is None:
             return []
 
         return [role for role in guild.roles if self._roles.has(role.id)]

--- a/nextcord/enums.py
+++ b/nextcord/enums.py
@@ -2103,6 +2103,6 @@ def try_enum(cls: Type[T], val: Any) -> T:
     """
 
     try:
-        return cls(val)
+        return cls(val)  # pyright: ignore[reportCallIssue]
     except ValueError:
         return UnknownEnumValue(name=f"unknown_{val}", value=val)  # type: ignore

--- a/nextcord/ext/application_checks/core.py
+++ b/nextcord/ext/application_checks/core.py
@@ -165,7 +165,7 @@ def check(predicate: "ApplicationCheck") -> AC:
         return CheckWrapper(func, predicate)
 
     wrapper.predicate = predicate
-    return wrapper  # type: ignore
+    return wrapper
 
 
 def check_any(*checks: "ApplicationCheck") -> AC:

--- a/nextcord/ext/application_checks/core.py
+++ b/nextcord/ext/application_checks/core.py
@@ -165,7 +165,7 @@ def check(predicate: "ApplicationCheck") -> AC:
         return CheckWrapper(func, predicate)
 
     wrapper.predicate = predicate
-    return wrapper
+    return wrapper  # type: ignore
 
 
 def check_any(*checks: "ApplicationCheck") -> AC:

--- a/nextcord/ext/commands/cog.py
+++ b/nextcord/ext/commands/cog.py
@@ -95,7 +95,7 @@ class CogMeta(type):
     __cog_commands__: List[Command]
     __cog_listeners__: List[Tuple[str, str]]
 
-    def __new__(cls, *args: Any, **kwargs: Any) -> Self:
+    def __new__(cls, *args: Any, **kwargs: Any) -> CogMeta:
         name, bases, attrs = args
         attrs["__cog_name__"] = kwargs.pop("name", name)
         attrs["__cog_settings__"] = kwargs.pop("command_attrs", {})

--- a/nextcord/ext/commands/converter.py
+++ b/nextcord/ext/commands/converter.py
@@ -970,7 +970,7 @@ class clean_content(Converter[str]):
                     f"@{m.display_name if self.use_nicknames else m.name}" if m else "@deleted-user"
                 )
 
-            def resolve_role(id: int) -> str:  # pyright: ignore[reportGeneralTypeIssues]
+            def resolve_role(id: int) -> str:  # pyright: ignore[reportRedeclaration]
                 r = _utils_get(msg.role_mentions, id=id) or ctx.guild.get_role(id)  # type: ignore
                 return f"@{r.name}" if r else "@deleted-role"
 

--- a/nextcord/ext/commands/converter.py
+++ b/nextcord/ext/commands/converter.py
@@ -1119,7 +1119,7 @@ CONVERTER_MAPPING: Dict[Type[Any], Any] = {
 }
 
 
-async def _actual_conversion(ctx: Context, converter, argument: str, param: inspect.Parameter):
+async def _actual_conversion(ctx: Context, converter: Any, argument: str, param: inspect.Parameter):
     if converter is bool:
         return _convert_to_bool(argument)
 
@@ -1140,14 +1140,16 @@ async def _actual_conversion(ctx: Context, converter, argument: str, param: insp
             return await converter().convert(ctx, argument)
 
         if isinstance(converter, Converter):
-            return await converter.convert(ctx, argument)  # type: ignore
+            return await converter.convert(ctx, argument)
     except CommandError:
         raise
     except Exception as exc:
         raise ConversionError(converter, exc) from exc  # type: ignore
 
     try:
-        return converter(argument)
+        # pyright believes this to be Any | type[object], which is fine anyway
+        # but claims 0 positional arguments
+        return converter(argument)  # pyright: ignore
     except CommandError:
         raise
     except Exception as exc:

--- a/nextcord/ext/commands/converter.py
+++ b/nextcord/ext/commands/converter.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import inspect
 import re
+from types import GenericAlias
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -1088,11 +1089,8 @@ def get_converter(param: inspect.Parameter) -> Any:
     return converter
 
 
-_GenericAlias = type(List[T])
-
-
-def is_generic_type(tp: Any, *, _GenericAlias: Type = _GenericAlias) -> bool:
-    return isinstance(tp, type) and issubclass(tp, Generic) or isinstance(tp, _GenericAlias)
+def is_generic_type(tp: Any) -> bool:
+    return isinstance(tp, type) and issubclass(tp, Generic) or isinstance(tp, GenericAlias)
 
 
 CONVERTER_MAPPING: Dict[Type[Any], Any] = {

--- a/nextcord/ext/commands/converter.py
+++ b/nextcord/ext/commands/converter.py
@@ -1062,7 +1062,7 @@ class Greedy(List[T]):
             raise TypeError("Greedy[...] expects a type or a Converter instance.")
 
         if converter in (str, type(None)) or origin is Greedy:
-            raise TypeError(f"Greedy[{converter.__class__.__name__}] is invalid.")
+            raise TypeError(f"Greedy[{type(converter).__name__}] is invalid.")
 
         if origin is Union and type(None) in args:
             raise TypeError(f"Greedy[{converter!r}] is invalid.")

--- a/nextcord/ext/commands/converter.py
+++ b/nextcord/ext/commands/converter.py
@@ -1067,7 +1067,8 @@ class Greedy(List[T]):
         if origin is Union and type(None) in args:
             raise TypeError(f"Greedy[{converter!r}] is invalid.")
 
-        return cls(converter=converter)
+        # The type variable T is completely lost by this point.
+        return cls(converter=converter)  # pyright: ignore
 
 
 def _convert_to_bool(argument: str) -> bool:

--- a/nextcord/ext/commands/core.py
+++ b/nextcord/ext/commands/core.py
@@ -740,8 +740,12 @@ class Command(_BaseCommand, Generic[CogT, P, T]):
         entries = []
         command = self
         # command.parent is type-hinted as GroupMixin some attributes are resolved via MRO
+        #
+        # ooliver1: command.parent may sometimes be bot, but not always since that is only
+        # added via GroupMixin.add_command etc.
+        # This should probably be checked as it is quite the typing issue.
         while command.parent is not None:  # type: ignore
-            command = command.parent
+            command = command.parent  # type: ignore
             entries.append(command.name)  # type: ignore
 
         return " ".join(reversed(entries))
@@ -759,7 +763,7 @@ class Command(_BaseCommand, Generic[CogT, P, T]):
         entries = []
         command = self
         while command.parent is not None:  # type: ignore
-            command = command.parent
+            command = command.parent  # type: ignore
             entries.append(command)
 
         return entries
@@ -1491,7 +1495,7 @@ class GroupMixin(Generic[CogT]):
         def decorator(func: Callable[Concatenate[ContextT, P], Coro[Any]]) -> GroupT:
             kwargs.setdefault("parent", self)
             result = group(name, *args, cls=cls, **kwargs)(func)
-            self.add_command(result)  # type: ignore
+            self.add_command(result)
             return result  # type: ignore
 
         return decorator

--- a/nextcord/ext/commands/flags.py
+++ b/nextcord/ext/commands/flags.py
@@ -412,7 +412,7 @@ async def convert_flag(ctx, argument: str, flag: Flag, annotation: Any = None) -
             return await convert_flag(ctx, argument, flag, annotation)
         if origin is Union and annotation.__args__[-1] is type(None):
             # typing.Optional[x]  # noqa: ERA001
-            annotation = Union[annotation.__args__[:-1]]  # type: ignore
+            annotation = Union[annotation.__args__[:-1]]
             return await run_converters(ctx, annotation, argument, param)
         if origin is dict:
             # typing.Dict[K, V] -> typing.Tuple[K, V]

--- a/nextcord/gateway.py
+++ b/nextcord/gateway.py
@@ -12,7 +12,7 @@ import time
 import traceback
 import zlib
 from collections import deque, namedtuple
-from typing import TYPE_CHECKING, Awaitable, Callable, Dict, List, Optional, Union
+from typing import TYPE_CHECKING, Awaitable, Callable, Dict, List, Optional, Union, cast
 
 import aiohttp
 
@@ -502,7 +502,8 @@ class DiscordWebSocket:
                 return
 
             if op == self.INVALIDATE_SESSION:
-                if data is True:
+                resumable = cast(bool, data)
+                if resumable is True:
                     await self.close()
                     raise ReconnectWebSocket(self.shard_id)
 

--- a/nextcord/guild.py
+++ b/nextcord/guild.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import contextlib
 import copy
 import unicodedata
 import warnings
@@ -416,11 +415,8 @@ class Guild(Hashable):
             self._voice_states[user_id] = after
 
         member = self.get_member(user_id)
-        if member is None:
-            try:
-                member = Member(data=data["member"], state=self._state, guild=self)
-            except KeyError:
-                member = None
+        if member is None and (member_data := data.get("member")):
+            member = Member(data=member_data, guild=self, state=self._state)
 
         return member, before, after
 
@@ -540,8 +536,8 @@ class Guild(Hashable):
 
     # TODO: refactor/remove?
     def _sync(self, data: GuildPayload) -> None:
-        with contextlib.suppress(KeyError):
-            self._large = data["large"]
+        if large := data.get("large") is not None:
+            self._large = large
 
         empty_tuple = ()
         for presence in data.get("presences", []):

--- a/nextcord/interactions.py
+++ b/nextcord/interactions.py
@@ -182,31 +182,31 @@ class Interaction(Hashable, Generic[ClientT]):
     """
 
     __slots__: Tuple[str, ...] = (
-        "id",
-        "type",
-        "guild_id",
-        "channel_id",
-        "data",
-        "application_id",
-        "message",
-        "user",
-        "locale",
-        "guild_locale",
-        "token",
-        "version",
-        "authorizing_integration_owners",
-        "context",
-        "application_command",
-        "attached",
-        "_background_tasks",
-        "_permissions",
         "_app_permissions",
-        "_state",
-        "_session",
-        "_original_message",
-        "_cs_response",
-        "_cs_followup",
+        "_background_tasks",
         "_cs_channel",
+        "_cs_followup",
+        "_cs_response",
+        "_original_message",
+        "_permissions",
+        "_session",
+        "_state",
+        "application_command",
+        "application_id",
+        "attached",
+        "authorizing_integration_owners",
+        "channel_id",
+        "context",
+        "data",
+        "guild_id",
+        "guild_locale",
+        "id",
+        "locale",
+        "message",
+        "token",
+        "type",
+        "user",
+        "version",
     )
 
     def __init__(self, *, data: InteractionPayload, state: ConnectionState) -> None:
@@ -249,22 +249,12 @@ class Interaction(Hashable, Generic[ClientT]):
         # TODO: there's a potential data loss here
         if self.guild_id:
             guild = self.guild or Object(id=self.guild_id)
-            try:
-                member = data["member"]
-            except KeyError:
-                pass
-            else:
+            if member := data.get("member"):
                 cached_member = self.guild and self.guild.get_member(int(member["user"]["id"]))  # type: ignore # user key should be present here
                 self.user = cached_member or Member(state=self._state, guild=guild, data=member)  # type: ignore # user key should be present here
                 self._permissions = int(member.get("permissions", 0))
-        else:
-            try:
-                user = data["user"]
-                self.user = self._state.get_user(int(user["id"])) or User(
-                    state=self._state, data=user
-                )
-            except KeyError:
-                pass
+        elif user := data.get("user"):
+            self.user = self._state.get_user(int(user["id"])) or User(state=self._state, data=user)
 
         authorizing_integration_owners = data.get("authorizing_integration_owners")
         self.authorizing_integration_owners: Optional[Dict[IntegrationType, int]]
@@ -676,8 +666,8 @@ class InteractionResponse:
     """
 
     __slots__: Tuple[str, ...] = (
-        "_responded",
         "_parent",
+        "_responded",
     )
 
     def __init__(self, parent: Interaction) -> None:

--- a/nextcord/interactions.py
+++ b/nextcord/interactions.py
@@ -233,14 +233,11 @@ class Interaction(Hashable, Generic[ClientT]):
         self.locale: Optional[str] = data.get("locale")
         self.guild_locale: Optional[str] = data.get("guild_locale")
 
-        self.message: Optional[Message]
-        try:
-            message = data["message"]
+        self.message: Optional[Message] = None
+        if message := data.get("message"):
             self.message = self._state._get_message(int(message["id"])) or Message(
                 state=self._state, channel=self.channel, data=message  # type: ignore
             )
-        except KeyError:
-            self.message = None
 
         self.user: Optional[Union[User, Member]] = None
         self._app_permissions: int = int(data.get("app_permissions", 0))

--- a/nextcord/invite.py
+++ b/nextcord/invite.py
@@ -373,13 +373,9 @@ class Invite(Hashable):
 
     @classmethod
     def from_incomplete(cls, *, state: ConnectionState, data: InvitePayload) -> Self:
-        guild: Optional[Union[Guild, PartialInviteGuild]]
-        try:
-            guild_data = data["guild"]
-        except KeyError:
-            # If we're here, then this is a group DM
-            guild = None
-        else:
+        # If guild is None, this is a Group DM
+        guild: Optional[Union[Guild, PartialInviteGuild]] = None
+        if guild_data := data.get("guild"):
             guild_id = int(guild_data["id"])
             guild = state._get_guild(guild_id)
             if guild is None:

--- a/nextcord/member.py
+++ b/nextcord/member.py
@@ -366,10 +366,9 @@ class Member(abc.Messageable, _UserTag):
     def _update(self, data: MemberPayload) -> None:
         # the nickname change is optional,
         # if it isn't in the payload then it didn't change
-        with contextlib.suppress(KeyError):
+        if "nick" in data:
             self.nick = data["nick"]
-
-        with contextlib.suppress(KeyError):
+        if "pending" in data:
             self.pending = data["pending"]
 
         self.premium_since = utils.parse_time(data.get("premium_since"))

--- a/nextcord/message.py
+++ b/nextcord/message.py
@@ -2373,7 +2373,7 @@ class PartialMessage(Hashable):
 
         if fields:
             # data isn't unbound
-            msg = self._state.create_message(channel=self.channel, data=data)  # type: ignore
+            msg = self._state.create_message(channel=self.channel, data=data)
             if view and not view.is_finished() and view.prevent_update:
                 self._state.store_view(view, self.id)
             return msg

--- a/nextcord/raw_models.py
+++ b/nextcord/raw_models.py
@@ -68,10 +68,7 @@ class RawMessageDeleteEvent(_RawReprMixin):
         self.message_id: int = int(data["id"])
         self.channel_id: int = int(data["channel_id"])
         self.cached_message: Optional[Message] = None
-        try:
-            self.guild_id: Optional[int] = int(data["guild_id"])
-        except KeyError:
-            self.guild_id: Optional[int] = None
+        self.guild_id: Optional[int] = int(data["guild_id"]) if "guild_id" in data else None
 
 
 class RawBulkMessageDeleteEvent(_RawReprMixin):
@@ -95,11 +92,7 @@ class RawBulkMessageDeleteEvent(_RawReprMixin):
         self.message_ids: Set[int] = {int(x) for x in data.get("ids", [])}
         self.channel_id: int = int(data["channel_id"])
         self.cached_messages: List[Message] = []
-
-        try:
-            self.guild_id: Optional[int] = int(data["guild_id"])
-        except KeyError:
-            self.guild_id: Optional[int] = None
+        self.guild_id: Optional[int] = int(data["guild_id"]) if "guild_id" in data else None
 
 
 class RawMessageUpdateEvent(_RawReprMixin):
@@ -132,11 +125,7 @@ class RawMessageUpdateEvent(_RawReprMixin):
         self.channel_id: int = int(data["channel_id"])
         self.data: MessageUpdateEvent = data
         self.cached_message: Optional[Message] = None
-
-        try:
-            self.guild_id: Optional[int] = int(data["guild_id"])
-        except KeyError:
-            self.guild_id: Optional[int] = None
+        self.guild_id: Optional[int] = int(data["guild_id"]) if "guild_id" in data else None
 
 
 class RawReactionActionEvent(_RawReprMixin):
@@ -177,11 +166,7 @@ class RawReactionActionEvent(_RawReprMixin):
         self.emoji: PartialEmoji = emoji
         self.event_type: str = event_type
         self.member: Optional[Member] = None
-
-        try:
-            self.guild_id: Optional[int] = int(data["guild_id"])
-        except KeyError:
-            self.guild_id: Optional[int] = None
+        self.guild_id: Optional[int] = int(data["guild_id"]) if "guild_id" in data else None
 
 
 class RawReactionClearEvent(_RawReprMixin):
@@ -202,11 +187,7 @@ class RawReactionClearEvent(_RawReprMixin):
     def __init__(self, data: ReactionClearEvent) -> None:
         self.message_id: int = int(data["message_id"])
         self.channel_id: int = int(data["channel_id"])
-
-        try:
-            self.guild_id: Optional[int] = int(data["guild_id"])
-        except KeyError:
-            self.guild_id: Optional[int] = None
+        self.guild_id: Optional[int] = int(data["guild_id"]) if "guild_id" in data else None
 
 
 class RawReactionClearEmojiEvent(_RawReprMixin):
@@ -232,11 +213,7 @@ class RawReactionClearEmojiEvent(_RawReprMixin):
         self.emoji: PartialEmoji = emoji
         self.message_id: int = int(data["message_id"])
         self.channel_id: int = int(data["channel_id"])
-
-        try:
-            self.guild_id: Optional[int] = int(data["guild_id"])
-        except KeyError:
-            self.guild_id: Optional[int] = None
+        self.guild_id: Optional[int] = int(data["guild_id"]) if "guild_id" in data else None
 
 
 class RawIntegrationDeleteEvent(_RawReprMixin):
@@ -259,11 +236,8 @@ class RawIntegrationDeleteEvent(_RawReprMixin):
     def __init__(self, data: IntegrationDeleteEvent) -> None:
         self.integration_id: int = int(data["id"])
         self.guild_id: int = int(data["guild_id"])
-
-        try:
-            self.application_id: Optional[int] = int(data["application_id"])
-        except KeyError:
-            self.application_id: Optional[int] = None
+        self.application_id: Optional[int]
+        self.application_id = int(data["application_id"]) if "application_id" in data else None
 
 
 class RawTypingEvent(_RawReprMixin):
@@ -294,11 +268,7 @@ class RawTypingEvent(_RawReprMixin):
             data.get("timestamp"), tz=datetime.timezone.utc
         )
         self.member: Optional[Member] = None
-
-        try:
-            self.guild_id: Optional[int] = int(data["guild_id"])
-        except KeyError:
-            self.guild_id: Optional[int] = None
+        self.guild_id: Optional[int] = int(data["guild_id"]) if "guild_id" in data else None
 
 
 class RawMemberRemoveEvent(_RawReprMixin):

--- a/nextcord/role.py
+++ b/nextcord/role.py
@@ -257,12 +257,7 @@ class Role(Hashable):
         if self._icon is None:
             self._icon: Optional[str] = data.get("unicode_emoji", None)
         self.tags: Optional[RoleTags]
-
-        try:
-            self.tags = RoleTags(data["tags"])
-        except KeyError:
-            self.tags = None
-
+        self.tags = RoleTags(data["tags"]) if "tags" in data else None
         self._flags: int = data.get("flags", 0)
 
     def is_default(self) -> bool:

--- a/nextcord/shard.py
+++ b/nextcord/shard.py
@@ -598,7 +598,7 @@ class AutoShardedClient(Client):
         activities = () if activity is None else (activity,)
         for guild in guilds:
             me = guild.me
-            if me is None:  # type: ignore
+            if me is None:
                 continue
 
             # Member.activities is typehinted as Tuple[ActivityType, ...], we may be setting it as Tuple[BaseActivity, ...]

--- a/nextcord/state.py
+++ b/nextcord/state.py
@@ -2162,7 +2162,7 @@ class ConnectionState:
         self.dispatch("raw_typing", raw)
 
         channel, guild = self._get_guild_channel(data)
-        if channel is not None:  # pyright: ignore[reportUnnecessaryComparison]
+        if channel is not None:
             user = raw.member or self._get_typing_user(channel, raw.user_id)  # type: ignore
             # will be messageable channel if we get here
 

--- a/nextcord/state.py
+++ b/nextcord/state.py
@@ -2447,9 +2447,7 @@ class AutoShardedConnectionState(ConnectionState):
         for shard_id, info in itertools.groupby(guilds, key=key):
             children: Tuple[Guild]
             futures: Tuple[Future]
-            # zip with `*` should, and will, return 2 tuples since every element is 2 length
-            # but pyright believes otherwise.
-            children, futures = zip(*info, strict=False)  # type: ignore
+            children, futures = zip(*info, strict=False)
             # 110 reqs/minute w/ 1 req/guild plus some buffer
             timeout = 61 * (len(children) / 110)
             try:

--- a/nextcord/state.py
+++ b/nextcord/state.py
@@ -512,17 +512,16 @@ class ConnectionState:
         self, data: MessagePayload
     ) -> Tuple[Union[Channel, Thread], Optional[Guild]]:
         channel_id = int(data["channel_id"])
-        try:
-            guild = self._get_guild(int(data["guild_id"]))
-        except KeyError:
+        if guild_id := data.get("guild_id"):
+            guild = self._get_guild(int(guild_id))
+            channel = guild and guild._resolve_channel(channel_id)
+        else:
             channel = self.get_channel(channel_id)
 
             if channel is None:
                 channel = DMChannel._from_message(self, channel_id)
 
             guild = getattr(channel, "guild", None)
-        else:
-            channel = guild and guild._resolve_channel(channel_id)
 
         return channel or PartialMessageable(state=self, id=channel_id), guild
 

--- a/nextcord/threads.py
+++ b/nextcord/threads.py
@@ -171,11 +171,8 @@ class Thread(Messageable, Hashable, PinsMixin):
         self._unroll_metadata(data["thread_metadata"])
         self.flags: ChannelFlags = ChannelFlags._from_value(data.get("flags", 0))
 
-        try:
-            member = data["member"]
-        except KeyError:
-            self.me = None
-        else:
+        self.me = None
+        if member := data.get("member"):
             self.me = ThreadMember(self, member)
 
         self.applied_tag_ids: List[int] = [int(tag_id) for tag_id in data.get("applied_tags", [])]

--- a/nextcord/ui/modal.py
+++ b/nextcord/ui/modal.py
@@ -38,7 +38,7 @@ def _walk_component_interaction_data(
 ) -> Iterator[ComponentInteractionData]:
     for item in components:
         if "components" in item:
-            yield from item["components"]  # type: ignore
+            yield from item["components"]
         else:
             yield item
 

--- a/nextcord/user.py
+++ b/nextcord/user.py
@@ -484,7 +484,7 @@ class User(BaseUser, abc.Messageable):
             pass
 
     @classmethod
-    def _copy(cls, user: User):
+    def _copy(cls, user: Self) -> Self:
         self = super()._copy(user)
         self._stored = False
         return self

--- a/nextcord/utils.py
+++ b/nextcord/utils.py
@@ -536,9 +536,7 @@ async def maybe_coroutine(
     value = f(*args, **kwargs)
     if _isawaitable(value):
         return await value
-    return value  # type: ignore
-    # type ignored as `_isawaitable` provides `TypeGuard[Awaitable[Any]]`
-    # yet we need a more specific type guard
+    return value
 
 
 async def async_all(
@@ -567,7 +565,7 @@ async def sane_wait_for(
 def get_slots(cls: Type[Any]) -> Iterator[str]:
     for mro in reversed(cls.__mro__):
         try:
-            yield from mro.__slots__  # type: ignore # handled below
+            yield from mro.__slots__
         except AttributeError:
             continue
 
@@ -1018,7 +1016,7 @@ def evaluate_annotation(
         args = tp.__args__
         if not hasattr(tp, "__origin__"):
             if tp.__class__ is UnionType:
-                converted = Union[args]  # type: ignore
+                converted = Union[args]
                 return evaluate_annotation(converted, globals, locals, cache)
 
             return tp

--- a/nextcord/utils.py
+++ b/nextcord/utils.py
@@ -39,6 +39,7 @@ from typing import (
     Type,
     TypeVar,
     Union,
+    get_args,
     overload,
 )
 
@@ -975,11 +976,11 @@ def as_chunks(iterator: _Iter[T], max_size: int) -> _Iter[List[T]]:
 
 
 def flatten_literal_params(parameters: Iterable[Any]) -> Tuple[Any, ...]:
-    params = []
+    params: list[Any] = []
     literal_cls = type(Literal[0])
     for p in parameters:
         if isinstance(p, literal_cls):
-            params.extend(p.__args__)
+            params.extend(get_args(p))
         else:
             params.append(p)
     return tuple(params)

--- a/nextcord/widget.py
+++ b/nextcord/widget.py
@@ -154,16 +154,7 @@ class WidgetMember(BaseUser):
         self.deafened: Optional[bool] = data.get("deaf", False) or data.get("self_deaf", False)
         self.muted: Optional[bool] = data.get("mute", False) or data.get("self_mute", False)
         self.suppress: Optional[bool] = data.get("suppress", False)
-
-        try:
-            game = data["game"]
-        except KeyError:
-            activity = None
-        else:
-            activity = create_activity(state, game)
-
-        self.activity = activity
-
+        self.activity = create_activity(state, data["game"]) if "game" in data else None
         self.connected_channel: Optional[WidgetChannel] = connected_channel
 
     def __repr__(self) -> str:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,7 +58,7 @@ pre-commit = "3.5.0"
 taskipy = "1.10.3"
 slotscheck = "0.19.1"
 python-dotenv = "0.20.0"
-pyright = "1.1.317"
+pyright = "1.1.391"
 sphinx_autobuild = "2021.3.14"
 
 [tool.poetry.group.docs.dependencies]


### PR DESCRIPTION

## Summary

Fix typing issues to update all the way to 1.1.391 from 1.1.317.

The most common change is that Pyright now checks types enclosed in a try except KeyError, so many of my changes refactor these cases to use if statements to avoid the exception. This IMO reads better especially for long try except else blocks where the else block is many lines from the try.

Following from this I will be updating Ruff, and then finally enabling typing rules for the newer formats of ``|``, ``dict[]``, etc.
<!-- What is this pull request for? Does it fix any issues? -->

<!-- Link any issues if applicable.
Use keywords from https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests
-->

<!-- Uncomment based on the type of your changes below -->

## This is a **Code Change**

- [x] I have tested my changes.
- [x] I have updated the documentation to reflect the changes.
- [x] I have run `task pyright` and fixed the relevant issues.
