### PR TITLE
fix(app-cmds): reject negative numbers when Range min is 0

### DIFF
--- a/nextcord/application_command.py
+++ b/nextcord/application_command.py
@@ -3648,9 +3648,9 @@ class RangeMeta(type):
                 return value
 
             def modify(self, option: SlashCommandOption) -> None:
-                if self.min and option.min_value is None:
+                if self.min is not None and option.min_value is None:
                     option.min_value = self.min
-                if self.max and option.max_value is None:
+                if self.max is not None and option.max_value is None:
                     option.max_value = self.max
 
         if isinstance(value, tuple):


### PR DESCRIPTION
It was a truthiness issue, where a range starting or ending in 0 would be interpreted as self.min or self.max = False, so negative numbers would be allowed

## Summary

Fix for #1015

<!-- Link any issues if applicable.
[Use keywords from https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests](https://github.com/nextcord/nextcord/issues/1015)
-->
<!--
## This is a **Code Change**

- [ *] I have tested my changes.
- [ ] I have updated the documentation to reflect the changes.
- [ ] I have run `task pyright` and fixed the relevant issues.
