### PR TITLE
fix: return in finally

### DIFF
--- a/nextcord/gateway.py
+++ b/nextcord/gateway.py
@@ -143,7 +143,7 @@ class KeepAliveHandler(threading.Thread):
                     _log.exception("An error occurred while stopping the gateway. Ignoring.")
                 finally:
                     self.stop()
-                    return  # noqa: B012  # ignoring is intentional
+                return
 
             data = self.get_payload()
             _log.debug(self.msg, self.shard_id, data["d"])

--- a/nextcord/player.py
+++ b/nextcord/player.py
@@ -565,8 +565,8 @@ class FFmpegOpusAudio(FFmpegAudio):
                 _log.info("Fallback probe found codec=%s, bitrate=%s", codec, bitrate)
         else:
             _log.info("Probe found codec=%s, bitrate=%s", codec, bitrate)
-        finally:
-            return codec, bitrate  # noqa: B012  # all exception are caught already
+
+        return codec, bitrate
 
     @staticmethod
     def _probe_codec_native(


### PR DESCRIPTION
## Summary

Using `return` in a finally clauses is a SyntaxWarning in Python 3.14.
https://peps.python.org/pep-0765/

## This is a **Code Change**

- [ ] I have tested my changes.
- [ ] I have updated the documentation to reflect the changes.
- [ ] I have run `task pyright` and fixed the relevant issues.
