### PR TITLE
feat: add thread starter message helpers

### DIFF
--- a/docs/whats_new.rst
+++ b/docs/whats_new.rst
@@ -23,6 +23,7 @@ specifically lower-level support for the "Message Components" section.
 New Features
 ~~~~~~~~~~~~
 
+- Add :attr:`Thread.starter_message_id`, :meth:`Thread.get_partial_starter_message`, and :meth:`Thread.fetch_starter_message` for working with a thread's starter message (:issue:`1215`).
 - Add support for `new auto moderation types <https://docs.discord.com/developers/change-log#may-31-2024>`_ (:issue:`1087`):
     - :attr:`AutoModerationEventType.member_update`
     - :attr:`AutoModerationTriggerType.member_profile`

--- a/nextcord/threads.py
+++ b/nextcord/threads.py
@@ -258,6 +258,16 @@ class Thread(Messageable, Hashable, PinsMixin):
         return self._state._get_message(self.last_message_id) if self.last_message_id else None
 
     @property
+    def starter_message_id(self) -> int:
+        """:class:`int`: The ID of the message that started this thread.
+
+        Discord uses the thread ID as the starter message ID.
+
+        .. versionadded:: 3.2
+        """
+        return self.id
+
+    @property
     def category(self) -> Optional[CategoryChannel]:
         """The category channel the parent channel belongs to, if applicable.
 
@@ -776,6 +786,44 @@ class Thread(Messageable, Hashable, PinsMixin):
         from .message import PartialMessage
 
         return PartialMessage(channel=self, id=message_id)
+
+    def get_partial_starter_message(self) -> PartialMessage:
+        """Creates a :class:`PartialMessage` for this thread's starter message.
+
+        This does not make an API request. Use :meth:`fetch_starter_message` to
+        retrieve the complete message from Discord.
+
+        .. versionadded:: 3.2
+
+        Returns
+        -------
+        :class:`PartialMessage`
+            The partial starter message.
+        """
+        return self.get_partial_message(self.starter_message_id)
+
+    async def fetch_starter_message(self) -> Message:
+        """|coro|
+
+        Retrieves this thread's starter message from Discord.
+
+        .. versionadded:: 3.2
+
+        Raises
+        ------
+        NotFound
+            The starter message was not found.
+        Forbidden
+            You do not have permission to retrieve the starter message.
+        HTTPException
+            Retrieving the starter message failed.
+
+        Returns
+        -------
+        :class:`Message`
+            The starter message.
+        """
+        return await self.fetch_message(self.starter_message_id)
 
     def _add_member(self, member: ThreadMember) -> None:
         self._members[member.id] = member

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+# SPDX-License-Identifier: MIT

--- a/tests/test_threads.py
+++ b/tests/test_threads.py
@@ -1,0 +1,39 @@
+# SPDX-License-Identifier: MIT
+
+from unittest import IsolatedAsyncioTestCase, TestCase
+from unittest.mock import AsyncMock, Mock, patch
+
+from nextcord.threads import Thread
+
+
+def make_thread(thread_id: int = 123) -> Thread:
+    thread = object.__new__(Thread)
+    thread.id = thread_id
+    return thread
+
+
+class ThreadStarterMessageTests(TestCase):
+    def test_starter_message_id_matches_thread_id(self) -> None:
+        thread = make_thread()
+
+        assert thread.starter_message_id == thread.id
+
+    def test_get_partial_starter_message_uses_thread_id(self) -> None:
+        thread = make_thread()
+        expected = Mock()
+
+        with patch.object(Thread, "get_partial_message", return_value=expected) as get_partial:
+            assert thread.get_partial_starter_message() is expected
+
+        get_partial.assert_called_once_with(thread.id)
+
+
+class ThreadStarterMessageAsyncTests(IsolatedAsyncioTestCase):
+    async def test_fetch_starter_message_uses_thread_id(self) -> None:
+        thread = make_thread()
+        expected = Mock()
+
+        with patch.object(Thread, "fetch_message", AsyncMock(return_value=expected)) as fetch:
+            assert await thread.fetch_starter_message() is expected
+
+        fetch.assert_awaited_once_with(thread.id)


### PR DESCRIPTION
Closes #1215.

Adds `Thread.starter_message_id` plus partial and fetched starter-message helpers. Includes focused unit coverage and a v3.2 changelog entry.

Validation: 3 unit tests, Ruff, Black, slotscheck, targeted Pyright, and strict Sphinx HTML.
