### PR TITLE
ci: re-add `poetry export` command

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -26,6 +26,8 @@ jobs:
 
       - name: Install Poetry
         uses: snok/install-poetry@v1
+        with:
+          plugins: poetry-plugin-export
 
       - name: Set up python ${{ matrix.python-version }}
         uses: actions/setup-python@v4

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -85,6 +85,8 @@ jobs:
 
       - name: Install Poetry
         uses: snok/install-poetry@v1
+        with:
+          plugins: poetry-plugin-export
 
       - name: Set up python 3.12
         uses: actions/setup-python@v4


### PR DESCRIPTION
## Summary

<!-- What is this pull request for? Does it fix any issues? -->

<!-- Link any issues if applicable.
Use keywords from https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests
-->

<!-- Uncomment based on the type of your changes below -->


All of the related information can be found in the bikeshedding channel
Summary: Poetry has removed the `export` command thus failing all CIs in nextcord. This PR attempts to re-add the `export` command through an extension given in the warning of older poetry versions.
## This is a **Code Change**

- [ ] I have tested my changes.
- [ ] I have updated the documentation to reflect the changes.
- [ ] I have run `task pyright` and fixed the relevant issues.
