### PR TITLE
build(deps): update `dave.py` version requirement to `^1.0`

### DIFF
--- a/nextcord/voice_client.py
+++ b/nextcord/voice_client.py
@@ -830,6 +830,9 @@ class E2EEState:
             )
 
             key_package = self._session.get_marshalled_key_package()
+            if not key_package:
+                msg = "Failed to create new MLS key package"
+                raise RuntimeError(msg)
             await self.voice_client.ws.send_dave_mls_key_package(key_package)
 
         # When the epoch is greater than 1, the protocol version of the existing MLS group is changing.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,7 @@ aiodns = { version = ">1.1", optional = true, markers = "sys_platform == 'linux'
 Brotli = { version = "*", optional = true, markers = "platform_python_implementation == 'CPython'" }
 # If brotlicffi is unsupported by an older aiohttp version, it will simply be ignored.
 brotlicffi = { version = "*", optional = true, markers = "platform_python_implementation != 'CPython'" }
-dave-py = { version = ">=0.1.2,<1.0", optional = true }
+dave-py = { version = "^1.0", optional = true }
 
 [tool.poetry.group.dev.dependencies]
 pre-commit = "3.5.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,7 @@ aiodns = { version = ">1.1", optional = true, markers = "sys_platform == 'linux'
 Brotli = { version = "*", optional = true, markers = "platform_python_implementation == 'CPython'" }
 # If brotlicffi is unsupported by an older aiohttp version, it will simply be ignored.
 brotlicffi = { version = "*", optional = true, markers = "platform_python_implementation != 'CPython'" }
-dave-py = { version = "^0.1.2", optional = true }
+dave-py = { version = ">=0.1.2,<1.0", optional = true }
 
 [tool.poetry.group.dev.dependencies]
 pre-commit = "3.5.0"


### PR DESCRIPTION
## Summary

The current `dave.py` version specifier of `^0.1.2` is essentially `>=0.1.2,<0.2.0` (see poetry [spec](https://python-poetry.org/docs/dependency-specification/#caret-requirements)). This PR expands the dependency version to be more permissive and allow any `v1.x.x` version.
`dave.py` uses semver (not sure if I had already added the [versioning section](https://github.com/DisnakeDev/dave.py#versioning) of the readme when you implemented it? perhaps not.), i.e. no breaking changes outside of major versions, so this should not break in the future.

Most notably, the latest builds I pushed recently ([v0.2.0+](https://github.com/DisnakeDev/dave.py/releases/tag/v0.2.0)) include support for Python 3.15. c: