### PR TITLE
typing: add reportPossiblyUnboundVariable to pyright config

### DIFF
--- a/nextcord/message.py
+++ b/nextcord/message.py
@@ -2373,7 +2373,10 @@ class PartialMessage(Hashable):
 
         if fields:
             # data isn't unbound
-            msg = self._state.create_message(channel=self.channel, data=data)
+            msg = self._state.create_message(
+                channel=self.channel,
+                data=data,  # pyright: ignore[reportPossiblyUnboundVariable]
+            )
             if view and not view.is_finished() and view.prevent_update:
                 self._state.store_view(view, self.id)
             return msg

--- a/nextcord/voice_client.py
+++ b/nextcord/voice_client.py
@@ -44,6 +44,8 @@ if TYPE_CHECKING:
     )
     from .user import ClientUser
 
+    nacl = MISSING
+
 
 has_nacl: bool
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -144,6 +144,7 @@ pythonVersion = "3.12"
 # https://github.com/microsoft/pyright/blob/main/docs/configuration.md
 reportInvalidStringEscapeSequence = false
 reportPropertyTypeMismatch = true
+reportPossiblyUnboundVariable = true
 reportDuplicateImport = true
 reportUntypedFunctionDecorator = true
 reportUntypedClassDecorator = true


### PR DESCRIPTION
also see #1252

## Summary

from https://github.com/nextcord/nextcord/pull/1252#issuecomment-2815322206:

in early 2024 `reportPossiblyUnboundVariable` got split off from `reportUnboundVariable`, but didn't keep the same default configuration. reportUnboundVariable is basic = error, while reportPossiblyUnboundVariable is basic = off. (change appeared in pyright@1.1.348 for the first time)

pyright commit: https://github.com/microsoft/pyright/commit/91960fba49303f9a0fe3281d394c4d904e2d11b6


from [pyright/docs/configuration.md](https://github.com/microsoft/pyright/blob/main/docs/configuration.md):

| Diagnostic Rule                           | Off        | Basic      | Standard   | Strict     |
| :---------------------------------------- | :--------- | :--------- | :--------- | :--------- |
| reportUnboundVariable                     | "none"     | "error"    | "error"    | "error"    |
| reportPossiblyUnboundVariable             | "none"     | "none"     | "error"    | "error"    |

## This is NOT a **Code Change**

- [x] I have tested my changes.
- [x] I have run `task pyright` and fixed the relevant issues.
