### PR TITLE
fix(voice): Add support for AEAD XChaCha20 Poly1305 encryption mode

### DIFF
--- a/nextcord/types/voice.py
+++ b/nextcord/types/voice.py
@@ -7,9 +7,7 @@ from typing_extensions import NotRequired
 from .member import MemberWithUser
 from .snowflake import Snowflake
 
-SupportedModes = Literal[
-    "aead_xchacha20_poly1305_rtpsize",
-]
+SupportedModes = Literal["aead_xchacha20_poly1305_rtpsize",]
 
 
 class _VoiceState(TypedDict):

--- a/nextcord/types/voice.py
+++ b/nextcord/types/voice.py
@@ -11,7 +11,7 @@ SupportedModes = Literal[
     "aead_xchacha20_poly1305_rtpsize",
     "xsalsa20_poly1305_lite",
     "xsalsa20_poly1305_suffix",
-    "xsalsa20_poly1305"
+    "xsalsa20_poly1305",
 ]
 
 

--- a/nextcord/types/voice.py
+++ b/nextcord/types/voice.py
@@ -9,9 +9,6 @@ from .snowflake import Snowflake
 
 SupportedModes = Literal[
     "aead_xchacha20_poly1305_rtpsize",
-    "xsalsa20_poly1305_lite",
-    "xsalsa20_poly1305_suffix",
-    "xsalsa20_poly1305",
 ]
 
 

--- a/nextcord/types/voice.py
+++ b/nextcord/types/voice.py
@@ -7,7 +7,12 @@ from typing_extensions import NotRequired
 from .member import MemberWithUser
 from .snowflake import Snowflake
 
-SupportedModes = Literal["xsalsa20_poly1305_lite", "xsalsa20_poly1305_suffix", "xsalsa20_poly1305"]
+SupportedModes = Literal[
+    "aead_xchacha20_poly1305_rtpsize",
+    "xsalsa20_poly1305_lite",
+    "xsalsa20_poly1305_suffix",
+    "xsalsa20_poly1305"
+]
 
 
 class _VoiceState(TypedDict):

--- a/nextcord/voice_client.py
+++ b/nextcord/voice_client.py
@@ -239,9 +239,6 @@ class VoiceClient(VoiceProtocol):
     warn_nacl = not has_nacl
     supported_modes: Tuple[SupportedModes, ...] = (
         "aead_xchacha20_poly1305_rtpsize",
-        "xsalsa20_poly1305_lite",
-        "xsalsa20_poly1305_suffix",
-        "xsalsa20_poly1305",
     )
 
     @property
@@ -527,9 +524,6 @@ class VoiceClient(VoiceProtocol):
         return encrypt_packet(header, data)
 
     def _encrypt_aead_xchacha20_poly1305_rtpsize(self, header: bytes, data) -> bytes:
-        # Essentially the same as _lite
-        # Uses an incrementing 32-bit integer which is appended to the payload
-        # The only other difference is we require AEAD with Additional Authenticated Data (the header)
         box = nacl.secret.Aead(bytes(self.secret_key))
         nonce = bytearray(24)
 
@@ -537,34 +531,6 @@ class VoiceClient(VoiceProtocol):
         self.checked_add("_incr_nonce", 1, 4294967295)
 
         return header + box.encrypt(bytes(data), bytes(header), bytes(nonce)).ciphertext + nonce[:4]
-
-    def _encrypt_xsalsa20_poly1305(self, header: bytes, data) -> bytes:
-        # Deprecated. Removal: 18th Nov 2024. See:
-        # https://discord.com/developers/docs/topics/voice-connections#transport-encryption-modes
-        box = nacl.secret.SecretBox(bytes(self.secret_key))
-        nonce = bytearray(24)
-        nonce[:12] = header
-
-        return header + box.encrypt(bytes(data), bytes(nonce)).ciphertext
-
-    def _encrypt_xsalsa20_poly1305_suffix(self, header: bytes, data) -> bytes:
-        # Deprecated. Removal: 18th Nov 2024. See:
-        # https://discord.com/developers/docs/topics/voice-connections#transport-encryption-modes
-        box = nacl.secret.SecretBox(bytes(self.secret_key))
-        nonce = nacl.utils.random(nacl.secret.SecretBox.NONCE_SIZE)  # type: ignore
-
-        return header + box.encrypt(bytes(data), nonce).ciphertext + nonce
-
-    def _encrypt_xsalsa20_poly1305_lite(self, header: bytes, data) -> bytes:
-        # Deprecated. Removal: 18th Nov 2024. See:
-        # https://discord.com/developers/docs/topics/voice-connections#transport-encryption-modes
-        box = nacl.secret.SecretBox(bytes(self.secret_key))
-        nonce = bytearray(24)
-
-        nonce[:4] = struct.pack(">I", self._incr_nonce)
-        self.checked_add("_incr_nonce", 1, 4294967295)
-
-        return header + box.encrypt(bytes(data), bytes(nonce)).ciphertext + nonce[:4]
 
     def play(
         self, source: AudioSource, *, after: Optional[Callable[[Optional[Exception]], Any]] = None

--- a/nextcord/voice_client.py
+++ b/nextcord/voice_client.py
@@ -233,11 +233,12 @@ class VoiceClient(VoiceProtocol):
         self._runner: asyncio.Task = MISSING
         self._player: Optional[AudioPlayer] = None
         self.encoder: Encoder = MISSING
-        self._lite_nonce: int = 0
+        self._incr_nonce: int = 0
         self.ws: DiscordVoiceWebSocket = MISSING
 
     warn_nacl = not has_nacl
     supported_modes: Tuple[SupportedModes, ...] = (
+        "aead_xchacha20_poly1305_rtpsize",
         "xsalsa20_poly1305_lite",
         "xsalsa20_poly1305_suffix",
         "xsalsa20_poly1305",
@@ -525,7 +526,21 @@ class VoiceClient(VoiceProtocol):
         encrypt_packet = getattr(self, "_encrypt_" + self.mode)
         return encrypt_packet(header, data)
 
+    def _encrypt_aead_xchacha20_poly1305_rtpsize(self, header: bytes, data) -> bytes:
+        # Essentially the same as _lite
+        # Uses an incrementing 32-bit integer which is appended to the payload
+        # The only other difference is we require AEAD with Additional Authenticated Data (the header)
+        box = nacl.secret.Aead(bytes(self.secret_key))
+        nonce = bytearray(24)
+
+        nonce[:4] = struct.pack(">I", self._incr_nonce)
+        self.checked_add("_incr_nonce", 1, 4294967295)
+
+        return header + box.encrypt(bytes(data), bytes(header), bytes(nonce)).ciphertext + nonce[:4]
+
     def _encrypt_xsalsa20_poly1305(self, header: bytes, data) -> bytes:
+        # Deprecated. Removal: 18th Nov 2024. See:
+        # https://discord.com/developers/docs/topics/voice-connections#transport-encryption-modes
         box = nacl.secret.SecretBox(bytes(self.secret_key))
         nonce = bytearray(24)
         nonce[:12] = header
@@ -533,17 +548,21 @@ class VoiceClient(VoiceProtocol):
         return header + box.encrypt(bytes(data), bytes(nonce)).ciphertext
 
     def _encrypt_xsalsa20_poly1305_suffix(self, header: bytes, data) -> bytes:
+        # Deprecated. Removal: 18th Nov 2024. See:
+        # https://discord.com/developers/docs/topics/voice-connections#transport-encryption-modes
         box = nacl.secret.SecretBox(bytes(self.secret_key))
         nonce = nacl.utils.random(nacl.secret.SecretBox.NONCE_SIZE)  # type: ignore
 
         return header + box.encrypt(bytes(data), nonce).ciphertext + nonce
 
     def _encrypt_xsalsa20_poly1305_lite(self, header: bytes, data) -> bytes:
+        # Deprecated. Removal: 18th Nov 2024. See:
+        # https://discord.com/developers/docs/topics/voice-connections#transport-encryption-modes
         box = nacl.secret.SecretBox(bytes(self.secret_key))
         nonce = bytearray(24)
 
-        nonce[:4] = struct.pack(">I", self._lite_nonce)
-        self.checked_add("_lite_nonce", 1, 4294967295)
+        nonce[:4] = struct.pack(">I", self._incr_nonce)
+        self.checked_add("_incr_nonce", 1, 4294967295)
 
         return header + box.encrypt(bytes(data), bytes(nonce)).ciphertext + nonce[:4]
 

--- a/nextcord/voice_client.py
+++ b/nextcord/voice_client.py
@@ -237,9 +237,7 @@ class VoiceClient(VoiceProtocol):
         self.ws: DiscordVoiceWebSocket = MISSING
 
     warn_nacl = not has_nacl
-    supported_modes: Tuple[SupportedModes, ...] = (
-        "aead_xchacha20_poly1305_rtpsize",
-    )
+    supported_modes: Tuple[SupportedModes, ...] = ("aead_xchacha20_poly1305_rtpsize",)
 
     @property
     def guild(self) -> Optional[Guild]:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ aiohttp = "^3.8.0"
 typing_extensions = "^4.2.0"
 audioop-lts = { version = "^0.2.1", python = "^3.13" }
 
-PyNaCl = { version = ">=1.3.0,<1.5", optional = true }
+PyNaCl = { version = ">=1.5.0,<1.6", optional = true }
 orjson = { version = ">=3.5.4", optional = true }
 # There is currently no way to express passthrough extras in Poetry.
 # https://github.com/python-poetry/poetry/issues/834


### PR DESCRIPTION
## Summary

This PR is based on Rapptz/discord.py#9953. It fixes an error when connecting to a voice channel, as discord has started to roll out  older encryption scheme.

## This is a **Code Change**

- [x] I have tested my changes.
  => With this change, my bot was able to connect to voice channels again
- [x] I have updated the documentation to reflect the changes.
  => No API change
- [x] I have run `task pyright` and fixed the relevant issues.
