### PR TITLE
fix(gateway): handle improper 1000 closures by Discord

### DIFF
--- a/nextcord/gateway.py
+++ b/nextcord/gateway.py
@@ -581,7 +581,10 @@ class DiscordWebSocket:
 
     def _can_handle_close(self) -> bool:
         code = self._close_code or self.socket.close_code
-        return code not in (1000, 4004, 4010, 4011, 4012, 4013, 4014)
+        # If the socket is closed remotely with 1000 and it's not our own explicit close
+        # then it's an improper close that should be handled and reconnected
+        is_improper_close = self._close_code is None and self.socket.close_code == 1000
+        return is_improper_close or code not in (1000, 4004, 4010, 4011, 4012, 4013, 4014)
 
     async def poll_event(self) -> None:
         """Polls for a DISPATCH event and handles the general gateway loop.


### PR DESCRIPTION
## Summary
Occasionally discord will disconnect bots connected to a voice channel with code 1000 which will lead to an error.

"cherry picked" from https://github.com/Rapptz/discord.py/commit/ed615887f073e0dd74de0c43d56a65934582e903

NB: I wanted to properly cherry-pick the commit (to maintain git blame), but since the two repositories use different folders this was the best I could do.
<!--
## This is a **Code Change**

- [x] I have tested my changes.
- [ ] I have updated the documentation to reflect the changes.
- [ ] I have run `task pyright` and fixed the relevant issues.