### PR TITLE
fix(http): improve logging, eliminate duplication, and clean up type checking

### DIFF
--- a/nextcord/http.py
+++ b/nextcord/http.py
@@ -841,6 +841,7 @@ class HTTPClient:
                         proxy_auth=self._proxy_auth,
                         **kwargs,
                     ) as response:
+                        assert response is not None
                         _log.debug(
                             "%s %s with %s has returned %s",
                             route.method,

--- a/nextcord/http.py
+++ b/nextcord/http.py
@@ -23,6 +23,7 @@ from typing import (
     Type,
     TypeVar,
     Union,
+    cast,
 )
 from urllib.parse import quote as _uriquote
 
@@ -641,6 +642,25 @@ class HTTPClient:
             ret["User-Agent"] = self._user_agent
 
         return ret
+
+    def _filter_payload(
+        self, payload: Dict[str, Any], valid_keys: Union[Tuple[str, ...], set[str]]
+    ) -> Dict[str, Any]:
+        """Filter a payload dictionary to only include valid keys.
+
+        Parameters
+        ----------
+        payload : Dict[str, Any]
+            The payload to filter.
+        valid_keys : Union[Tuple[str, ...], set[str]]
+            The keys that are allowed in the filtered payload.
+
+        Returns
+        -------
+        Dict[str, Any]
+            A new dictionary containing only the valid keys and their values.
+        """
+        return {k: v for k, v in payload.items() if k in valid_keys}
 
     async def recreate(self) -> None:
         if not self.__session or self.__session.closed:
@@ -2788,7 +2808,7 @@ class HTTPClient:
             "name",
             "description",
         )
-        payload = {k: v for k, v in payload.items() if k in valid_keys}
+        payload = self._filter_payload(payload, valid_keys)
         return self.request(
             Route("PATCH", "/guilds/{guild_id}/templates/{code}", guild_id=guild_id, code=code),
             json=payload,
@@ -3888,7 +3908,7 @@ class HTTPClient:
             "send_start_notification",
             "guild_scheduled_event_id",
         )
-        payload = {k: v for k, v in payload.items() if k in valid_keys}
+        payload = self._filter_payload(payload, valid_keys)
 
         return self.request(
             Route("POST", "/stage-instances"),
@@ -3911,7 +3931,7 @@ class HTTPClient:
             "topic",
             "privacy_level",
         )
-        payload = {k: v for k, v in payload.items() if k in valid_keys}
+        payload = self._filter_payload(payload, valid_keys)
 
         return self.request(
             Route("PATCH", "/stage-instances/{channel_id}", channel_id=channel_id),
@@ -4007,7 +4027,7 @@ class HTTPClient:
             "description",
             "options",
         )
-        payload = {k: v for k, v in payload.items() if k in valid_keys}  # type: ignore
+        payload = self._filter_payload(cast(Dict[str, Any], payload), valid_keys)
         r = Route(
             "PATCH",
             "/applications/{application_id}/commands/{command_id}",
@@ -4143,7 +4163,7 @@ class HTTPClient:
             "description",
             "options",
         )
-        payload = {k: v for k, v in payload.items() if k in valid_keys}  # type: ignore
+        payload = self._filter_payload(cast(Dict[str, Any], payload), valid_keys)  # type: ignore
         r = Route(
             "PATCH",
             "/applications/{application_id}/guilds/{guild_id}/commands/{command_id}",
@@ -4577,7 +4597,7 @@ class HTTPClient:
             "entity_type",
             "image",
         }
-        payload = {k: v for k, v in payload.items() if k in valid_keys}
+        payload = self._filter_payload(payload, valid_keys)
         r = Route("POST", "/guilds/{guild_id}/scheduled-events", guild_id=guild_id)
         return self.request(
             r,
@@ -4632,7 +4652,7 @@ class HTTPClient:
             "status",
             "image",
         }
-        payload = {k: v for k, v in payload.items() if k in valid_keys}
+        payload = self._filter_payload(payload, valid_keys)
         r = Route(
             "PATCH",
             "/guilds/{guild_id}/scheduled-events/{event_id}",

--- a/nextcord/http.py
+++ b/nextcord/http.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import sys
+from collections.abc import Mapping
 from datetime import datetime, timedelta, timezone
 from types import TracebackType
 from typing import (
@@ -23,7 +24,6 @@ from typing import (
     Type,
     TypeVar,
     Union,
-    cast,
 )
 from urllib.parse import quote as _uriquote
 
@@ -644,13 +644,13 @@ class HTTPClient:
         return ret
 
     def _filter_payload(
-        self, payload: Dict[str, Any], valid_keys: Union[Tuple[str, ...], set[str]]
+        self, payload: Mapping[str, Any], valid_keys: Union[Tuple[str, ...], set[str]]
     ) -> Dict[str, Any]:
         """Filter a payload dictionary to only include valid keys.
 
         Parameters
         ----------
-        payload : :class:`dict`[:class:`str`, :class:`Any`]
+        payload : :class:`Mapping`[:class:`str`, :class:`Any`]
             The payload to filter.
         valid_keys : Union[:class:`tuple`[:class:`str`, ...], :class:`set`[:class:`str`]]
             The keys that are allowed in the filtered payload.
@@ -4027,7 +4027,7 @@ class HTTPClient:
             "description",
             "options",
         )
-        payload = self._filter_payload(cast(Dict[str, Any], payload), valid_keys)  # type: ignore
+        payload = self._filter_payload(payload, valid_keys)  # type: ignore
         r = Route(
             "PATCH",
             "/applications/{application_id}/commands/{command_id}",
@@ -4163,7 +4163,7 @@ class HTTPClient:
             "description",
             "options",
         )
-        payload = self._filter_payload(cast(Dict[str, Any], payload), valid_keys)  # type: ignore
+        payload = self._filter_payload(payload, valid_keys)  # type: ignore
         r = Route(
             "PATCH",
             "/applications/{application_id}/guilds/{guild_id}/commands/{command_id}",

--- a/nextcord/http.py
+++ b/nextcord/http.py
@@ -1065,7 +1065,8 @@ class HTTPClient:
                 if not response.headers.get("Via") or isinstance(return_value, str):
                     _log.error(
                         "Path %s resulted in what appears to be a CloudFlare ban, either a "
-                        "large amount of errors recently happened and/or Nextcord has a bug."
+                        "large amount of errors recently happened and/or Nextcord has a bug.",
+                        rate_limit_path,
                     )
                     # Banned by Cloudflare more than likely.
                     raise HTTPException(response, return_value)

--- a/nextcord/http.py
+++ b/nextcord/http.py
@@ -650,14 +650,14 @@ class HTTPClient:
 
         Parameters
         ----------
-        payload : Dict[str, Any]
+        payload : :class:`dict`[:class:`str`, :class:`Any`]
             The payload to filter.
-        valid_keys : Union[Tuple[str, ...], set[str]]
+        valid_keys : Union[:class:`tuple`[:class:`str`, ...], :class:`set`[:class:`str`]]
             The keys that are allowed in the filtered payload.
 
         Returns
         -------
-        Dict[str, Any]
+        :class:`dict`[:class:`str`, :class:`Any`]
             A new dictionary containing only the valid keys and their values.
         """
         return {k: v for k, v in payload.items() if k in valid_keys}

--- a/nextcord/http.py
+++ b/nextcord/http.py
@@ -4027,7 +4027,7 @@ class HTTPClient:
             "description",
             "options",
         )
-        payload = self._filter_payload(cast(Dict[str, Any], payload), valid_keys)
+        payload = self._filter_payload(cast(Dict[str, Any], payload), valid_keys)  # type: ignore
         r = Route(
             "PATCH",
             "/applications/{application_id}/commands/{command_id}",


### PR DESCRIPTION
## Summary

Fix logging gaps, eliminate code duplication, and clean up type checking issues in the HTTP client.

## This is a **Code Change**

**Changes:**
- Fix missing log parameter in CloudFlare error logging
- Add type assertion for response in context manager  
- Extract payload filtering to helper method (removes 7 duplicated blocks)
- Add type suppression for payload assignment
- Update docstring formatting

**Why:**
- Better debugging info when CloudFlare issues occur
- Cleaner type checking, no IDE warnings
- Centralized payload filtering logic
- Follows codebase conventions

**Testing:**
- Pyright: 0 errors, 0 warnings
- HTTPClient imports successfully
- Logging fix verified
- No breaking changes

- [x] I have tested my changes.
- [x] I have updated the documentation to reflect the changes.
- [x] I have run `task pyright` and fixed the relevant issues.
