### PR TITLE
fix(http): corrected HTTP request keys for event editing

### DIFF
--- a/nextcord/http.py
+++ b/nextcord/http.py
@@ -4521,7 +4521,7 @@ class HTTPClient:
     ) -> Response[scheduled_events.ScheduledEvent]:
         valid_keys = {
             "channel_id",
-            "event_metadata",
+            "entity_metadata",
             "name",
             "privacy_level",
             "scheduled_start_time",


### PR DESCRIPTION
When editing an event, metadata was not being handled correctly. This was because the key for the event metadata was incorrectly set as 'event_metadata' instead of 'entity_metadata', as specified in the API documentation. Due to this mismatch, metadata was ignored when updating events.

This PR fixes the issue by ensuring the correct key ('entity_metadata') is used.

I have tested the changes, but no test are included. However since the API is clear on this issue and there are no other references to any of the functions affected, no problems should arise.

## Summary

- [x] I have tested my changes.
- [ ] I have updated the documentation to reflect the changes. (No need, as the issue is backend-related.)
- [ ] I have run `task pyright` and fixed the relevant issues. (Not run, but types were not affected.)