### PR TITLE
fix: specify correct types for Opus on Apple Silicon

### DIFF
--- a/nextcord/opus.py
+++ b/nextcord/opus.py
@@ -129,7 +129,7 @@ def _err_ne(result: T, func: Callable, args: List) -> T:
 # The fourth is the error handler.
 exported_functions: List[Tuple[Any, ...]] = [
     # Generic
-    ("opus_get_version_string", None, ctypes.c_char_p, None),
+    ("opus_get_version_string", [], ctypes.c_char_p, None),
     ("opus_strerror", [ctypes.c_int], ctypes.c_char_p, None),
     # Encoder functions
     ("opus_encoder_get_size", [ctypes.c_int], ctypes.c_int, None),
@@ -151,7 +151,7 @@ exported_functions: List[Tuple[Any, ...]] = [
         ctypes.c_int32,
         _err_lt,
     ),
-    ("opus_encoder_ctl", None, ctypes.c_int32, _err_lt),
+    ("opus_encoder_ctl", [EncoderStructPtr, ctypes.c_int], ctypes.c_int32, _err_lt),
     ("opus_encoder_destroy", [EncoderStructPtr], None, None),
     # Decoder functions
     ("opus_decoder_get_size", [ctypes.c_int], ctypes.c_int, None),
@@ -182,7 +182,7 @@ exported_functions: List[Tuple[Any, ...]] = [
         ctypes.c_int,
         _err_lt,
     ),
-    ("opus_decoder_ctl", None, ctypes.c_int32, _err_lt),
+    ("opus_decoder_ctl", [DecoderStructPtr, ctypes.c_int], ctypes.c_int32, _err_lt),
     ("opus_decoder_destroy", [DecoderStructPtr], None, None),
     (
         "opus_decoder_get_nb_samples",


### PR DESCRIPTION
## Summary

Cherry picking this [patch](https://github.com/Rapptz/discord.py/pull/8052)

Apple Silicon has a special calling convention for variadic functions. This is an issue when using the Opus encoder:

```
Python 3.13.2 (main, Feb  4 2025, 14:51:09) [Clang 16.0.0 (clang-1600.0.26.6)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> import nextcord.opus
>>> nextcord.opus.Encoder()
Traceback (most recent call last):
  File "<python-input-1>", line 1, in <module>
    nextcord.opus.Encoder()
    ~~~~~~~~~~~~~~~~~~~~~^^
  File "/Users/ad/projects/nextcord/nextcord/opus.py", line 342, in __init__
    self.set_bitrate(128)
    ~~~~~~~~~~~~~~~~^^^^^
  File "/Users/ad/projects/nextcord/nextcord/opus.py", line 363, in set_bitrate
    _lib.opus_encoder_ctl(self._state, CTL_SET_BITRATE, kbps * 1024)
    ~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/ad/projects/nextcord/nextcord/opus.py", line 113, in _err_lt
    raise OpusError(result)
nextcord.opus.OpusError: invalid argument
```

With the changes m13253 provided in the original PR:
```
Python 3.13.2 (main, Feb  4 2025, 14:51:09) [Clang 16.0.0 (clang-1600.0.26.6)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> import nextcord.opus
>>> nextcord.opus.Encoder()
<nextcord.opus.Encoder object at 0x107586900>
```

## This is a **Code Change**

- [x] I have tested my changes.
- [ ] I have updated the documentation to reflect the changes.
- [x] I have run `task pyright` and fixed the relevant issues.
