### PR TITLE
fix: string select erroring on default custom id

### DIFF
--- a/nextcord/ui/select/string.py
+++ b/nextcord/ui/select/string.py
@@ -74,7 +74,7 @@ class StringSelect(SelectBase, Generic[V_co]):
     def __init__(
         self,
         *,
-        custom_id: str = MISSING,
+        custom_id: str | None = None,
         placeholder: Optional[str] = None,
         min_values: int = 1,
         max_values: int = 1,


### PR DESCRIPTION
## Summary

Fixes a regression in default custom id generation

Closes #1287

## This is a **Code Change**

- [X] I have tested my changes.
- [ ] I have updated the documentation to reflect the changes.
- [ ] I have run `task pyright` and fixed the relevant issues.
