### PR TITLE
fix(ui): validate custom IDs before storing them

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -99,3 +99,6 @@ jobs:
 
       - name: Run slotscheck
         run: task slotscheck
+
+      - name: Run unit tests
+        run: python -m unittest discover -s tests

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,6 +57,12 @@ To run all of these but `slotscheck`, you can simply run `task lint` in the root
 
 If you would like these to run automatically, you can use `task precommit` to install pre-commit hooks. This will run all of the above on every commit.
 
+## Unit Tests
+
+Run `python -m unittest discover -s tests` in the development environment.
+The lint workflow runs these tests alongside slotscheck. UI custom-ID tests cover
+construction and reassignment, preserving generated IDs and link buttons.
+
 ## Type Annotations
 
 Nextcord uses [Pyright](https://github.com/microsoft/pyright) for type checking. To use it, run `task pyright` in the root directory of the project, or `python -m task pyright` (`py -m` etc) if that does not work.

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -3053,6 +3053,12 @@ RoleConnectionMetadata
 Bot UI Kit
 ----------
 
+Custom IDs supplied to UI items and modals must be strings; invalid types raise
+:class:`TypeError` during construction or assignment. Omitting the ID generates
+one automatically. Buttons and select menus also accept ``None`` during
+construction to generate an ID; link buttons have no custom ID.
+
+
 The library has helpers to help create component-based UIs.
 
 View

--- a/nextcord/ui/button.py
+++ b/nextcord/ui/button.py
@@ -10,7 +10,7 @@ from ..components import Button as ButtonComponent
 from ..enums import ButtonStyle, ComponentType
 from ..partial_emoji import PartialEmoji, _EmojiTag
 from ..utils import MISSING
-from .item import Item, ItemCallbackType
+from .item import Item, ItemCallbackType, _validate_custom_id
 
 __all__ = (
     "Button",
@@ -77,6 +77,7 @@ class Button(Item[V_co]):
         row: Optional[int] = None,
     ) -> None:
         super().__init__()
+        _validate_custom_id(custom_id, allow_none=True)
         if custom_id is not None and url is not None:
             raise TypeError("Cannot mix both url and custom_id with Button")
 
@@ -127,8 +128,7 @@ class Button(Item[V_co]):
 
     @custom_id.setter
     def custom_id(self, value: Optional[str]) -> None:
-        if value is not None and not isinstance(value, str):
-            raise TypeError("custom_id must be None or str")
+        _validate_custom_id(value, allow_none=True)
 
         self._underlying.custom_id = value  # type: ignore
 

--- a/nextcord/ui/item.py
+++ b/nextcord/ui/item.py
@@ -24,6 +24,12 @@ V_co = TypeVar("V_co", bound="View", covariant=True)
 ItemCallbackType = Callable[[Any, I, Interaction[ClientT]], Coroutine[Any, Any, Any]]
 
 
+def _validate_custom_id(value: object, *, allow_none: bool = False) -> None:
+    if not isinstance(value, str) and not (allow_none and value is None):
+        expected = "None or str" if allow_none else "str"
+        raise TypeError(f"custom_id must be {expected}")
+
+
 class Item(Generic[V_co]):
     """Represents the base UI item that all UI components inherit from.
 

--- a/nextcord/ui/modal.py
+++ b/nextcord/ui/modal.py
@@ -13,7 +13,7 @@ from typing import TYPE_CHECKING, Any, Callable, Dict, Iterator, List, Optional,
 
 from ..components import Component
 from ..utils import MISSING
-from .item import Item
+from .item import Item, _validate_custom_id
 from .view import _component_to_item, _ViewWeights, _walk_all_components
 
 __all__ = (
@@ -105,6 +105,15 @@ class Modal:
         self.__timeout_task: Optional[asyncio.Task[None]] = None
         self.__background_tasks: Set[asyncio.Task[None]] = set()
         self.__stopped: asyncio.Future[bool] = loop.create_future()
+
+    @property
+    def custom_id(self) -> str:
+        return self._custom_id
+
+    @custom_id.setter
+    def custom_id(self, value: str) -> None:
+        _validate_custom_id(value)
+        self._custom_id = value
 
     async def __timeout_task_impl(self) -> None:
         while True:

--- a/nextcord/ui/modal.py
+++ b/nextcord/ui/modal.py
@@ -93,6 +93,8 @@ class Modal:
         self.title = title
         self.timeout = timeout
         self._provided_custom_id = custom_id is not MISSING
+        # Assignment goes through the property setter, so generated and supplied
+        # IDs use the same validation as later reassignment.
         self.custom_id = os.urandom(16).hex() if custom_id is MISSING else custom_id
         self.auto_defer = auto_defer
 
@@ -108,6 +110,7 @@ class Modal:
 
     @property
     def custom_id(self) -> str:
+        """:class:`str`: The validated ID sent with modal interactions."""
         return self._custom_id
 
     @custom_id.setter

--- a/nextcord/ui/select/base.py
+++ b/nextcord/ui/select/base.py
@@ -14,7 +14,7 @@ from ...role import Role
 from ...state import ConnectionState
 from ...user import User
 from ...utils import MISSING
-from ..item import Item
+from ..item import Item, _validate_custom_id
 
 __all__ = ("SelectBase",)
 
@@ -121,8 +121,9 @@ class SelectBase(Item[V_co]):
     ) -> None:
         super().__init__()
         self._selected_values: List[str] = []
-        self._provided_custom_id = custom_id is not None
-        custom_id = os.urandom(16).hex() if custom_id is None else custom_id
+        self._provided_custom_id = custom_id is not None and custom_id is not MISSING
+        custom_id = os.urandom(16).hex() if not self._provided_custom_id else custom_id
+        _validate_custom_id(custom_id)
         self._underlying = SelectMenu(
             custom_id=custom_id,
             placeholder=placeholder if placeholder is not None else MISSING,
@@ -139,8 +140,7 @@ class SelectBase(Item[V_co]):
 
     @custom_id.setter
     def custom_id(self, value: str) -> None:
-        if not isinstance(value, str):
-            raise TypeError("custom_id must be None or str")
+        _validate_custom_id(value)
 
         self._underlying.custom_id = value
 

--- a/nextcord/ui/select/channel.py
+++ b/nextcord/ui/select/channel.py
@@ -101,7 +101,7 @@ class ChannelSelect(SelectBase, Generic[V_co]):
         self._selected_values: ChannelSelectValues = ChannelSelectValues()
         self.channel_types: list[ChannelType] = channel_types
         self._underlying = ChannelSelectMenu(
-            custom_id=custom_id,
+            custom_id=self.custom_id,
             channel_types=channel_types,
             placeholder=placeholder if placeholder is not None else MISSING,
             # default_values=

--- a/nextcord/ui/select/mentionable.py
+++ b/nextcord/ui/select/mentionable.py
@@ -109,7 +109,7 @@ class MentionableSelect(SelectBase, Generic[V_co]):
         )
         self._selected_values: MentionableSelectValues = MentionableSelectValues()
         self._underlying = MentionableSelectMenu(
-            custom_id=custom_id,
+            custom_id=self.custom_id,
             placeholder=placeholder if placeholder is not None else MISSING,
             # default_values=
             min_values=min_values,

--- a/nextcord/ui/select/role.py
+++ b/nextcord/ui/select/role.py
@@ -95,7 +95,7 @@ class RoleSelect(SelectBase, Generic[V_co]):
         )
         self._selected_values: RoleSelectValues = RoleSelectValues()
         self._underlying = RoleSelectMenu(
-            custom_id=custom_id,
+            custom_id=self.custom_id,
             placeholder=placeholder if placeholder is not None else MISSING,
             # default_values=
             min_values=min_values,

--- a/nextcord/ui/select/user.py
+++ b/nextcord/ui/select/user.py
@@ -100,7 +100,7 @@ class UserSelect(SelectBase, Generic[V_co]):
         )
         self._selected_values: UserSelectValues = UserSelectValues()
         self._underlying = UserSelectMenu(
-            custom_id=custom_id,
+            custom_id=self.custom_id,
             placeholder=placeholder if placeholder is not None else MISSING,
             # default_values=
             min_values=min_values,

--- a/nextcord/ui/text_input.py
+++ b/nextcord/ui/text_input.py
@@ -10,7 +10,7 @@ from ..enums import ComponentType, TextInputStyle
 from ..guild import Guild
 from ..state import ConnectionState
 from ..utils import MISSING
-from .item import Item
+from .item import Item, _validate_custom_id
 
 __all__ = ("TextInput",)
 
@@ -87,6 +87,7 @@ class TextInput(Item[V_co]):
     ) -> None:
         self._provided_custom_id = custom_id is not MISSING
         custom_id = os.urandom(16).hex() if custom_id is MISSING else custom_id
+        _validate_custom_id(custom_id)
         self._underlying = TextInputComponent(
             style=style,
             label=label,
@@ -110,16 +111,15 @@ class TextInput(Item[V_co]):
         self._underlying.style = value
 
     @property
-    def custom_id(self) -> Optional[str]:
-        """Optional[:class:`str`]: The ID of the text input that gets received during an interaction."""
+    def custom_id(self) -> str:
+        """:class:`str`: The ID of the text input that gets received during an interaction."""
         return self._underlying.custom_id
 
     @custom_id.setter
-    def custom_id(self, value: Optional[str]) -> None:
-        if value is not None and not isinstance(value, str):
-            raise TypeError("custom_id must be None or str")
+    def custom_id(self, value: str) -> None:
+        _validate_custom_id(value)
 
-        self._underlying.custom_id = value  # type: ignore
+        self._underlying.custom_id = value
 
     @property
     def label(self) -> str:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -218,6 +218,8 @@ ignore = [
 ]
 
 [tool.ruff.lint.per-file-ignores]
+# Unit tests use the standard library runner rather than pytest.
+"tests/*" = ["PT009", "PT027"]
 "__init__.py" = [
     "F401", # unused imports in __init__.py, "from . import abc, ..."
 ]

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+# SPDX-License-Identifier: MIT

--- a/tests/test_custom_id.py
+++ b/tests/test_custom_id.py
@@ -1,0 +1,102 @@
+# SPDX-License-Identifier: MIT
+
+import unittest
+
+from nextcord import ui
+
+
+class CustomIDTests(unittest.IsolatedAsyncioTestCase):
+    async def test_invalid_ids_are_rejected_at_construction(self):
+        for factory in self.factories():
+            for value in (123, False, b"id", [], {}, object()):
+                with (
+                    self.subTest(factory=factory, value=value),
+                    self.assertRaisesRegex(TypeError, "custom_id"),
+                ):
+                    factory(custom_id=value)
+
+    async def test_invalid_assignment_preserves_previous_id(self):
+        for factory in self.factories():
+            for value in (123, False, b"id", [], {}, object()):
+                obj = factory(custom_id="original")
+                with self.subTest(factory=factory, value=value):
+                    with self.assertRaisesRegex(TypeError, "custom_id"):
+                        obj.custom_id = value
+                    self.assertEqual(obj.custom_id, "original")
+
+    async def test_explicit_and_generated_ids(self):
+        for factory in self.factories():
+            with self.subTest(factory=factory):
+                self.assertEqual(factory(custom_id="stable").custom_id, "stable")
+                obj = factory()
+                self.assertIsInstance(obj.custom_id, str)
+                self.assertEqual(len(obj.custom_id), 32)
+                obj.custom_id = "replacement"
+                self.assertEqual(obj.custom_id, "replacement")
+
+    async def test_link_button_and_select_none_defaults(self):
+        self.assertIsNone(ui.Button(url="https://example.com").custom_id)
+        for factory in (
+            ui.Button,
+            ui.StringSelect,
+            ui.UserSelect,
+            ui.RoleSelect,
+            ui.MentionableSelect,
+            ui.ChannelSelect,
+        ):
+            with self.subTest(factory=factory):
+                self.assertIsInstance(factory(custom_id=None).custom_id, str)
+
+    async def test_decorator_defaults_generate_ids(self):
+        for decorate in (
+            ui.button,
+            ui.string_select,
+            ui.user_select,
+            ui.role_select,
+            ui.mentionable_select,
+            ui.channel_select,
+        ):
+
+            async def callback(self, item, interaction):
+                pass
+
+            with self.subTest(decorate=decorate):
+                view_type = type("DecoratedView", (ui.View,), {"item": decorate()(callback)})
+                view = view_type()
+                self.assertIsInstance(view.children[0].custom_id, str)
+                self.assertFalse(view.children[0]._provided_custom_id)
+
+    async def test_required_ids_reject_none(self):
+        for factory in (
+            lambda **kw: ui.TextInput(label="Label", **kw),
+            lambda **kw: ui.Modal("Title", **kw),
+        ):
+            with self.subTest(factory=factory):
+                with self.assertRaisesRegex(TypeError, "custom_id"):
+                    factory(custom_id=None)
+                obj = factory(custom_id="original")
+                with self.assertRaisesRegex(TypeError, "custom_id"):
+                    obj.custom_id = None
+                self.assertEqual(obj.custom_id, "original")
+
+    async def test_component_reconstruction_validates_ids(self):
+        for factory in self.factories()[:6]:
+            obj = factory(custom_id="original")
+            with self.subTest(factory=factory):
+                component = type(obj._underlying).from_dict(obj.to_component_dict())
+                component.custom_id = 123
+                with self.assertRaisesRegex(TypeError, "custom_id"):
+                    factory.from_component(component)
+
+    @staticmethod
+    def factories():
+        return (
+            ui.Button,
+            ui.StringSelect,
+            ui.UserSelect,
+            ui.RoleSelect,
+            ui.MentionableSelect,
+            ui.ChannelSelect,
+            lambda **kw: ui.TextInput(label="Label", **kw),
+            lambda **kw: ui.Modal("Title", **kw),
+        )


### PR DESCRIPTION
## Summary

Passing an integer `custom_id` to a UI constructor currently succeeds, producing an ID that cannot match the string returned in an interaction. This change raises `TypeError` at construction or assignment instead of allowing that invalid state to reach dispatch.

Fixes #1187.

- Share validation between Button, select menus, TextInput, and Modal construction/setters. A rejected assignment preserves the existing ID.
- Preserve generated IDs through select subclasses that rebuild their underlying component. Normalize the select decorators' omitted-ID sentinel at the base boundary.
- Preserve omitted-ID generation and link buttons. TextInput and Modal require string IDs when explicitly provided; `TextInput.custom_id = None` now raises instead of storing an invalid value. Button retains its optional ID for link behavior.
- Add seven standard-library unittest groups and run them in the existing lint workflow. Tests cover non-string variants across all eight public UI classes, reassignment, defaults, decorators, and invalid component reconstruction. Document the contract and test command.

## Validation

Python 3.12, with Poetry development groups and CI extras installed:

- Initial regression suite: 54 failing subtests on unchanged source.
- Final `python -m unittest discover -s tests`: seven test groups passed.
- `pre-commit run --all-files`: passed.
- `python -m pyright --pythonpath .venv/bin/python`: 128 files, zero errors or warnings.
- `python -m slotscheck --verbose -m nextcord`: passed.
- Sphinx HTML build from `docs`: passed.
- `git diff --check`: passed.

No Discord token or live connection was used. Existing low-level component payload APIs are unchanged; validation is enforced by the public UI wrappers. The existing Item refactor #1070 touches these files but does not implement this validation.

AI assistance: Codex implemented this change and ran the checks listed above.
