### PR TITLE
feat(user): Add new Premium Type

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -1379,6 +1379,9 @@ of :class:`enum.Enum`.
 .. autoclass:: InteractionResponseType
     :members:
 
+.. autoclass:: PremiumType
+    :members:
+
 .. autoclass:: Locale
     :members:
 

--- a/docs/whats_new.rst
+++ b/docs/whats_new.rst
@@ -12,6 +12,24 @@ Changelog
 This page keeps a detailed human-friendly rendering of what's new and changed
 in specific versions.
 
+.. _vp3p1p1:
+
+v3.1.1
+------
+
+This patch release aligns with Discord's OAuth behaviour for Nitro tiers on user payloads.
+
+Discord API
+~~~~~~~~~~~
+
+- Discord now masks ``premium_type`` as ``0`` unless the ``identify.premium`` OAuth2 scope is granted (partner applications only). The library documents this on :attr:`User.premium_type <nextcord.User.premium_type>` and adds :data:`utils.OAUTH2_SCOPE_IDENTIFY_PREMIUM <nextcord.utils.OAUTH2_SCOPE_IDENTIFY_PREMIUM>`.
+
+New Features
+~~~~~~~~~~~~
+
+- Add :class:`PremiumType` and :attr:`User.premium_type <nextcord.User.premium_type>`.
+- Add :data:`utils.OAUTH2_SCOPE_IDENTIFY_PREMIUM <nextcord.utils.OAUTH2_SCOPE_IDENTIFY_PREMIUM>`.
+
 .. _vp3p1p0:
 
 v3.1.0

--- a/nextcord/enums.py
+++ b/nextcord/enums.py
@@ -53,6 +53,7 @@ __all__ = (
     "IntegrationType",
     "InteractionContextType",
     "MessageReferenceType",
+    "PremiumType",
 )
 
 
@@ -1403,6 +1404,24 @@ class AuditLogAction(IntEnum):
         if v < 143:
             return "auto_moderation_rule"
         return None
+
+
+class PremiumType(IntEnum):
+    """The Nitro subscription type reported in a user's ``premium_type`` field.
+
+    .. versionadded:: 3.1.1
+
+    Note that Discord intentionally returns :attr:`~PremiumType.none` when the requesting
+    application does not have the partner-restricted ``identify.premium`` OAuth2 scope;
+    see :attr:`User.premium_type <nextcord.User.premium_type>`.
+    """
+
+    none = 0
+    """No Nitro subscription (or masked, see :attr:`~nextcord.User.premium_type`)."""
+    nitro_classic = 1
+    """Nitro Classic."""
+    nitro = 2
+    """Nitro."""
 
 
 class UserFlags(IntEnum):

--- a/nextcord/user.py
+++ b/nextcord/user.py
@@ -7,8 +7,7 @@ from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
 from . import abc
 from .asset import Asset
 from .colour import Colour
-from .enums import DefaultAvatar
-from .enums import PremiumType
+from .enums import DefaultAvatar, PremiumType
 from .flags import PublicUserFlags
 from .utils import MISSING, obj_to_base64_data, snowflake_time
 

--- a/nextcord/user.py
+++ b/nextcord/user.py
@@ -8,6 +8,7 @@ from . import abc
 from .asset import Asset
 from .colour import Colour
 from .enums import DefaultAvatar
+from .enums import PremiumType
 from .flags import PublicUserFlags
 from .utils import MISSING, obj_to_base64_data, snowflake_time
 
@@ -104,6 +105,7 @@ class BaseUser(_UserTag):
         "_state",
         "global_name",
         "_avatar_decoration",
+        "_premium_type",
     )
 
     if TYPE_CHECKING:
@@ -119,11 +121,13 @@ class BaseUser(_UserTag):
         _accent_colour: Optional[str]
         _public_flags: int
         _avatar_decoration: Optional[AvatarDecorationDataPayload]
+        _premium_type: int
 
     def __init__(
         self, *, state: ConnectionState, data: Union[PartialUserPayload, UserPayload]
     ) -> None:
         self._state = state
+        self._premium_type = 0
         self._update(data)
 
     def __repr__(self) -> str:
@@ -157,6 +161,8 @@ class BaseUser(_UserTag):
         self.bot = data.get("bot", False)
         self.system = data.get("system", False)
         self.global_name = data.get("global_name", None)
+        if "premium_type" in data:
+            self._premium_type = int(data["premium_type"])
 
     @classmethod
     def _copy(cls, user: Self) -> Self:
@@ -172,6 +178,7 @@ class BaseUser(_UserTag):
         self.bot = user.bot
         self._state = user._state
         self._public_flags = user._public_flags
+        self._premium_type = user._premium_type
 
         return self
 
@@ -189,6 +196,24 @@ class BaseUser(_UserTag):
     def public_flags(self) -> PublicUserFlags:
         """:class:`PublicUserFlags`: The publicly available flags the user has."""
         return PublicUserFlags._from_value(self._public_flags)
+
+    @property
+    def premium_type(self) -> Union[PremiumType, int]:
+        """The user's Nitro subscription level from the ``premium_type`` field.
+
+        Returns either a :class:`PremiumType` value or an :class:`int` if Discord introduces
+        a new tier that is not yet been modeled.
+
+        .. note::
+
+            Unless your application is an approved Discord partner **and** you request the
+            ``identify.premium`` OAuth2 scope during user authorization (see
+            :data:`~nextcord.utils.OAUTH2_SCOPE_IDENTIFY_PREMIUM`), Discord returns ``0`` for every user
+            regardless of their real subscription tier.
+
+        .. versionadded:: 3.1.1
+        """
+        return PremiumType.try_value(self._premium_type)
 
     @property
     def avatar(self) -> Optional[Asset]:

--- a/nextcord/utils.py
+++ b/nextcord/utils.py
@@ -73,6 +73,7 @@ if TYPE_CHECKING:
 
 __all__ = (
     "oauth_url",
+    "OAUTH2_SCOPE_IDENTIFY_PREMIUM",
     "snowflake_time",
     "time_snowflake",
     "find",
@@ -92,6 +93,10 @@ __all__ = (
 )
 
 DISCORD_EPOCH = 1420070400000
+
+# OAuth2 scope Discord requires for truthful ``premium_type`` on user objects (partner-only;
+# applications without approval always receive ``0``).
+OAUTH2_SCOPE_IDENTIFY_PREMIUM = "identify.premium"
 
 
 class _MissingSentinel:


### PR DESCRIPTION
## Summary

This pull add's Discord’s OAuth behavior for user `premium_type`: Discord returns `0` for applications that do not have the **`identify.premium`** scope.
The change adds library support and documentation for the scope.

**Code**

- Add **`PremiumType`** (`nextcord.enums`) for API values `0` / `1` / `2`.
- Expose **`User.premium_type`** (on `BaseUser`, so `User` and `ClientUser` inherit it), using **`PremiumType.try_value`** for forward compatibility.
- Only update the internal tier when the payload includes **`premium_type`**, so partial user updates do not reset a previously known value to `0`.
- Add **`nextcord.utils.OAUTH2_SCOPE_IDENTIFY_PREMIUM`** (`"identify.premium"`) and extend **`oauth_url`** docs for OAuth user flows.

**Documentation**

- Changelog entry (`docs/whats_new.rst`, v3.1.1).
- Developer note (`docs/discord.rst`) on `premium_type` and `identify.premium`.
- API reference: `PremiumType`

## This is a **Code Change**

- [x] I have tested my changes.
- [x] I have updated the documentation to reflect the changes.
- [ ] I have run `task pyright` and fixed the relevant issues.