### PR TITLE
fix: forbid CONIN$ and CONOUT$ in to_path

### DIFF
--- a/nextcord/__main__.py
+++ b/nextcord/__main__.py
@@ -189,6 +189,8 @@ def to_path(parser, name: str, *, replace_spaces: bool = False):
             "LPT7",
             "LPT8",
             "LPT9",
+            "CONIN$",
+            "CONOUT$",
         )
         if len(name) <= 4 and name.upper() in forbidden:
             parser.error("invalid directory name given, use a different one")


### PR DESCRIPTION
## Summary

As suggested in https://github.com/nextcord/nextcord/issues/1258, this adds CONIN$ and CONOUT$ to the forbidden paths list in `to_path` in `nextcord/__main__.py`, as these aren't real paths on Windows and won't be interpreted by the OS as filesystem entries.

## This is a **Code Change**

- [x] I have tested my changes.
- [x] I have updated the documentation to reflect the changes.
- [x] I have run `task pyright` and fixed the relevant issues.
