### PR TITLE
fix(user): use correct condition for default_avatar index

### DIFF
--- a/nextcord/user.py
+++ b/nextcord/user.py
@@ -152,7 +152,7 @@ class BaseUser(_UserTag):
         ..versionchanged:: 2.6
             Added handling for the new username system for users without a discriminator.
         """
-        if self.discriminator != "0":
+        if self.discriminator == "0":
             avatar_index = (self.id >> 22) % len(DefaultAvatar)
         else:
             avatar_index = int(self.discriminator) % 5


### PR DESCRIPTION
## Summary

Before the new username system was implemented, the defaut_avatar index used depended on the discriminator. By introducing the new username system, discriminators were all set to "0", and the index is now dependent on the user ID, but users still on the old system would keep using the index provided by their discriminator. (see https://discord.com/developers/docs/reference#image-formatting-cdn-endpoints)
This behaviour wasn't implemented correctly in nextcord : the condition for checking if a user is using the new username system was done in reverse, resulting in differences from the official client.
This PR aims to fix that.

## This is a **Code Change**

- [X] I have tested my changes.
- [X] I have run `task pyright` and fixed the relevant issues.
