### PR TITLE
fix(voice): send speaking packet on reconnect

### DIFF
--- a/nextcord/player.py
+++ b/nextcord/player.py
@@ -696,12 +696,10 @@ class AudioPlayer(threading.Thread):
             raise TypeError('Expected a callable for the "after" parameter.')
 
     def _do_run(self) -> None:
-        self.loops = 0
-        self._start = time.perf_counter()
+        self._reset_state(speak=True)
 
         # getattr lookup speed ups
         play_audio = self.client.send_audio_packet
-        self._speak(True)
 
         while not self._end.is_set():
             # are we paused?
@@ -715,8 +713,7 @@ class AudioPlayer(threading.Thread):
                 # wait until we are connected
                 self._connected.wait()
                 # reset our internal data
-                self.loops = 0
-                self._start = time.perf_counter()
+                self._reset_state(speak=self._resumed.is_set())
 
             self.loops += 1
             data = self.source.read()
@@ -729,6 +726,14 @@ class AudioPlayer(threading.Thread):
             next_time = self._start + self.DELAY * self.loops
             delay = max(0, self.DELAY + (next_time - time.perf_counter()))
             time.sleep(delay)
+
+    # this is called right after (re)connecting;
+    # reset the timings and set the speaking state accordingly
+    def _reset_state(self, *, speak: bool) -> None:
+        self.loops = 0
+        self._start = time.perf_counter()
+        if speak:
+            self._speak(True)
 
     def run(self) -> None:
         try:


### PR DESCRIPTION
## Summary

`AudioPlayer` would previously not update the [`SPEAKING`](https://discord.com/developers/docs/topics/voice-connections#speaking) state to a non-zero value after reconnecting (which happens when moving between channels, for instance). This results in the bot continuing to send audio packets, which aren't processed by Discord as the speaking state would still be `0`.

Cherry-picked from https://github.com/DisnakeDev/disnake/commit/25ba55c53c41908327229b41008d007ef5659fa3

Closes #882

## This is a **Code Change**

- [ ] I have tested my changes.
- [x] I have run `task pyright` and fixed the relevant issues.
