### PR TITLE
fix(commands): allow BucketType in CooldownMapping._bucket_key

### DIFF
--- a/nextcord/ext/commands/cooldowns.py
+++ b/nextcord/ext/commands/cooldowns.py
@@ -206,9 +206,6 @@ class CooldownMapping:
         return cls(Cooldown(rate, per), type)
 
     def _bucket_key(self, msg: Message) -> Any:
-        if isinstance(self._type, BucketType):
-            raise TypeError("Cannot call _bucket_key on a BucketType")
-
         return self._type(msg)
 
     def _verify_cache_integrity(self, current: Optional[float] = None) -> None:


### PR DESCRIPTION
Fixes #1282

## Summary
_bucket_key unconditionally raised TypeError whenever the mapping's _type was a BucketType (e.g. `@cooldown(1, 5, BucketType.user)`), introduced in 4fde8bf as a typing guard. BucketType defines __call__, so `self._type(msg)` already works correctly for both BucketType and plain callables; the guard just blocked the case before it could run.

## This is a **Code Change**

- [x] I have tested my changes.
- [ ] I have updated the documentation to reflect the changes.
- [x] I have run `task pyright` and fixed the relevant issues.
