### PR TITLE
feat: id and guild id property for application commands

### DIFF
--- a/nextcord/application_command.py
+++ b/nextcord/application_command.py
@@ -2043,6 +2043,8 @@ class BaseApplicationCommand(CallbackMixin, CallbackWrapperMixin):
         CallbackMixin.__init__(self, callback=callback, parent_cog=parent_cog)
         self._state: Optional[ConnectionState] = None
         self.type = cmd_type or ApplicationCommandType(1)
+        self.id: int
+        self.guild_id: Optional[int] = None
         self.name: Optional[str] = name
         self.name_localizations: Optional[Dict[Union[str, Locale], str]] = name_localizations
         self._description: Optional[str] = description
@@ -2338,9 +2340,11 @@ class BaseApplicationCommand(CallbackMixin, CallbackWrapperMixin):
         """
         self._state = state
         command_id = int(data["id"])
+        self.id = command_id
         if guild_id := data.get("guild_id", None):
             guild_id = int(guild_id)
             self.command_ids[guild_id] = command_id
+            self.guild_id = guild_id
             self.guild_ids_to_rollout.add(guild_id)
         else:
             self.command_ids[None] = command_id


### PR DESCRIPTION
## Summary

<!-- What is this pull request for? Does it fix any issues? -->
Provides `.id` and `.guild_id` for Application Commands.
I am not sure about correctness of those changes, but should be good. I don't know why nextcord didn't had those properties before, as it should be there instead of using `.command_ids`. Seems more logical to me.
<!-- Link any issues if applicable.
Use keywords from https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests
-->

<!-- Uncomment based on the type of your changes below -->

<!--
## This is a **Code Change**

- [x ] I have tested my changes.
- [ ] I have updated the documentation to reflect the changes.
- [ ] I have run `task pyright` and fixed the relevant issues.
