### PR TITLE
fix(http): add proxy to HTTPClient.recreate (#1257)

### DIFF
--- a/nextcord/http.py
+++ b/nextcord/http.py
@@ -647,6 +647,8 @@ class HTTPClient:
             self.__session = aiohttp.ClientSession(
                 connector=self._connector,
                 ws_response_class=DiscordClientWebSocketResponse,
+                proxy=self._proxy,
+                proxy_auth=self._proxy_auth,
             )
             await self._start_ratelimit_shedding_loop()
 


### PR DESCRIPTION
## Summary

Closes #1257

Create the ClientSession in HTTPClient.recreate with a proxy.

## This is a **Code Change**

- [ ] I have tested my changes.
- [ ] I have updated the documentation to reflect the changes.
- [x] I have run `task pyright` and fixed the relevant issues.
