### PR TITLE
fix(scheduled-events): validate external metadata

### DIFF
--- a/nextcord/guild.py
+++ b/nextcord/guild.py
@@ -3654,7 +3654,8 @@ class Guild(Hashable):
         channel: :class:`abc.GuildChannel`
             The channel the event will happen in, if any
         metadata: :class:`EntityMetadata`
-            The metadata for the event
+            The metadata for the event. This is required for external events,
+            and its ``location`` must not be ``None``.
         name: :class:`str`
             The name of the event
         privacy_level: :class:`ScheduledEventPrivacyLevel`
@@ -3677,7 +3678,17 @@ class Guild(Hashable):
         -------
         :class:`ScheduledEvent`
             The created event object.
+
+        Raises
+        ------
+        ValueError
+            The event is external and no metadata location was provided.
         """
+        if entity_type is ScheduledEventEntityType.external and (
+            metadata is MISSING or metadata.location is None
+        ):
+            raise ValueError("external scheduled events require a metadata location")
+
         payload: Dict[str, Any] = {
             "name": name,
             "entity_type": entity_type.value,

--- a/tests/test_scheduled_events.py
+++ b/tests/test_scheduled_events.py
@@ -1,0 +1,79 @@
+import datetime
+import unittest
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+from nextcord.enums import ScheduledEventEntityType
+from nextcord.guild import Guild
+from nextcord.scheduled_events import EntityMetadata
+
+
+class TestCreateScheduledEvent(unittest.IsolatedAsyncioTestCase):
+    def setUp(self) -> None:
+        self.http = SimpleNamespace(create_event=AsyncMock(return_value={"id": "1"}))
+        self.guild = object.__new__(Guild)
+        self.guild.id = 123
+        self.guild._state = SimpleNamespace(http=self.http)
+        self.start_time = datetime.datetime.now(datetime.timezone.utc)
+
+    async def test_external_event_requires_metadata(self) -> None:
+        with self.assertRaisesRegex(ValueError, "require a metadata location"):
+            await self.guild.create_scheduled_event(
+                name="External event",
+                entity_type=ScheduledEventEntityType.external,
+                start_time=self.start_time,
+            )
+
+        self.http.create_event.assert_not_awaited()
+
+    async def test_external_event_requires_metadata_location(self) -> None:
+        with self.assertRaisesRegex(ValueError, "require a metadata location"):
+            await self.guild.create_scheduled_event(
+                name="External event",
+                entity_type=ScheduledEventEntityType.external,
+                start_time=self.start_time,
+                metadata=EntityMetadata(),
+            )
+
+        self.http.create_event.assert_not_awaited()
+
+    async def test_external_event_accepts_metadata_location(self) -> None:
+        event = object()
+        metadata = EntityMetadata(location="Conference hall")
+
+        with patch.object(Guild, "_store_scheduled_event", return_value=event):
+            result = await self.guild.create_scheduled_event(
+                name="External event",
+                entity_type=ScheduledEventEntityType.external,
+                start_time=self.start_time,
+                metadata=metadata,
+            )
+
+        self.assertIs(result, event)
+        self.http.create_event.assert_awaited_once_with(
+            123,
+            reason=None,
+            name="External event",
+            entity_type=ScheduledEventEntityType.external.value,
+            scheduled_start_time=self.start_time.isoformat(),
+            entity_metadata=metadata.__dict__,
+            privacy_level=2,
+        )
+
+    async def test_voice_event_does_not_require_metadata(self) -> None:
+        event = object()
+
+        with patch.object(Guild, "_store_scheduled_event", return_value=event):
+            result = await self.guild.create_scheduled_event(
+                name="Voice event",
+                entity_type=ScheduledEventEntityType.voice,
+                start_time=self.start_time,
+            )
+
+        self.assertIs(result, event)
+        self.http.create_event.assert_awaited_once()
+        self.assertNotIn("entity_metadata", self.http.create_event.await_args.kwargs)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_scheduled_events.py
+++ b/tests/test_scheduled_events.py
@@ -17,23 +17,35 @@ class TestCreateScheduledEvent(unittest.IsolatedAsyncioTestCase):
         self.start_time = datetime.datetime.now(datetime.timezone.utc)
 
     async def test_external_event_requires_metadata(self) -> None:
-        with self.assertRaisesRegex(ValueError, "require a metadata location"):
+        error = None
+        try:
             await self.guild.create_scheduled_event(
                 name="External event",
                 entity_type=ScheduledEventEntityType.external,
                 start_time=self.start_time,
             )
+        except ValueError as exc:
+            error = str(exc)
+
+        assert error is not None, "missing metadata should be rejected"
+        assert "require a metadata location" in error
 
         self.http.create_event.assert_not_awaited()
 
     async def test_external_event_requires_metadata_location(self) -> None:
-        with self.assertRaisesRegex(ValueError, "require a metadata location"):
+        error = None
+        try:
             await self.guild.create_scheduled_event(
                 name="External event",
                 entity_type=ScheduledEventEntityType.external,
                 start_time=self.start_time,
                 metadata=EntityMetadata(),
             )
+        except ValueError as exc:
+            error = str(exc)
+
+        assert error is not None, "metadata without a location should be rejected"
+        assert "require a metadata location" in error
 
         self.http.create_event.assert_not_awaited()
 
@@ -49,7 +61,7 @@ class TestCreateScheduledEvent(unittest.IsolatedAsyncioTestCase):
                 metadata=metadata,
             )
 
-        self.assertIs(result, event)
+        assert result is event
         self.http.create_event.assert_awaited_once_with(
             123,
             reason=None,
@@ -70,9 +82,9 @@ class TestCreateScheduledEvent(unittest.IsolatedAsyncioTestCase):
                 start_time=self.start_time,
             )
 
-        self.assertIs(result, event)
+        assert result is event
         self.http.create_event.assert_awaited_once()
-        self.assertNotIn("entity_metadata", self.http.create_event.await_args.kwargs)
+        assert "entity_metadata" not in self.http.create_event.await_args.kwargs
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Validate external scheduled-event metadata before making the HTTP request, and document that external events require a location.

Fixes #1162

## This is a **Code Change**

- [x] I have tested my changes.
- [x] I have updated the documentation to reflect the changes.
- [x] I have run `task pyright` and fixed the relevant issues.
