### PR TITLE
typing(commands): improves type correctness by using a concrete retur…

### DIFF
--- a/nextcord/ext/commands/cog.py
+++ b/nextcord/ext/commands/cog.py
@@ -20,8 +20,8 @@ if TYPE_CHECKING:
     from .core import Command
 
 __all__ = (
-    "CogMeta",
     "Cog",
+    "CogMeta",
 )
 
 CogT = TypeVar("CogT", bound="Cog")
@@ -95,7 +95,7 @@ class CogMeta(type):
     __cog_commands__: List[Command]
     __cog_listeners__: List[Tuple[str, str]]
 
-    def __new__(cls, *args: Any, **kwargs: Any) -> Self:
+    def __new__(cls, *args: Any, **kwargs: Any) -> CogMeta:
         name, bases, attrs = args
         attrs["__cog_name__"] = kwargs.pop("name", name)
         attrs["__cog_settings__"] = kwargs.pop("command_attrs", {})


### PR DESCRIPTION
…n type for metaclass __new__

## Summary

<!-- What is this pull request for? Does it fix any issues? -->
Addresses a Pylance warning in the `CogMeta` metaclass. The `__new__` method was annotated with a return type of `typing.Self`, which causes the Pylance warning:
```
"Self" cannot be used within a metaclass (a subclass of "type")
```
<!-- Link any issues if applicable.
Use keywords from https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests
-->

<!-- Uncomment based on the type of your changes below -->

## This is a **Code Change**

- [x] I have run `task pyright` and fixed the relevant issues.
