### PR TITLE
fix(history_iterator): messages repeat if before & after not set

### DIFF
--- a/nextcord/abc.py
+++ b/nextcord/abc.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import copy
+import warnings
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -29,7 +30,7 @@ from .errors import ClientException, InvalidArgument
 from .file import File
 from .flags import ChannelFlags, MessageFlags
 from .invite import Invite
-from .iterators import history_iterator
+from .iterators import OLDEST_OBJECT, history_iterator
 from .mentions import AllowedMentions
 from .partial_emoji import PartialEmoji
 from .permissions import PermissionOverwrite, Permissions
@@ -1654,9 +1655,9 @@ class Messageable:
         *,
         limit: Optional[int] = 100,
         before: Optional[SnowflakeTime] = None,
-        after: Optional[SnowflakeTime] = None,
+        after: Optional[SnowflakeTime] = OLDEST_OBJECT,
         around: Optional[SnowflakeTime] = None,
-        oldest_first: Optional[bool] = None,
+        oldest_first: Optional[bool] = True,
     ) -> AsyncIterator[Message]:
         """|asynciter|
 
@@ -1712,6 +1713,21 @@ class Messageable:
         :class:`~nextcord.Message`
             The message with the message data parsed.
         """
+        if oldest_first is None:
+            warnings.warn(
+                "Passing None for oldest_first is deprecated. It now defaults to True.",
+                FutureWarning,
+                stacklevel=2,
+            )
+            oldest_first = True
+        if after is None:
+            warnings.warn(
+                "Passing None for after is deprecated. It now defaults to OLDEST_OBJECT.",
+                FutureWarning,
+                stacklevel=2,
+            )
+            after = OLDEST_OBJECT
+
         return history_iterator(
             self, limit=limit, before=before, after=after, around=around, oldest_first=oldest_first
         )

--- a/nextcord/iterators.py
+++ b/nextcord/iterators.py
@@ -171,6 +171,7 @@ async def history_iterator(
     elif reverse:
         after_stategy = True
         if before is not None:
+
             def _check(msg: MessagePayload):
                 b = cast("Object | Snowflake | None", before)
                 return b is not None and int(msg["id"]) < b.id
@@ -179,6 +180,7 @@ async def history_iterator(
     else:
         before_strategy = True
         if after != OLDEST_OBJECT:
+
             def _check(msg: MessagePayload):
                 a = cast("Object | Snowflake | None", after)
                 return a is not None and int(msg["id"]) > a.id
@@ -196,17 +198,11 @@ async def history_iterator(
 
     while get_retrieve():
         if around is not None and around_strategy:
-            data = await state.http.logs_from(
-                channel.id, retrieve, around=around.id
-            )
+            data = await state.http.logs_from(channel.id, retrieve, around=around.id)
         elif before is not None and before_strategy:
-            data = await state.http.logs_from(
-                channel.id, retrieve, before=before.id
-            )
+            data = await state.http.logs_from(channel.id, retrieve, before=before.id)
         else:
-            data = await state.http.logs_from(
-                channel.id, retrieve, after=after.id
-            )
+            data = await state.http.logs_from(channel.id, retrieve, after=after.id)
 
         if data:
             if limit is not None:

--- a/nextcord/iterators.py
+++ b/nextcord/iterators.py
@@ -97,6 +97,8 @@ async def history_iterator(
     ``after``, sorted with newest first. For filling over 100 messages, update the
     ``after`` parameter to the newest message received. If messages are not
     reversed, they will be out of order (99-0, 199-100, so on)
+    If neither are specified, it will default to ``after`` set to
+    ``OLDEST_OBJECT``.
 
     A note that if both ``before`` and ``after`` are specified, ``before`` is ignored by the
     messages endpoint.
@@ -130,11 +132,12 @@ async def history_iterator(
     if isinstance(around, datetime.datetime):
         around = Object(id=time_snowflake(around))
 
+    reverse = after is not None if oldest_first is None else oldest_first
+    after = after or OLDEST_OBJECT
+
     state = messageable._state
     channel = await messageable._get_channel()
     retrieve = 0
-
-    reverse = after is not None if oldest_first is None else oldest_first
 
     checks: List[Callable[[MessagePayload], bool]] = []
     if around:
@@ -154,11 +157,11 @@ async def history_iterator(
 
             checks.append(_check)
 
-        if after is not None:
+        if after != OLDEST_OBJECT:
 
             def _check(msg: MessagePayload):
                 a = cast("Object | Snowflake | None", after)
-                return a is not None and a.id < int(msg["id"])
+                return a is not None and int(msg["id"]) > a.id
 
             checks.append(_check)
 
@@ -176,7 +179,7 @@ async def history_iterator(
             channel.id,
             retrieve,
             before.id if before is not None and around is None else None,
-            after.id if after is not None and around is None else None,
+            after.id if after != OLDEST_OBJECT and around is None else None,
             around.id if around is not None else None,
         )
 
@@ -186,7 +189,8 @@ async def history_iterator(
 
             if before is not None:
                 before = Object(id=int(data[-1]["id"]))
-            if after is not None:
+            # case where before & after is set, after is set, or after is not set (defaults to after being set to OLDEST_OBJECT)
+            if around is None:
                 after = Object(id=int(data[0]["id"]))
             if around is not None:
                 around = None

--- a/nextcord/iterators.py
+++ b/nextcord/iterators.py
@@ -82,9 +82,9 @@ async def history_iterator(
     messageable: Messageable,
     limit: Optional[int],
     before: Optional[SnowflakeTime] = None,
-    after: Optional[SnowflakeTime] = None,
+    after: SnowflakeTime = OLDEST_OBJECT,
     around: Optional[SnowflakeTime] = None,
-    oldest_first: Optional[bool] = None,
+    oldest_first: bool = True,
 ):
     """Iterator for receiving a channel's message history.
 
@@ -132,8 +132,10 @@ async def history_iterator(
     if isinstance(around, datetime.datetime):
         around = Object(id=time_snowflake(around))
 
-    reverse = after is not None if oldest_first is None else oldest_first
-    after = after or OLDEST_OBJECT
+    reverse = oldest_first
+    before_strategy = False
+    after_stategy = False
+    around_strategy = False
 
     state = messageable._state
     channel = await messageable._get_channel()
@@ -145,6 +147,8 @@ async def history_iterator(
             raise ValueError("history does not support around with limit=None")
         if limit > 100:
             raise ValueError("history max limit 100 when specifying around parameter")
+
+        around_strategy = True
 
         # in nested functions, pyright thinks that the before and after parameters are
         # their old definitions as a parameter, so we manually cast in the functions
@@ -164,6 +168,22 @@ async def history_iterator(
                 return a is not None and int(msg["id"]) > a.id
 
             checks.append(_check)
+    elif reverse:
+        after_stategy = True
+        if before is not None:
+            def _check(msg: MessagePayload):
+                b = cast("Object | Snowflake | None", before)
+                return b is not None and int(msg["id"]) < b.id
+
+            checks.append(_check)
+    else:
+        before_strategy = True
+        if after != OLDEST_OBJECT:
+            def _check(msg: MessagePayload):
+                a = cast("Object | Snowflake | None", after)
+                return a is not None and int(msg["id"]) > a.id
+
+            checks.append(_check)
 
     # we combine all of the checks together so we only have to replace the data payload once
     check: Callable[[MessagePayload], bool] = lambda m: all(c(m) for c in checks)
@@ -175,25 +195,29 @@ async def history_iterator(
         return retrieve > 0
 
     while get_retrieve():
-        data: List[MessagePayload] = await state.http.logs_from(
-            channel.id,
-            retrieve,
-            before.id if before is not None and around is None else None,
-            after.id if after != OLDEST_OBJECT and around is None else None,
-            around.id if around is not None else None,
-        )
+        if around is not None and around_strategy:
+            data = await state.http.logs_from(
+                channel.id, retrieve, around=around.id
+            )
+        elif before is not None and before_strategy:
+            data = await state.http.logs_from(
+                channel.id, retrieve, before=before.id
+            )
+        else:
+            data = await state.http.logs_from(
+                channel.id, retrieve, after=after.id
+            )
 
         if data:
             if limit is not None:
                 limit -= retrieve
 
-            if before is not None:
-                before = Object(id=int(data[-1]["id"]))
-            # case where before & after is set, after is set, or after is not set (defaults to after being set to OLDEST_OBJECT)
-            if around is None:
-                after = Object(id=int(data[0]["id"]))
-            if around is not None:
+            if around_strategy:
                 around = None
+            if before_strategy:
+                before = Object(id=int(data[-1]["id"]))
+            if after_stategy:
+                after = Object(id=int(data[0]["id"]))
 
         if len(data) < 100:
             limit = 0

--- a/nextcord/iterators.py
+++ b/nextcord/iterators.py
@@ -134,7 +134,7 @@ async def history_iterator(
 
     reverse = oldest_first
     before_strategy = False
-    after_stategy = False
+    after_strategy = False
     around_strategy = False
 
     state = messageable._state
@@ -169,7 +169,7 @@ async def history_iterator(
 
             checks.append(_check)
     elif reverse:
-        after_stategy = True
+        after_strategy = True
         if before is not None:
 
             def _check(msg: MessagePayload):
@@ -199,8 +199,10 @@ async def history_iterator(
     while get_retrieve():
         if around is not None and around_strategy:
             data = await state.http.logs_from(channel.id, retrieve, around=around.id)
-        elif before is not None and before_strategy:
-            data = await state.http.logs_from(channel.id, retrieve, before=before.id)
+        elif before_strategy:
+            data = await state.http.logs_from(
+                channel.id, retrieve, before=before.id if before is not None else None
+            )
         else:
             data = await state.http.logs_from(channel.id, retrieve, after=after.id)
 
@@ -212,7 +214,7 @@ async def history_iterator(
                 around = None
             if before_strategy:
                 before = Object(id=int(data[-1]["id"]))
-            if after_stategy:
+            if after_strategy:
                 after = Object(id=int(data[0]["id"]))
 
         if len(data) < 100:


### PR DESCRIPTION
## Summary

<!-- What is this pull request for? Does it fix any issues? -->

fixes #1238, an issue introduced with the async iterator rewrite in 3.0 where messages would loop every 100 messages due to the `after` parameter never being updated. I also updated the documentation a bit to clarify this default behavior of the iterator since the original documentation never mentions it.

<!-- Link any issues if applicable.
Use keywords from https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests
-->

<!-- Uncomment based on the type of your changes below -->

## This is a **Code Change**

- [x] I have tested my changes.
- [x] I have updated the documentation to reflect the changes.
- [x] I have run `task pyright` and fixed the relevant issues.
