### PR TITLE
feat(abc,message,webhook): add components parameter and fix overloads

### DIFF
--- a/nextcord/abc.py
+++ b/nextcord/abc.py
@@ -1263,7 +1263,7 @@ class Messageable:
         reference: Optional[Union[Message, MessageReference, PartialMessage]] = ...,
         mention_author: Optional[bool] = ...,
         view: Optional[View] = ...,
-        components: Optional[List[Component]] = ...,
+        components: Optional[Sequence[Component]] = ...,
         flags: Optional[MessageFlags] = ...,
         suppress_embeds: Optional[bool] = ...,
     ) -> Message: ...
@@ -1283,7 +1283,7 @@ class Messageable:
         reference: Optional[Union[Message, MessageReference, PartialMessage]] = ...,
         mention_author: Optional[bool] = ...,
         view: Optional[View] = ...,
-        components: Optional[List[Component]] = ...,
+        components: Optional[Sequence[Component]] = ...,
         flags: Optional[MessageFlags] = ...,
         suppress_embeds: Optional[bool] = ...,
     ) -> Message: ...
@@ -1303,7 +1303,7 @@ class Messageable:
         reference: Optional[Union[Message, MessageReference, PartialMessage]] = ...,
         mention_author: Optional[bool] = ...,
         view: Optional[View] = ...,
-        components: Optional[List[Component]] = ...,
+        components: Optional[Sequence[Component]] = ...,
         flags: Optional[MessageFlags] = ...,
         suppress_embeds: Optional[bool] = ...,
     ) -> Message: ...
@@ -1323,7 +1323,7 @@ class Messageable:
         reference: Optional[Union[Message, MessageReference, PartialMessage]] = ...,
         mention_author: Optional[bool] = ...,
         view: Optional[View] = ...,
-        components: Optional[List[Component]] = ...,
+        components: Optional[Sequence[Component]] = ...,
         flags: Optional[MessageFlags] = ...,
         suppress_embeds: Optional[bool] = ...,
     ) -> Message: ...
@@ -1344,7 +1344,7 @@ class Messageable:
         reference: Optional[Union[Message, MessageReference, PartialMessage]] = None,
         mention_author: Optional[bool] = None,
         view: Optional[View] = None,
-        components: Optional[List[Component]] = None,
+        components: Optional[Sequence[Component]] = None,
         flags: Optional[MessageFlags] = None,
         suppress_embeds: Optional[bool] = None,
     ):
@@ -1426,7 +1426,7 @@ class Messageable:
             Whether to suppress embeds on this message.
 
             .. versionadded:: 2.4
-        components: List[:class:`~nextcord.components.Component`]
+        components: Optional[Sequence[:class:`~nextcord.components.Component`]]
             A list of components to send with the message (Components V2).
 
             .. versionadded:: 3.4

--- a/nextcord/abc.py
+++ b/nextcord/abc.py
@@ -56,6 +56,7 @@ if TYPE_CHECKING:
     from typing_extensions import Self
 
     from .asset import Asset
+    from .components import Component
     from .channel import (
         CategoryChannel,
         DMChannel,
@@ -1262,6 +1263,7 @@ class Messageable:
         reference: Optional[Union[Message, MessageReference, PartialMessage]] = ...,
         mention_author: Optional[bool] = ...,
         view: Optional[View] = ...,
+        components: Optional[List[Component]] = ...,
         flags: Optional[MessageFlags] = ...,
         suppress_embeds: Optional[bool] = ...,
     ) -> Message: ...
@@ -1281,6 +1283,7 @@ class Messageable:
         reference: Optional[Union[Message, MessageReference, PartialMessage]] = ...,
         mention_author: Optional[bool] = ...,
         view: Optional[View] = ...,
+        components: Optional[List[Component]] = ...,
         flags: Optional[MessageFlags] = ...,
         suppress_embeds: Optional[bool] = ...,
     ) -> Message: ...
@@ -1300,6 +1303,7 @@ class Messageable:
         reference: Optional[Union[Message, MessageReference, PartialMessage]] = ...,
         mention_author: Optional[bool] = ...,
         view: Optional[View] = ...,
+        components: Optional[List[Component]] = ...,
         flags: Optional[MessageFlags] = ...,
         suppress_embeds: Optional[bool] = ...,
     ) -> Message: ...
@@ -1319,6 +1323,7 @@ class Messageable:
         reference: Optional[Union[Message, MessageReference, PartialMessage]] = ...,
         mention_author: Optional[bool] = ...,
         view: Optional[View] = ...,
+        components: Optional[List[Component]] = ...,
         flags: Optional[MessageFlags] = ...,
         suppress_embeds: Optional[bool] = ...,
     ) -> Message: ...
@@ -1339,6 +1344,7 @@ class Messageable:
         reference: Optional[Union[Message, MessageReference, PartialMessage]] = None,
         mention_author: Optional[bool] = None,
         view: Optional[View] = None,
+        components: Optional[List[Component]] = None,
         flags: Optional[MessageFlags] = None,
         suppress_embeds: Optional[bool] = None,
     ):
@@ -1420,6 +1426,10 @@ class Messageable:
             Whether to suppress embeds on this message.
 
             .. versionadded:: 2.4
+        components: List[:class:`~nextcord.components.Component`]
+            A list of components to send with the message (Components V2).
+
+            .. versionadded:: 3.3
 
         Raises
         ------
@@ -1447,6 +1457,8 @@ class Messageable:
             flags = MessageFlags()
         if suppress_embeds is not None:
             flags.suppress_embeds = suppress_embeds
+        if components is not None:
+            flags.is_components_v2 = True
 
         flag_value: Optional[int] = flags.value if flags.value != 0 else None
 
@@ -1488,12 +1500,14 @@ class Messageable:
                     "reference parameter must be Message, MessageReference, or PartialMessage"
                 ) from None
 
-        components: Optional[List[ComponentPayload]] = None
-        if view:
+        components_payload: Optional[List[ComponentPayload]] = None
+        if components is not None:
+            components_payload = [comp.to_dict() for comp in components]
+        elif view:
             if not hasattr(view, "__discord_ui_view__"):
                 raise InvalidArgument(f"view parameter must be View not {view.__class__!r}")
 
-            components = cast(List[ComponentPayload], view.to_components())
+            components_payload = cast(List[ComponentPayload], view.to_components())
 
         if file is not None and files is not None:
             raise InvalidArgument("Cannot pass both file and files parameter to send()")
@@ -1514,7 +1528,7 @@ class Messageable:
                     nonce=nonce,
                     message_reference=reference_payload,
                     stickers=stickers_payload,
-                    components=components,
+                    components=components_payload,
                     flags=flag_value,
                 )
             finally:
@@ -1536,7 +1550,7 @@ class Messageable:
                     allowed_mentions=allowed_mentions_payload,
                     message_reference=reference_payload,
                     stickers=stickers_payload,
-                    components=components,
+                    components=components_payload,
                     flags=flag_value,
                 )
             finally:
@@ -1553,7 +1567,7 @@ class Messageable:
                 allowed_mentions=allowed_mentions_payload,
                 message_reference=reference_payload,
                 stickers=stickers_payload,
-                components=components,
+                components=components_payload,
                 flags=flag_value,
             )
 

--- a/nextcord/abc.py
+++ b/nextcord/abc.py
@@ -56,7 +56,6 @@ if TYPE_CHECKING:
     from typing_extensions import Self
 
     from .asset import Asset
-    from .components import Component
     from .channel import (
         CategoryChannel,
         DMChannel,
@@ -67,6 +66,7 @@ if TYPE_CHECKING:
         VoiceChannel,
     )
     from .client import Client
+    from .components import Component
     from .embeds import Embed, EmbedData
     from .enums import InviteTarget
     from .guild import Guild
@@ -1502,7 +1502,9 @@ class Messageable:
 
         components_payload: Optional[List[ComponentPayload]] = None
         if components is not None:
-            components_payload = cast(List[ComponentPayload], [comp.to_dict() for comp in components])
+            components_payload = cast(
+                List[ComponentPayload], [comp.to_dict() for comp in components]
+            )
         elif view:
             if not hasattr(view, "__discord_ui_view__"):
                 raise InvalidArgument(f"view parameter must be View not {view.__class__!r}")

--- a/nextcord/abc.py
+++ b/nextcord/abc.py
@@ -1429,7 +1429,7 @@ class Messageable:
         components: List[:class:`~nextcord.components.Component`]
             A list of components to send with the message (Components V2).
 
-            .. versionadded:: 3.3
+            .. versionadded:: 3.4
 
         Raises
         ------

--- a/nextcord/abc.py
+++ b/nextcord/abc.py
@@ -1502,7 +1502,7 @@ class Messageable:
 
         components_payload: Optional[List[ComponentPayload]] = None
         if components is not None:
-            components_payload = [comp.to_dict() for comp in components]
+            components_payload = cast(List[ComponentPayload], [comp.to_dict() for comp in components])
         elif view:
             if not hasattr(view, "__discord_ui_view__"):
                 raise InvalidArgument(f"view parameter must be View not {view.__class__!r}")

--- a/nextcord/interactions.py
+++ b/nextcord/interactions.py
@@ -14,6 +14,7 @@ from typing import (
     Generic,
     List,
     Optional,
+    Sequence,
     Set,
     Tuple,
     TypeVar,
@@ -536,7 +537,7 @@ class Interaction(Hashable, Generic[ClientT]):
         attachments: List[Attachment] = MISSING,
         view: Optional[View] = MISSING,
         allowed_mentions: Optional[AllowedMentions] = None,
-        components: list[components.Component] | None = None,
+        components: Optional[Sequence[components.Component]] = MISSING,
     ) -> InteractionMessage:
         """|coro|
 
@@ -572,6 +573,11 @@ class Interaction(Hashable, Generic[ClientT]):
         view: Optional[:class:`~nextcord.ui.View`]
             The updated view to update this message with. If ``None`` is passed then
             the view is removed.
+        components: Optional[Sequence[:class:`~nextcord.components.Component`]]
+            A list of components to edit the message with (Components V2). If ``None`` is passed then
+            the components are removed.
+
+            .. versionadded:: 3.4
 
         Raises
         ------
@@ -680,7 +686,7 @@ class Interaction(Hashable, Generic[ClientT]):
         flags: Optional[MessageFlags] = None,
         ephemeral: Optional[bool] = None,
         suppress_embeds: Optional[bool] = None,
-        components: list[components.Component] | None = None,
+        components: Optional[Sequence[components.Component]] = MISSING,
     ) -> Union[PartialInteractionMessage, WebhookMessage]:
         """|coro|
 
@@ -743,6 +749,7 @@ class Interaction(Hashable, Generic[ClientT]):
             allowed_mentions=allowed_mentions,
             flags=flags,
             suppress_embeds=suppress_embeds,
+            components=components,
         )
 
     async def edit(self, *args, **kwargs) -> Optional[Message]:
@@ -943,7 +950,7 @@ class InteractionResponse:
         flags: Optional[MessageFlags] = None,
         ephemeral: Optional[bool] = None,
         suppress_embeds: Optional[bool] = None,
-        components: list[components.Component] | None = None,
+        components: Optional[Sequence[components.Component]] = MISSING,
     ) -> PartialInteractionMessage:
         """|coro|
 
@@ -993,6 +1000,10 @@ class InteractionResponse:
             Whether to suppress embeds on this message.
 
             .. versionadded:: 2.4
+        components: Optional[Sequence[:class:`~nextcord.components.Component`]]
+            A list of components (Components V2) to send with the message.
+
+            .. versionadded:: 3.4
 
         Raises
         ------
@@ -1052,7 +1063,7 @@ class InteractionResponse:
             flags.suppress_embeds = suppress_embeds
         if ephemeral is not None:
             flags.ephemeral = ephemeral
-        if components is not None:
+        if components is not MISSING and components is not None:
             flags.is_components_v2 = True
             payload["components"] = [comp.to_dict() for comp in components]
 
@@ -1147,7 +1158,7 @@ class InteractionResponse:
         attachments: List[Attachment] = MISSING,
         view: Optional[View] = MISSING,
         delete_after: Optional[float] = None,
-        components: list[components.Component] | None = None,
+        components: Optional[Sequence[components.Component]] = MISSING,
     ) -> Optional[Message]:
         """|coro|
 
@@ -1178,6 +1189,11 @@ class InteractionResponse:
             If provided, the number of seconds to wait in the background
             before deleting the message we just sent. If the deletion fails,
             then it is silently ignored.
+        components: Optional[Sequence[:class:`~nextcord.components.Component`]]
+            A list of components to edit the message with (Components V2). If ``None`` is passed then
+            the components are removed.
+
+            .. versionadded:: 3.4
 
 
         Raises
@@ -1240,8 +1256,11 @@ class InteractionResponse:
                 payload["components"] = []
             else:
                 payload["components"] = view.to_components()
-        elif components is not None:
-            payload["components"] = [comp.to_dict() for comp in components]
+        elif components is not MISSING:
+            if components is not None:
+                payload["components"] = [comp.to_dict() for comp in components]
+            else:
+                payload["components"] = []
 
         adapter = async_context.get()
         try:
@@ -1284,7 +1303,7 @@ class _InteractionMessageMixin:
         view: Optional[View] = MISSING,
         allowed_mentions: Optional[AllowedMentions] = None,
         delete_after: Optional[float] = None,
-        components: list[components.Component] | None = None,
+        components: Optional[Sequence[components.Component]] = MISSING,
     ) -> InteractionMessage:
         """|coro|
 
@@ -1318,6 +1337,11 @@ class _InteractionMessageMixin:
             If provided, the number of seconds to wait in the background
             before deleting the message we just edited. If the deletion fails,
             then it is silently ignored.
+        components: Optional[Sequence[:class:`~nextcord.components.Component`]]
+            A list of components to edit the message with (Components V2). If ``None`` is passed then
+            the components are removed.
+
+            .. versionadded:: 3.4
 
         Raises
         ------

--- a/nextcord/message.py
+++ b/nextcord/message.py
@@ -18,6 +18,7 @@ from typing import (
     Dict,
     List,
     Optional,
+    Sequence,
     Set,
     Tuple,
     Union,
@@ -1711,7 +1712,7 @@ class Message(Hashable):
         delete_after: Optional[float] = ...,
         allowed_mentions: Optional[AllowedMentions] = ...,
         view: Optional[View] = ...,
-        components: Optional[List[Component]] = ...,
+        components: Optional[Sequence[Component]] = ...,
     ) -> Message: ...
 
     @overload
@@ -1725,7 +1726,7 @@ class Message(Hashable):
         delete_after: Optional[float] = ...,
         allowed_mentions: Optional[AllowedMentions] = ...,
         view: Optional[View] = ...,
-        components: Optional[List[Component]] = ...,
+        components: Optional[Sequence[Component]] = ...,
         file: Optional[File] = ...,
     ) -> Message: ...
 
@@ -1740,7 +1741,7 @@ class Message(Hashable):
         delete_after: Optional[float] = ...,
         allowed_mentions: Optional[AllowedMentions] = ...,
         view: Optional[View] = ...,
-        components: Optional[List[Component]] = ...,
+        components: Optional[Sequence[Component]] = ...,
         files: Optional[List[File]] = ...,
     ) -> Message: ...
 
@@ -1755,7 +1756,7 @@ class Message(Hashable):
         delete_after: Optional[float] = ...,
         allowed_mentions: Optional[AllowedMentions] = ...,
         view: Optional[View] = ...,
-        components: Optional[List[Component]] = ...,
+        components: Optional[Sequence[Component]] = ...,
         files: Optional[List[File]] = ...,
     ) -> Message: ...
 
@@ -1769,7 +1770,7 @@ class Message(Hashable):
         delete_after: Optional[float] = None,
         allowed_mentions: Optional[AllowedMentions] = MISSING,
         view: Optional[View] = MISSING,
-        components: Optional[List[Component]] = MISSING,
+        components: Optional[Sequence[Component]] = MISSING,
         file: Optional[File] = MISSING,
         files: Optional[List[File]] = MISSING,
     ) -> Message:
@@ -1827,7 +1828,7 @@ class Message(Hashable):
             If provided, a list of new files to add to the message.
 
             .. versionadded:: 2.0
-        components: Optional[List[:class:`~nextcord.components.Component`]]
+        components: Optional[Sequence[:class:`~nextcord.components.Component`]]
             If provided, a list of new components to add to the message.
 
             .. versionadded:: 3.4

--- a/nextcord/message.py
+++ b/nextcord/message.py
@@ -1830,7 +1830,7 @@ class Message(Hashable):
         components: Optional[List[:class:`~nextcord.components.Component`]]
             If provided, a list of new components to add to the message.
 
-            .. versionadded:: 3.3
+            .. versionadded:: 3.4
 
         Raises
         ------

--- a/nextcord/message.py
+++ b/nextcord/message.py
@@ -1711,7 +1711,7 @@ class Message(Hashable):
         delete_after: Optional[float] = ...,
         allowed_mentions: Optional[AllowedMentions] = ...,
         view: Optional[View] = ...,
-        file: Optional[File] = ...,
+        components: Optional[List[Component]] = ...,
     ) -> Message: ...
 
     @overload
@@ -1725,6 +1725,7 @@ class Message(Hashable):
         delete_after: Optional[float] = ...,
         allowed_mentions: Optional[AllowedMentions] = ...,
         view: Optional[View] = ...,
+        components: Optional[List[Component]] = ...,
         file: Optional[File] = ...,
     ) -> Message: ...
 
@@ -1739,6 +1740,7 @@ class Message(Hashable):
         delete_after: Optional[float] = ...,
         allowed_mentions: Optional[AllowedMentions] = ...,
         view: Optional[View] = ...,
+        components: Optional[List[Component]] = ...,
         files: Optional[List[File]] = ...,
     ) -> Message: ...
 
@@ -1753,6 +1755,7 @@ class Message(Hashable):
         delete_after: Optional[float] = ...,
         allowed_mentions: Optional[AllowedMentions] = ...,
         view: Optional[View] = ...,
+        components: Optional[List[Component]] = ...,
         files: Optional[List[File]] = ...,
     ) -> Message: ...
 
@@ -1766,6 +1769,7 @@ class Message(Hashable):
         delete_after: Optional[float] = None,
         allowed_mentions: Optional[AllowedMentions] = MISSING,
         view: Optional[View] = MISSING,
+        components: Optional[List[Component]] = MISSING,
         file: Optional[File] = MISSING,
         files: Optional[List[File]] = MISSING,
     ) -> Message:
@@ -1823,6 +1827,10 @@ class Message(Hashable):
             If provided, a list of new files to add to the message.
 
             .. versionadded:: 2.0
+        components: Optional[List[:class:`~nextcord.components.Component`]]
+            If provided, a list of new components to add to the message.
+
+            .. versionadded:: 3.3
 
         Raises
         ------
@@ -1881,7 +1889,15 @@ class Message(Hashable):
         if attachments is not MISSING:
             payload["attachments"] = [a.to_dict() for a in attachments]
 
-        if view is not MISSING:
+        if components is not MISSING:
+            flags = MessageFlags._from_value(self.flags.value)
+            flags.is_components_v2 = True
+            payload["flags"] = flags.value
+            if components:
+                payload["components"] = [c.to_dict() for c in components]
+            else:
+                payload["components"] = []
+        elif view is not MISSING:
             self._state.prevent_view_updates_for(self.id)
             if view:
                 payload["components"] = view.to_components()

--- a/nextcord/webhook/async_.py
+++ b/nextcord/webhook/async_.py
@@ -17,6 +17,7 @@ from typing import (
     Literal,
     NamedTuple,
     Optional,
+    Sequence,
     Tuple,
     Type,
     Union,
@@ -507,7 +508,7 @@ def handle_message_parameters(
     flags: Optional[MessageFlags] = None,
     suppress_embeds: Optional[bool] = None,
     thread_name: Optional[str] = None,
-    components: list[Component] | None = None,
+    components: Optional[Sequence[Component]] = MISSING,
 ) -> ExecuteWebhookParameters:
     if files is not MISSING and file is not MISSING:
         raise InvalidArgument("Cannot mix file and files keyword arguments.")
@@ -559,9 +560,12 @@ def handle_message_parameters(
     if ephemeral is not None:
         flags.ephemeral = ephemeral
 
-    if components is not None:
+    if components is not MISSING:
         flags.is_components_v2 = True
-        payload["components"] = [comp.to_dict() for comp in components]
+        if components is not None:
+            payload["components"] = [comp.to_dict() for comp in components]
+        else:
+            payload["components"] = []
 
     if flags.value != 0:
         payload["flags"] = flags.value
@@ -746,6 +750,7 @@ class WebhookMessage(Message):
         view: Optional[View] = MISSING,
         allowed_mentions: Optional[AllowedMentions] = None,
         delete_after: Optional[float] = None,
+        components: Optional[Sequence[Component]] = MISSING,
     ) -> WebhookMessage:
         """|coro|
 
@@ -793,6 +798,11 @@ class WebhookMessage(Message):
             then it is silently ignored.
 
             .. versionadded:: 2.0
+        components: Optional[Sequence[:class:`~nextcord.components.Component`]]
+            A list of components to edit the message with (Components V2). If ``None`` is passed then
+            the components are removed.
+
+            .. versionadded:: 3.4
 
         Raises
         ------
@@ -822,6 +832,7 @@ class WebhookMessage(Message):
             attachments=attachments,
             view=view,
             allowed_mentions=allowed_mentions,
+            components=components,
         )
 
         if delete_after is not None:
@@ -1375,6 +1386,7 @@ class Webhook(BaseWebhook):
         flags: Optional[MessageFlags] = None,
         suppress_embeds: Optional[bool] = None,
         thread_name: Optional[str] = None,
+        components: Optional[Sequence[Component]] = MISSING,
     ) -> WebhookMessage: ...
 
     @overload
@@ -1398,6 +1410,7 @@ class Webhook(BaseWebhook):
         flags: Optional[MessageFlags] = None,
         suppress_embeds: Optional[bool] = None,
         thread_name: Optional[str] = None,
+        components: Optional[Sequence[Component]] = MISSING,
     ) -> None: ...
 
     async def send(
@@ -1420,7 +1433,7 @@ class Webhook(BaseWebhook):
         flags: Optional[MessageFlags] = None,
         suppress_embeds: Optional[bool] = None,
         thread_name: Optional[str] = None,
-        components: list[Component] | None = None,
+        components: Optional[Sequence[Component]] = MISSING,
     ) -> Optional[WebhookMessage]:
         """|coro|
 
@@ -1509,6 +1522,10 @@ class Webhook(BaseWebhook):
             Name of thread to create (requires the webhook channel to be a forum or media channel).
 
             .. versionadded:: 3.0
+        components: Optional[Sequence[:class:`~nextcord.components.Component`]]
+            A list of components (Components V2) to send with the message.
+
+            .. versionadded:: 3.4
 
         Raises
         ------
@@ -1651,6 +1668,7 @@ class Webhook(BaseWebhook):
         view: Optional[View] = MISSING,
         thread: Snowflake = MISSING,
         allowed_mentions: Optional[AllowedMentions] = None,
+        components: Optional[Sequence[Component]] = MISSING,
     ) -> WebhookMessage:
         """|coro|
 
@@ -1701,6 +1719,11 @@ class Webhook(BaseWebhook):
             The thread that the message to be edited is in.
 
             .. versionadded:: 3.0
+        components: Optional[Sequence[:class:`~nextcord.components.Component`]]
+            A list of components to edit the message with (Components V2). If ``None`` is passed then
+            the components are removed.
+
+            .. versionadded:: 3.4
 
         Raises
         ------
@@ -1744,6 +1767,7 @@ class Webhook(BaseWebhook):
             view=view,
             allowed_mentions=allowed_mentions,
             previous_allowed_mentions=previous_mentions,
+            components=components,
         )
         adapter = async_context.get()
         thread_id: Optional[int] = None

--- a/nextcord/webhook/sync.py
+++ b/nextcord/webhook/sync.py
@@ -15,7 +15,19 @@ import re
 import threading
 import time
 from types import TracebackType
-from typing import TYPE_CHECKING, Any, Dict, List, Literal, Optional, Tuple, Type, Union, overload
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Dict,
+    List,
+    Literal,
+    Optional,
+    Sequence,
+    Tuple,
+    Type,
+    Union,
+    overload,
+)
 from urllib.parse import quote as urlquote
 from weakref import WeakValueDictionary
 
@@ -35,6 +47,7 @@ _log = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
     from ..abc import Snowflake
+    from ..components import Component
     from ..embeds import Embed
     from ..file import File
     from ..mentions import AllowedMentions
@@ -405,6 +418,7 @@ class SyncWebhookMessage(Message):
         file: File = MISSING,
         files: List[File] = MISSING,
         allowed_mentions: Optional[AllowedMentions] = None,
+        components: Optional[Sequence[Component]] = MISSING,
     ) -> SyncWebhookMessage:
         """Edits the message.
 
@@ -428,6 +442,11 @@ class SyncWebhookMessage(Message):
         allowed_mentions: :class:`AllowedMentions`
             Controls the mentions being processed in this message.
             See :meth:`.abc.Messageable.send` for more information.
+        components: Optional[Sequence[:class:`~nextcord.components.Component`]]
+            A list of components to edit the message with (Components V2). If ``None`` is passed then
+            the components are removed.
+
+            .. versionadded:: 3.4
 
         Raises
         ------
@@ -456,6 +475,7 @@ class SyncWebhookMessage(Message):
             files=files,
             attachments=attachments,
             allowed_mentions=allowed_mentions,
+            components=components,
         )
 
     def delete(self, *, delay: Optional[float] = None) -> None:
@@ -832,8 +852,10 @@ class SyncWebhook(BaseWebhook):
         embed: Embed = MISSING,
         embeds: List[Embed] = MISSING,
         allowed_mentions: AllowedMentions = MISSING,
+        thread: Snowflake = MISSING,
         wait: Literal[True],
         thread_name: Optional[str] = None,
+        components: Optional[Sequence[Component]] = MISSING,
     ) -> SyncWebhookMessage: ...
 
     @overload
@@ -849,8 +871,10 @@ class SyncWebhook(BaseWebhook):
         embed: Embed = MISSING,
         embeds: List[Embed] = MISSING,
         allowed_mentions: AllowedMentions = MISSING,
+        thread: Snowflake = MISSING,
         wait: Literal[False] = ...,
         thread_name: Optional[str] = None,
+        components: Optional[Sequence[Component]] = MISSING,
     ) -> None: ...
 
     def send(
@@ -868,6 +892,7 @@ class SyncWebhook(BaseWebhook):
         thread: Snowflake = MISSING,
         wait: bool = False,
         thread_name: Optional[str] = None,
+        components: Optional[Sequence[Component]] = MISSING,
     ) -> Optional[SyncWebhookMessage]:
         """Sends a message using the webhook.
 
@@ -921,6 +946,10 @@ class SyncWebhook(BaseWebhook):
             Name of thread to create (requires the webhook channel to be a forum or media channel).
 
             .. versionadded:: 3.0
+        components: Optional[Sequence[:class:`~nextcord.components.Component`]]
+            A list of components (Components V2) to send with the message.
+
+            .. versionadded:: 3.4
 
         Raises
         ------
@@ -962,6 +991,7 @@ class SyncWebhook(BaseWebhook):
             allowed_mentions=allowed_mentions,
             previous_allowed_mentions=previous_mentions,
             thread_name=thread_name,
+            components=components,
         )
         adapter: WebhookAdapter = _get_webhook_adapter()
 
@@ -1030,6 +1060,7 @@ class SyncWebhook(BaseWebhook):
         attachments: List[Attachment] = MISSING,
         allowed_mentions: Optional[AllowedMentions] = None,
         thread: Snowflake = MISSING,
+        components: Optional[Sequence[Component]] = MISSING,
     ) -> SyncWebhookMessage:
         """Edits a message owned by this webhook.
 
@@ -1063,6 +1094,11 @@ class SyncWebhook(BaseWebhook):
             The thread that the message to be edited is in.
 
             .. versionadded:: 3.0
+        components: Optional[Sequence[:class:`~nextcord.components.Component`]]
+            A list of components to edit the message with (Components V2). If ``None`` is passed then
+            the components are removed.
+
+            .. versionadded:: 3.4
 
         Raises
         ------
@@ -1093,6 +1129,7 @@ class SyncWebhook(BaseWebhook):
             embeds=embeds,
             allowed_mentions=allowed_mentions,
             previous_allowed_mentions=previous_mentions,
+            components=components,
         )
         adapter: WebhookAdapter = _get_webhook_adapter()
         thread_id: Optional[int] = None


### PR DESCRIPTION
## Summary

<!-- What is this pull request for? Does it fix any issues? -->

Adds native support for passing `components` (Components V2) directly to `Messageable.send()` and `Message.edit()`.

PR #1254 introduced initial support for Components V2 in interaction responses and webhooks, but did not implement the `components` parameter for `Messageable.send()` or `Message.edit()`. This PR addresses that omission.

With this change, users can natively invoke:

```python
await channel.send(components=[container])
await message.edit(components=[container])
```

## This is a **Code Change**

- [x] I have tested my changes.
- [x] I have updated the documentation to reflect the changes.
- [x] I have run `task pyright` and fixed the relevant issues.

---

### Related Issues
Closes #1297

### Additional Changes
- Added missing `components` parameter to `@overload` signatures for `Webhook.send`, `Webhook.edit_message`, `SyncWebhook.send`, and `SyncWebhook.edit_message`.
- Updated typings to use covariant `Sequence[Component]` instead of invariant lists, resolving static typing errors when passing `list[Container]`.
- Fixed missing `components` argument forwarding in `Interaction.send`.
- Added `MISSING` sentinel handling for `.edit()` methods to avoid unintended clearing of components.