### PR TITLE
feat(voice): add SSRC-to-user mapping

### DIFF
--- a/nextcord/gateway.py
+++ b/nextcord/gateway.py
@@ -754,7 +754,7 @@ class DiscordVoiceWebSocket:
     SESSION_DESCRIPTION
         Receive only. Gives you the secret key required for voice.
     SPEAKING
-        Send only. Notifies the client if you are currently speaking.
+        Bidirectional. Notifies when you or others are speaking.
     HEARTBEAT_ACK
         Receive only. Tells you your heartbeat has been acknowledged.
     RESUME
@@ -909,9 +909,76 @@ class DiscordVoiceWebSocket:
             interval = data["heartbeat_interval"] / 1000.0
             self._keep_alive = VoiceKeepAliveHandler(ws=self, interval=min(interval, 5.0))
             self._keep_alive.start()
+        elif op == self.SPEAKING:
+            await self.handle_speaking(data)
+        elif op == self.CLIENT_CONNECT:
+            await self.handle_client_connect(data)
+        elif op == self.CLIENT_DISCONNECT:
+            await self.handle_client_disconnect(data)
 
         if self._hook is not None:
             await self._hook(self, msg)
+
+    async def handle_speaking(self, data: Dict[str, Any]) -> None:
+        """Handle SPEAKING opcode (5) - user started/stopped speaking.
+
+        Parameters
+        ----------
+        data: Dict[:class:`str`, Any]
+            The payload data containing user_id, ssrc, and speaking state.
+        """
+        user_id = int(data.get("user_id", 0))
+        ssrc = data.get("ssrc")
+        speaking = data.get("speaking", 0)
+
+        if ssrc and user_id:
+            self._connection.ssrc_map[ssrc] = user_id
+            _log.debug(
+                "SPEAKING event: SSRC %s mapped to user_id %s (speaking=%s)",
+                ssrc,
+                user_id,
+                speaking,
+            )
+
+    async def handle_client_connect(self, data: Dict[str, Any]) -> None:
+        """Handle CLIENT_CONNECT opcode (12) - user joined voice channel.
+
+        Parameters
+        ----------
+        data: Dict[:class:`str`, Any]
+            The payload data containing user_id and audio_ssrc.
+        """
+        user_id = int(data.get("user_id", 0))
+        audio_ssrc = data.get("audio_ssrc")
+
+        if audio_ssrc and user_id:
+            self._connection.ssrc_map[audio_ssrc] = user_id
+            _log.info("CLIENT_CONNECT event: SSRC %s mapped to user_id %s", audio_ssrc, user_id)
+
+    async def handle_client_disconnect(self, data: Dict[str, Any]) -> None:
+        """Handle CLIENT_DISCONNECT opcode (13) - user left voice channel.
+
+        Parameters
+        ----------
+        data: Dict[:class:`str`, Any]
+            The payload data containing user_id.
+        """
+        user_id = int(data.get("user_id", 0))
+
+        # Remove the SSRC mapping for this user
+        ssrc_to_remove = None
+        for ssrc, uid in self._connection.ssrc_map.items():
+            if uid == user_id:
+                ssrc_to_remove = ssrc
+                break
+
+        if ssrc_to_remove is not None:
+            del self._connection.ssrc_map[ssrc_to_remove]
+            _log.info(
+                "CLIENT_DISCONNECT event: user_id %s (SSRC %s) removed",
+                user_id,
+                ssrc_to_remove,
+            )
 
     async def initial_connection(self, data: Dict[str, Any]) -> None:
         state = self._connection

--- a/nextcord/voice_client.py
+++ b/nextcord/voice_client.py
@@ -22,7 +22,7 @@ import logging
 import socket
 import struct
 import threading
-from typing import TYPE_CHECKING, Any, Callable, List, Optional, Tuple, Union, cast
+from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Tuple, Union, cast
 
 from . import opus, utils
 from .backoff import ExponentialBackoff
@@ -198,6 +198,8 @@ class VoiceClient(VoiceProtocol):
         The voice channel connected to.
     loop: :class:`asyncio.AbstractEventLoop`
         The event loop that the voice client is running on.
+    ssrc_map: Dict[:class:`int`, :class:`int`]
+        A mapping of SSRC identifiers to Discord user IDs for voice participants.
     """
 
     endpoint_ip: str
@@ -235,6 +237,7 @@ class VoiceClient(VoiceProtocol):
         self.encoder: Encoder = MISSING
         self._lite_nonce: int = 0
         self.ws: DiscordVoiceWebSocket = MISSING
+        self.ssrc_map: Dict[int, int] = {}
 
     warn_nacl = not has_nacl
     supported_modes: Tuple[SupportedModes, ...] = (
@@ -252,6 +255,21 @@ class VoiceClient(VoiceProtocol):
     def user(self) -> ClientUser:
         """:class:`ClientUser`: The user connected to voice (i.e. ourselves)."""
         return self._state.user  # type: ignore # [should exist]
+
+    def get_user_id_from_ssrc(self, ssrc: int) -> Optional[int]:
+        """Get the Discord user_id for a given SSRC.
+
+        Parameters
+        ----------
+        ssrc: :class:`int`
+            The RTP SSRC identifier from the voice packet.
+
+        Returns
+        -------
+        Optional[:class:`int`]
+            The Discord user_id, or None if the SSRC is not found.
+        """
+        return self.ssrc_map.get(ssrc)
 
     def checked_add(self, attr, value, limit: int) -> None:
         val = getattr(self, attr)

--- a/nextcord/voice_client.py
+++ b/nextcord/voice_client.py
@@ -259,6 +259,8 @@ class VoiceClient(VoiceProtocol):
     def get_user_id_from_ssrc(self, ssrc: int) -> Optional[int]:
         """Get the Discord user_id for a given SSRC.
 
+        .. versionadded:: 3.2.0
+
         Parameters
         ----------
         ssrc: :class:`int`


### PR DESCRIPTION
Summary

Add SSRC → user_id tracking to VoiceClient and wire up handlers in DiscordVoiceWebSocket so bots can reliably attribute incoming voice packets to Discord users. Also fixes the SPEAKING opcode doc to note it’s bidirectional.  ￼

Changes
	•	VoiceClient
	•	New field: ssrc_map: Dict[int, int] to store SSRC→user_id.  ￼
	•	New method: get_user_id_from_ssrc(ssrc: int) -> Optional[int].  ￼
	•	DiscordVoiceWebSocket
	•	Route opcodes to new handlers in received_message: SPEAKING (5), CLIENT_CONNECT (12), CLIENT_DISCONNECT (13).  ￼
	•	handle_speaking: map data["ssrc"] → data["user_id"].  ￼
	•	handle_client_connect: map data["audio_ssrc"] → data["user_id"].  ￼
	•	handle_client_disconnect: remove mapping for the departing user_id.  ￼
	•	Docs: Change SPEAKING from “send only” to “bidirectional” in gateway docs.  ￼

Rationale

Voice receive paths often see SSRCs with no stable user association, leading to “unknown speaker” artifacts. Persisting SSRC→user_id whenever Discord signals speaking/connect/disconnect enables accurate speaker attribution for recording, transcription, and moderation.  ￼