### PR TITLE
feat!: make Member no longer require guild object.

### DIFF
--- a/nextcord/application_command.py
+++ b/nextcord/application_command.py
@@ -3539,9 +3539,10 @@ def get_users_from_interaction(
         #  users that read from interaction.data further down the line.
         for member_id, member_payload in member_payloads.copy().items():
             # If a member isn't in the cache, construct a new one.
-            if interaction.guild is None or (
-                not (member := interaction.guild.get_member(int(member_id)))
-                and "users" in data["resolved"]
+            member = None
+            if "users" in data["resolved"] and (
+                interaction.guild is None
+                or (not (member := interaction.guild.get_member(int(member_id))))
             ):
                 user_payload = data["resolved"]["users"][member_id]
                 # This is required to construct the Member.

--- a/nextcord/application_command.py
+++ b/nextcord/application_command.py
@@ -3538,19 +3538,16 @@ def get_users_from_interaction(
         # Because the payload is modified further down, a copy is made to avoid affecting methods or
         #  users that read from interaction.data further down the line.
         for member_id, member_payload in member_payloads.copy().items():
-            if interaction.guild is None:
-                raise TypeError("Cannot resolve members if Interaction.guild is None")
-
             # If a member isn't in the cache, construct a new one.
-            if (
+            if interaction.guild is None or (
                 not (member := interaction.guild.get_member(int(member_id)))
                 and "users" in data["resolved"]
             ):
                 user_payload = data["resolved"]["users"][member_id]
                 # This is required to construct the Member.
                 member_payload["user"] = user_payload
-                member = Member(data=member_payload, guild=interaction.guild, state=state)  # type: ignore
-                interaction.guild._add_member(member)
+                # Currently the guild ID isn't bundled with the member data, so we use the interaction's guild ID.
+                member = Member(data=member_payload, guild=interaction.guild, state=state, guild_id=interaction.guild_id)  # type: ignore
 
             if member is not None:
                 ret.append(member)


### PR DESCRIPTION
## Summary

<!-- What is this pull request for? Does it fix any issues? -->
Before this PR, `Member` objects required a corresponding `Guild` object to be instantiated. In an older era before interactions, this was fine. Nowadays, it's not only possible but expected (thanks UserApps) for a `Guild` object to not always be available.

This PR makes the `guild` parameter when creating `Member`s optional, and changes the various properties and methods to work with that.

<!-- Link any issues if applicable.
Use keywords from https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests
-->

<!-- Uncomment based on the type of your changes below -->

## This is a **Code Change**

- [ ] I have tested my changes.
- [ ] I have updated the documentation to reflect the changes.
- [ ] I have run `task pyright` and fixed the relevant issues.
