### PR TITLE
refactor: replace deprecated asyncio.iscoroutinefunction

### DIFF
--- a/docs/extensions/attributetable.py
+++ b/docs/extensions/attributetable.py
@@ -1,4 +1,3 @@
-import asyncio
 import importlib
 import inspect
 import re
@@ -234,7 +233,7 @@ def get_class_results(lookup, modulename, name, fullname):
 
         if value is not None:
             doc = value.__doc__ or ""
-            if asyncio.iscoroutinefunction(value) or doc.startswith("|coro|"):
+            if inspect.iscoroutinefunction(value) or doc.startswith("|coro|"):
                 key = _("Methods")
                 badge = attributetablebadge("async", "async")
                 badge["badge-type"] = _("coroutine")

--- a/nextcord/application_command.py
+++ b/nextcord/application_command.py
@@ -2,8 +2,8 @@
 
 from __future__ import annotations
 
-import asyncio
 import contextlib
+import inspect
 import logging
 import sys
 import warnings
@@ -657,7 +657,7 @@ class CallbackMixin:
             if isinstance(callback, CallbackWrapper):
                 self.callback = callback.callback
 
-            if not asyncio.iscoroutinefunction(self.callback):
+            if not inspect.iscoroutinefunction(self.callback):
                 raise TypeError(f"{self.error_name} Callback must be a coroutine")
 
         self.parent_cog = parent_cog
@@ -797,7 +797,7 @@ class CallbackMixin:
             )
 
         try:
-            if not asyncio.iscoroutinefunction(self.callback):
+            if not inspect.iscoroutinefunction(self.callback):
                 raise TypeError("Callback must be a coroutine")
             # While this arguably is Slash Commands only, we could do some neat stuff in the future with it in other
             #  commands. While Discord doesn't support anything else having Options, we
@@ -1027,7 +1027,7 @@ class CallbackMixin:
         callback: Callable[[:class:`Interaction`, :class:`ApplicationError`], :class:`asyncio.Awaitable[Any]`]
             The callback to call when an error occurs.
         """
-        if not asyncio.iscoroutinefunction(callback):
+        if not inspect.iscoroutinefunction(callback):
             raise TypeError("The error handler must be a coroutine.")
 
         self.error_callback = callback
@@ -1095,7 +1095,7 @@ class AutocompleteOptionMixin:
     def from_autocomplete_callback(self, callback: Callable) -> AutocompleteOptionMixin:
         """Parses a callback meant to be the autocomplete function."""
         self.autocomplete_callback = callback
-        if not asyncio.iscoroutinefunction(self.autocomplete_callback):
+        if not inspect.iscoroutinefunction(self.autocomplete_callback):
             raise TypeError("Callback must be a coroutine")
 
         skip_count = 2  # We skip the first and second args, they are always the Interaction and

--- a/nextcord/client.py
+++ b/nextcord/client.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
+import inspect
 import logging
 import signal
 import sys
@@ -1301,7 +1302,7 @@ class Client:
             The coroutine passed is not actually a coroutine.
         """
 
-        if not asyncio.iscoroutinefunction(coro):
+        if not inspect.iscoroutinefunction(coro):
             raise TypeError("event registered must be a coroutine function")
 
         setattr(self, coro.__name__, coro)
@@ -1334,7 +1335,7 @@ class Client:
         """
         name = func.__name__ if name is MISSING else name
 
-        if not asyncio.iscoroutinefunction(func):
+        if not inspect.iscoroutinefunction(func):
             raise TypeError("Listeners must be coroutines")
 
         if name in self.extra_events:
@@ -3029,7 +3030,7 @@ class Client:
         TypeError
             The coroutine passed is not actually a coroutine.
         """
-        if not asyncio.iscoroutinefunction(coro):
+        if not inspect.iscoroutinefunction(coro):
             raise TypeError("The pre-invoke hook must be a coroutine.")
 
         self._application_command_before_invoke = coro
@@ -3062,7 +3063,7 @@ class Client:
         TypeError
             The coroutine passed is not actually a coroutine.
         """
-        if not asyncio.iscoroutinefunction(coro):
+        if not inspect.iscoroutinefunction(coro):
             raise TypeError("The post-invoke hook must be a coroutine.")
 
         self._application_command_after_invoke = coro

--- a/nextcord/ext/application_checks/core.py
+++ b/nextcord/ext/application_checks/core.py
@@ -2,8 +2,8 @@
 
 from __future__ import annotations
 
-import asyncio
 import functools
+import inspect
 from typing import TYPE_CHECKING, Callable, Dict, Union
 
 import nextcord
@@ -58,7 +58,7 @@ class CheckWrapper(CallbackWrapper):
     def __init__(self, callback: Union[Callable, CallbackWrapper], predicate) -> None:
         super().__init__(callback)
 
-        if not asyncio.iscoroutinefunction(predicate):
+        if not inspect.iscoroutinefunction(predicate):
 
             @functools.wraps(predicate)
             async def async_wrapper(ctx):

--- a/nextcord/ext/commands/bot.py
+++ b/nextcord/ext/commands/bot.py
@@ -434,7 +434,7 @@ class BotBase(GroupMixin):
         TypeError
             The coroutine passed is not actually a coroutine.
         """
-        if not asyncio.iscoroutinefunction(coro):
+        if not inspect.iscoroutinefunction(coro):
             raise TypeError("The pre-invoke hook must be a coroutine.")
 
         self._before_invoke = coro
@@ -467,7 +467,7 @@ class BotBase(GroupMixin):
         TypeError
             The coroutine passed is not actually a coroutine.
         """
-        if not asyncio.iscoroutinefunction(coro):
+        if not inspect.iscoroutinefunction(coro):
             raise TypeError("The post-invoke hook must be a coroutine.")
 
         self._after_invoke = coro
@@ -670,7 +670,7 @@ class BotBase(GroupMixin):
 
         extras = extras or {}
         try:
-            if asyncio.iscoroutinefunction(setup):
+            if inspect.iscoroutinefunction(setup):
                 try:
                     # I don't want to deal with handling tasks with a niche feature.
                     asyncio.create_task(setup(self, **extras))  # noqa: RUF006

--- a/nextcord/ext/commands/cog.py
+++ b/nextcord/ext/commands/cog.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import asyncio
 import contextlib
 import inspect
 from typing import TYPE_CHECKING, Any, Callable, ClassVar, Dict, Generator, List, Tuple, TypeVar
@@ -130,7 +129,7 @@ class CogMeta(type):
                     if elem.startswith(("cog_", "bot_")):
                         raise TypeError(no_bot_cog.format(base, elem))
                     commands[elem] = value
-                elif asyncio.iscoroutinefunction(value):
+                elif inspect.iscoroutinefunction(value):
                     if not hasattr(value, "__cog_listener__"):
                         continue
 
@@ -284,7 +283,7 @@ class Cog(ClientCog, metaclass=CogMeta):
             actual = func
             if isinstance(actual, staticmethod):
                 actual = actual.__func__
-            if not asyncio.iscoroutinefunction(actual):
+            if not inspect.iscoroutinefunction(actual):
                 raise TypeError("Listener function must be a coroutine function.")
             actual.__cog_listener__ = True
             to_assign = name or actual.__name__

--- a/nextcord/ext/commands/core.py
+++ b/nextcord/ext/commands/core.py
@@ -288,7 +288,7 @@ class Command(_BaseCommand, Generic[CogT, P, T]):
         ],
         **kwargs: Any,
     ) -> None:
-        if not asyncio.iscoroutinefunction(func):
+        if not inspect.iscoroutinefunction(func):
             raise TypeError("Callback must be a coroutine.")
 
         name = kwargs.get("name") or func.__name__
@@ -1031,7 +1031,7 @@ class Command(_BaseCommand, Generic[CogT, P, T]):
             The coroutine passed is not actually a coroutine.
         """
 
-        if not asyncio.iscoroutinefunction(coro):
+        if not inspect.iscoroutinefunction(coro):
             raise TypeError("The error handler must be a coroutine.")
 
         self.on_error: Error = coro
@@ -1065,7 +1065,7 @@ class Command(_BaseCommand, Generic[CogT, P, T]):
         TypeError
             The coroutine passed is not actually a coroutine.
         """
-        if not asyncio.iscoroutinefunction(coro):
+        if not inspect.iscoroutinefunction(coro):
             raise TypeError("The pre-invoke hook must be a coroutine.")
 
         self._before_invoke = coro
@@ -1092,7 +1092,7 @@ class Command(_BaseCommand, Generic[CogT, P, T]):
         TypeError
             The coroutine passed is not actually a coroutine.
         """
-        if not asyncio.iscoroutinefunction(coro):
+        if not inspect.iscoroutinefunction(coro):
             raise TypeError("The post-invoke hook must be a coroutine.")
 
         self._after_invoke = coro
@@ -1860,7 +1860,7 @@ def check(predicate: Check) -> Callable[[T], T]:
 
         return func
 
-    if asyncio.iscoroutinefunction(predicate):
+    if inspect.iscoroutinefunction(predicate):
         decorator.predicate = predicate
     else:
 

--- a/nextcord/ext/tasks/__init__.py
+++ b/nextcord/ext/tasks/__init__.py
@@ -108,7 +108,7 @@ class Loop(Generic[LF]):
         self._last_iteration: datetime.datetime = MISSING
         self._next_iteration = None
 
-        if not asyncio.iscoroutinefunction(self.coro):
+        if not inspect.iscoroutinefunction(self.coro):
             raise TypeError(f"Expected coroutine function, not {type(self.coro).__name__!r}.")
 
     async def _call_loop_function(self, name: str, *args: Any, **kwargs: Any) -> None:
@@ -473,7 +473,7 @@ class Loop(Generic[LF]):
             The function was not a coroutine.
         """
 
-        if not asyncio.iscoroutinefunction(coro):
+        if not inspect.iscoroutinefunction(coro):
             raise TypeError(f"Expected coroutine function, received {coro.__class__.__name__!r}.")
 
         self._before_loop = coro
@@ -501,7 +501,7 @@ class Loop(Generic[LF]):
             The function was not a coroutine.
         """
 
-        if not asyncio.iscoroutinefunction(coro):
+        if not inspect.iscoroutinefunction(coro):
             raise TypeError(f"Expected coroutine function, received {coro.__class__.__name__!r}.")
 
         self._after_loop = coro
@@ -527,7 +527,7 @@ class Loop(Generic[LF]):
         TypeError
             The function was not a coroutine.
         """
-        if not asyncio.iscoroutinefunction(coro):
+        if not inspect.iscoroutinefunction(coro):
             raise TypeError(f"Expected coroutine function, received {coro.__class__.__name__!r}.")
 
         self._error = coro  # type: ignore  # `self` messes with the type checker

--- a/nextcord/member.py
+++ b/nextcord/member.py
@@ -2,9 +2,9 @@
 
 from __future__ import annotations
 
-import asyncio
 import contextlib
 import datetime
+import inspect
 import itertools
 import sys
 from operator import attrgetter
@@ -161,7 +161,7 @@ def flatten_user(cls):
             # probably a member function by now
             def generate_function(x, value):
                 # We want sphinx to properly show coroutine functions as coroutines
-                if asyncio.iscoroutinefunction(value):
+                if inspect.iscoroutinefunction(value):
 
                     async def general(self, *args, **kwargs):  # type: ignore
                         return await getattr(self._user, x)(*args, **kwargs)

--- a/nextcord/ui/button.py
+++ b/nextcord/ui/button.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-import asyncio
+import inspect
 import os
 from typing import TYPE_CHECKING, Callable, Optional, Tuple, TypeVar, Union
 
@@ -258,7 +258,7 @@ def button(
     def decorator(
         func: ItemCallbackType[Button[V_co], ClientT]
     ) -> ItemCallbackType[Button[V_co], ClientT]:
-        if not asyncio.iscoroutinefunction(func):
+        if not inspect.iscoroutinefunction(func):
             raise TypeError("Button function must be a coroutine function")
 
         func.__discord_ui_model_type__ = Button

--- a/nextcord/ui/select/channel.py
+++ b/nextcord/ui/select/channel.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-import asyncio
+import inspect
 from typing import TYPE_CHECKING, Callable, Generic, List, Optional, Tuple, TypeVar
 
 from ...abc import GuildChannel
@@ -190,7 +190,7 @@ def channel_select(
     """
 
     def decorator(func: ItemCallbackType) -> ItemCallbackType:
-        if not asyncio.iscoroutinefunction(func):
+        if not inspect.iscoroutinefunction(func):
             raise TypeError("Select function must be a coroutine function")
 
         func.__discord_ui_model_type__ = ChannelSelect

--- a/nextcord/ui/select/mentionable.py
+++ b/nextcord/ui/select/mentionable.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-import asyncio
+import inspect
 from typing import TYPE_CHECKING, Callable, Generic, List, Optional, Tuple, TypeVar
 
 from ...components import MentionableSelectMenu
@@ -195,7 +195,7 @@ def mentionable_select(
     """
 
     def decorator(func: ItemCallbackType) -> ItemCallbackType:
-        if not asyncio.iscoroutinefunction(func):
+        if not inspect.iscoroutinefunction(func):
             raise TypeError("Select function must be a coroutine function")
 
         func.__discord_ui_model_type__ = MentionableSelect

--- a/nextcord/ui/select/role.py
+++ b/nextcord/ui/select/role.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-import asyncio
+import inspect
 from typing import TYPE_CHECKING, Callable, Generic, List, Optional, Tuple, TypeVar
 
 from ...components import RoleSelectMenu
@@ -180,7 +180,7 @@ def role_select(
     """
 
     def decorator(func: ItemCallbackType) -> ItemCallbackType:
-        if not asyncio.iscoroutinefunction(func):
+        if not inspect.iscoroutinefunction(func):
             raise TypeError("Select function must be a coroutine function")
 
         func.__discord_ui_model_type__ = RoleSelect

--- a/nextcord/ui/select/string.py
+++ b/nextcord/ui/select/string.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-import asyncio
+import inspect
 from typing import TYPE_CHECKING, Callable, Generic, List, Optional, Tuple, TypeVar, Union
 
 from ...components import SelectOption, StringSelectMenu
@@ -247,7 +247,7 @@ def string_select(
     def decorator(
         func: ItemCallbackType[Select[V_co], ClientT]
     ) -> ItemCallbackType[Select[V_co], ClientT]:
-        if not asyncio.iscoroutinefunction(func):
+        if not inspect.iscoroutinefunction(func):
             raise TypeError("Select function must be a coroutine function")
 
         func.__discord_ui_model_type__ = StringSelect

--- a/nextcord/ui/select/user.py
+++ b/nextcord/ui/select/user.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-import asyncio
+import inspect
 from typing import TYPE_CHECKING, Callable, Generic, List, Optional, Tuple, TypeVar
 
 from ...components import UserSelectMenu
@@ -185,7 +185,7 @@ def user_select(
     """
 
     def decorator(func: ItemCallbackType) -> ItemCallbackType:
-        if not asyncio.iscoroutinefunction(func):
+        if not inspect.iscoroutinefunction(func):
             raise TypeError("Select function must be a coroutine function")
 
         func.__discord_ui_model_type__ = UserSelect


### PR DESCRIPTION
## Summary
Python 3.14 will deprecated `asyncio.iscoroutinefunction` in favor of `inspect.iscoroutinefunction` which has been available for some time now.

https://docs.python.org/3.14/deprecations/pending-removal-in-3.16.html
https://docs.python.org/3.14/library/inspect.html#inspect.iscoroutinefunction