### PR TITLE
fix(voice): 4006 voice websocket connection error

### DIFF
--- a/nextcord/voice_client.py
+++ b/nextcord/voice_client.py
@@ -295,10 +295,7 @@ class VoiceClient(VoiceProtocol):
             )
             return
 
-        self.endpoint, _, _ = endpoint.rpartition(":")
-        if self.endpoint.startswith("wss://"):
-            # Just in case, strip it off since we're going to add it later
-            self.endpoint = self.endpoint[6:]
+        self.endpoint = endpoint.removeprefix("wss://")
 
         # This gets set later
         self.endpoint_ip = MISSING


### PR DESCRIPTION
## Summary

This PR is based on Rapptz/discord.py#10210 and Pycord-Development/pycord#2812, adapting them to nextcord

Fixes the 4006 errors caused by how nextcord handles the voice endpoints ports.

This PR fixes #1262.

## This is a **Code Change**

- [x] I have tested my changes.
- [x] I have updated the documentation to reflect the changes.
- [x] I have run `task pyright` and fixed the relevant issues.
