### PR TITLE
fix(components): prevent UnboundLocalError with missing emoji in SelectOptionPayload

### DIFF
--- a/nextcord/components.py
+++ b/nextcord/components.py
@@ -554,8 +554,7 @@ class SelectOption:
 
     @classmethod
     def from_dict(cls, data: SelectOptionPayload) -> SelectOption:
-        if "emoji" in data:
-            emoji = PartialEmoji.from_dict(data["emoji"])
+        emoji = PartialEmoji.from_dict(data["emoji"]) if "emoji" in data else None
 
         return cls(
             label=data["label"],


### PR DESCRIPTION
## Summary

This PR fixes a critical bug which causes bots to crash when receiving a message containing a select component with an option not having an emoji. The emoji variable was in that case not defined which caused an UnboundLocalError exception to be raised.

## This is a **Code Change**

- [X] I have tested my changes.
- [X] I have run `task pyright` and fixed the relevant issues.
